### PR TITLE
Fix producer image name

### DIFF
--- a/examples/manifests/producer.yaml
+++ b/examples/manifests/producer.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: sidecar-producer-sa
       containers:
         - name: cloud-native-event-producer
-          image: cloud-native-event-consumer
+          image: cloud-native-event-producer
           args:
             - "--local-api-addr=127.0.0.1:9089"
             - "--api-path=/api/cloudNotifications/v1/"


### PR DESCRIPTION
Signed-off-by: Aneesh Puttur <aneeshputtur@gmail.com>
Producer.YAML was using consumer image, hence both were acting as consumers.
Fixed it to use producer image