### PR TITLE
Servicemonitor and metrics exposed to prometheus

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -43,20 +43,20 @@ import (
 
 var (
 	//defaults
-	storePath         string = "."
-	amqpHost          string = "amqp:localhost:5672"
-	apiPort           int    = 8080
-	channelBufferSize int    = 10
+	storePath         string
+	amqpHost          string
+	apiPort           int
+	channelBufferSize int = 10
 	scConfig          *common.SCConfiguration
 	pubSubAPI         *restapi.Server
-	metricsAddr       string = ":9292"
+	metricsAddr       string
 	apiPath           string = "/api/cloudNotifications/v1/"
 )
 
 func main() {
 	// init
 	common.InitLogger()
-	flag.StringVar(&metricsAddr, "metrics-addr", ":9433", "The address the metric endpoint binds to.")
+	flag.StringVar(&metricsAddr, "metrics-addr", ":9091", "The address the metric endpoint binds to.")
 	flag.StringVar(&storePath, "store-path", ".", "The path to store publisher and subscription info.")
 	flag.StringVar(&amqpHost, "transport-host", "amqp:localhost:5672", "The transport bus hostname or service name.")
 	flag.IntVar(&apiPort, "api-port", 8080, "The address the rest api endpoint binds to.")

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,38 @@
+## Running examples
+
+### Side car
+```shell
+make build-plugins
+make run
+```
+### Consumer
+```shell
+make run-consumer
+```
+### Producer
+```shell
+make run-producer
+```
+
+## Building images 
+```shell
+1. hack/build-image.sh
+2. hack/build-example-image.sh
+3. podman images
+```
+#### Push images to a repo
+
+```shell
+podman push localhost/cloud-event-proxy:edf2bcfd-dirty quay.io/aneeshkp/cloud-event-proxy:latest
+podman push localhost/cloud-native-event-consumer:edf2bcfd-dirty quay.io/aneeshkp/cloud-native-event-consumer:latest
+podman push localhost/cloud-native-event-producer:edf2bcfd-dirty quay.io/aneeshkp/cloud-native-event-producer:latest
+```
+
+Use producer.yaml,consumer.yaml and service.yaml from examples/manifests folder to deploy to a cluster.
+Make sure you update the image path.
+
+
+
+
+
+

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -79,7 +79,7 @@ cne_events_received{status="success",type="/news-service/finance"} 3
 cne_events_received{status="success",type="/news-service/sports"} 3
 ```
 
-####Full metrics
+#### Full Metrics
 ```json
 # HELP cne_amqp_connections_resets Metric to get number of connection resets
 # TYPE cne_amqp_connections_resets gauge

--- a/examples/manifests/consumer.yaml
+++ b/examples/manifests/consumer.yaml
@@ -23,9 +23,10 @@ spec:
                     operator: In
                     values:
                       - local
+      serviceAccountName: sidecar-producer-sa
       containers:
-        - name: cloud-native-event-consumer
-          image: cloud-native-event-consumer
+        - name: cloud-nativer-event-consumer
+          image: quay.io/aneeshkp/cloud-native-event-consumer:latest
           args:
             - "--local-api-addr=127.0.0.1:9089"
             - "--api-path=/api/cloudNotifications/v1/"
@@ -48,9 +49,9 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
         - name: cloud-native-event-sidecar
-          image: cloud-event-proxy
+          image: quay.io/aneeshkp/cloud-event-proxy:latest
           args:
-            - "--metrics-addr=127.0.0.1:8443"
+            - "--metrics-addr=127.0.0.1:9091"
             - "--store-path=/store"
             - "--transport-host=amqp://amq-interconnect"
             - "--api-port=8080"
@@ -74,6 +75,31 @@ spec:
           volumeMounts:
             - name: pubsubstore
               mountPath: /store
+          ports:
+            - name: metrics-port
+              containerPort: 9091
+        - name: kube-rbac-proxy
+          image: quay.io/coreos/kube-rbac-proxy:v0.5.0
+          args:
+            - --logtostderr
+            - --secure-listen-address=:8443
+            - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+            - --upstream=http://127.0.0.1:9091/
+            - --tls-private-key-file=/etc/metrics/tls.key
+            - --tls-cert-file=/etc/metrics/tls.crt
+          ports:
+            - containerPort: 8443
+              name: https
+          resources:
+            requests:
+              cpu: 10m
+              memory: 20Mi
+          volumeMounts:
+            - name: sidecar-certs
+              mountPath: /etc/metrics
       volumes:
         - name: pubsubstore
           emptyDir: {}
+        - name: sidecar-certs
+          secret:
+            secretName: sidecar-consumer-secret

--- a/examples/manifests/kustomization.yaml
+++ b/examples/manifests/kustomization.yaml
@@ -1,6 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - namespce.yaml
+  - service-account.yaml
+  - roles.yaml
+  - service.yaml
   - consumer.yaml
   - producer.yaml
 replicas:

--- a/examples/manifests/namespace.yaml
+++ b/examples/manifests/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cloud-native-events
+  labels:
+    name: cloud-native-events
+    openshift.io/cluster-monitoring: "true"

--- a/examples/manifests/producer.yaml
+++ b/examples/manifests/producer.yaml
@@ -23,9 +23,10 @@ spec:
                     operator: In
                     values:
                       - local
+      serviceAccountName: sidecar-producer-sa
       containers:
-        - name: cloud-native-event-producer
-          image: cloud-native-event-producer
+        - name: cloud-nativer-event-producer
+          image: quay.io/aneeshkp/cloud-native-event-producer:latest
           args:
             - "--local-api-addr=127.0.0.1:9089"
             - "--api-path=/api/cloudNotifications/v1/"
@@ -48,9 +49,9 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
         - name: cloud-native-event-sidecar
-          image: cloud-event-proxy
+          image: quay.io/aneeshkp/cloud-event-proxy:latest
           args:
-            - "--metrics-addr=127.0.0.1:8443"
+            - "--metrics-addr=127.0.0.1:9091"
             - "--store-path=/store"
             - "--transport-host=amqp://amq-interconnect"
             - "--api-port=8080"
@@ -74,6 +75,31 @@ spec:
           volumeMounts:
             - name: pubsubstore
               mountPath: /store
+          ports:
+            - name: metrics-port
+              containerPort: 9091
+        - name: kube-rbac-proxy
+          image: quay.io/coreos/kube-rbac-proxy:v0.5.0
+          args:
+            - --logtostderr
+            - --secure-listen-address=:8443
+            - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+            - --upstream=http://127.0.0.1:9091/
+            - --tls-private-key-file=/etc/metrics/tls.key
+            - --tls-cert-file=/etc/metrics/tls.crt
+          ports:
+            - containerPort: 8443
+              name: https
+          resources:
+            requests:
+              cpu: 10m
+              memory: 20Mi
+          volumeMounts:
+            - name: sidecar-certs
+              mountPath: /etc/metrics
       volumes:
         - name: pubsubstore
           emptyDir: {}
+        - name: sidecar-certs
+          secret:
+            secretName: sidecar-producer-secret

--- a/examples/manifests/roles.yaml
+++ b/examples/manifests/roles.yaml
@@ -1,0 +1,88 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: sidecar-producer-role
+rules:
+  - apiGroups: ["authentication.k8s.io"]
+    resources: ["tokenreviews"]
+    verbs: ["create"]
+  - apiGroups: ["authorization.k8s.io"]
+    resources: ["subjectaccessreviews"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: sidecar-producer-role-binding
+roleRef:
+  kind: ClusterRole
+  name: sidecar-producer-role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: sidecar-producer-sa
+    namespace: cloud-native-events
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: sidecar-consumer-role
+rules:
+  - apiGroups: ["authentication.k8s.io"]
+    resources: ["tokenreviews"]
+    verbs: ["create"]
+  - apiGroups: ["authorization.k8s.io"]
+    resources: ["subjectaccessreviews"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: sidecar-consumer-role-binding
+roleRef:
+  kind: ClusterRole
+  name: sidecar-consumer-role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: sidecar-consumer-sa
+    namespace: cloud-native-events
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: cloud-native-events
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - get
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: cloud-native-events
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring
+

--- a/examples/manifests/servcie-account.yaml
+++ b/examples/manifests/servcie-account.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sidecar-producer-sa
+  namespace: cloud-native-events
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sidecar-consumer-sa
+  namespace: cloud-native-events

--- a/examples/manifests/service.yaml
+++ b/examples/manifests/service.yaml
@@ -1,0 +1,83 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+    service.alpha.openshift.io/serving-cert-secret-name: sidecar-producer-secret
+  name: producer-sidecar-service
+  labels:
+    app: producer-service
+spec:
+  ports:
+    - name: metrics
+      port: 8443
+      targetPort: https
+  selector:
+    app: producer
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+    service.alpha.openshift.io/serving-cert-secret-name: sidecar-consumer-secret
+  name: consumer-sidecar-service
+  labels:
+    app: consumer-service
+spec:
+  ports:
+    - name: metrics
+      port: 8443
+      targetPort: https
+  selector:
+    app: consumer
+  type: ClusterIP
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    name: producer-sidecar-service-monitor
+  name: producer-sidecar-service-monitor
+  namespace: cloud-native-events
+spec:
+  jobLabel: cloud-native-events
+  endpoints:
+    - interval: 30s
+      port: metrics
+      bearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+      scheme: "https"
+      tlsConfig:
+        caFile: "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt"
+        serverName: "producer-sidecar-service.cloud-native-events.svc"
+  selector:
+    matchLabels:
+      app: producer-service
+  namespaceSelector:
+    matchNames:
+      - cloud-native-events
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    k8s-app: consumer-sidecar-service-monitor
+  name: consumer-sidecar-service-monitor
+  namespace: cloud-native-events
+spec:
+  jobLabel: cloud-native-events
+  endpoints:
+    - interval: 30s
+      port: metrics
+      bearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+      scheme: "https"
+      tlsConfig:
+        caFile: "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt"
+        serverName: "consumer-sidecar-service.cloud-native-events.svc"
+  selector:
+    matchLabels:
+      app: consumer-service
+  namespaceSelector:
+    matchNames:
+      - cloud-native-events

--- a/examples/producer/main.go
+++ b/examples/producer/main.go
@@ -34,11 +34,11 @@ import (
 )
 
 var (
-	apiAddr                string = "localhost:8080"
-	apiPath                string = "/api/cloudNotifications/v1/"
+	apiAddr                string
+	apiPath                string
+	localAPIAddr           string
 	resourceAddressSports  string = "/news-service/sports"
 	resourceAddressFinance string = "/news-service/finance"
-	localAPIAddr           string = "localhost:9088"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.15
 require (
 	github.com/cloudevents/sdk-go/v2 v2.4.1
 	github.com/prometheus/client_golang v1.10.0
-	github.com/redhat-cne/rest-api v0.0.0-20210505133918-6d18ad9062d8
-	github.com/redhat-cne/sdk-go v0.0.0-20210505133653-ca6e6ff0d534
+	github.com/redhat-cne/rest-api v0.0.0-20210505135319-b6fdad26dc32
+	github.com/redhat-cne/sdk-go v0.0.0-20210505165043-0793aa787373
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/net v0.0.0-20210505024714-0287a6fb4125

--- a/go.sum
+++ b/go.sum
@@ -276,10 +276,11 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3xv4=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
-github.com/redhat-cne/rest-api v0.0.0-20210505133918-6d18ad9062d8 h1:Nmw1nmyDPiC/RkHQknLgXZRBnUkOSvjjUEn4Tw0lMn8=
-github.com/redhat-cne/rest-api v0.0.0-20210505133918-6d18ad9062d8/go.mod h1:YMRXPhCIPuPBi9YOMdH+huCjT7UWSmnkjQ9VzkpBDVw=
-github.com/redhat-cne/sdk-go v0.0.0-20210505133653-ca6e6ff0d534 h1:c1aQSvCKuOpNXF7lhQeCG3whMt8Mh5HR/vvy8XXhY5w=
+github.com/redhat-cne/rest-api v0.0.0-20210505135319-b6fdad26dc32 h1:t4en6VJn4aX2KU3DJ8Dz05IgJWI8OgGVrIvDi94nhrM=
+github.com/redhat-cne/rest-api v0.0.0-20210505135319-b6fdad26dc32/go.mod h1:YMRXPhCIPuPBi9YOMdH+huCjT7UWSmnkjQ9VzkpBDVw=
 github.com/redhat-cne/sdk-go v0.0.0-20210505133653-ca6e6ff0d534/go.mod h1:FqtKJTyjOtOS5YPs3M0CZ9Vc/RYgEv9ecp+Zq4Lbeyk=
+github.com/redhat-cne/sdk-go v0.0.0-20210505165043-0793aa787373 h1:SUqiHCva1mzMpvL+j8KV3XdbwzThJCX6r7aJScheIfo=
+github.com/redhat-cne/sdk-go v0.0.0-20210505165043-0793aa787373/go.mod h1:FqtKJTyjOtOS5YPs3M0CZ9Vc/RYgEv9ecp+Zq4Lbeyk=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=


### PR DESCRIPTION
Signed-off-by: Aneesh Puttur <aneeshputtur@gmail.com>
Added manifest required to deploy in OpenShift for the example application.
Sidecar deployment uses Kube-rbac-proxy to secure the metrics endpoint.

