### PR TITLE
COPY plugins from absolute path to make imagebuilder happy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN hack/build-go.sh
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest AS bin
 COPY --from=builder /go/src/github.com/redhat-cne/cloud-event-proxy/build/cloud-event-proxy /
-COPY --from=builder go/src/github.com/redhat-cne/cloud-event-proxy/plugins/*.so /plugins/
+COPY --from=builder /go/src/github.com/redhat-cne/cloud-event-proxy/plugins/*.so /plugins/
 
 LABEL io.k8s.display-name="Cloud Event Proxy" \
       io.k8s.description="This is a component of OpenShift Container Platform and provides a side car to handle cloud events." \


### PR DESCRIPTION
Building this image with [imagebuilder](https://github.com/openshift/imagebuilder)
results in the following error:
```
lstat /var/lib/docker/overlay2/.../merged/go/src/github.com/redhat-cne/cloud-event-proxy/go/src/github.com/redhat-cne/cloud-event-proxy/plugins/: no such file or directory
```

Most probably because `WORKDIR` is different than `/` in Brew/OSBS ... turning it into an absolute path fixes the problem.