### PR TITLE
Let GOARCH be inferred from the environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ export CGO_ENABLED=1
 export GOFLAGS=-mod=vendor
 export COMMON_GO_ARGS=-race
 export GOOS=linux
-export GOARCH=amd64
 
 ifeq (,$(shell go env GOBIN))
   GOBIN=$(shell go env GOPATH)/bin


### PR DESCRIPTION
When building this image on a non-amd64 environment, we get the following errors:
```
go build  -o plugins/amqp_plugin.so -buildmode=plugin plugins/amqp/amqp_plugin.go
gcc_amd64.S: Assembler messages:
gcc_amd64.S:25: Error: unrecognized opcode: `pushq'
gcc_amd64.S:26: Error: unrecognized opcode: `pushq'
gcc_amd64.S:27: Error: unrecognized opcode: `pushq'
gcc_amd64.S:28: Error: unrecognized opcode: `pushq'
gcc_amd64.S:29: Error: unrecognized opcode: `pushq'
gcc_amd64.S:30: Error: unrecognized opcode: `pushq'
gcc_amd64.S:35: Error: unrecognized opcode: `call'
gcc_amd64.S:38: Error: unrecognized opcode: `popq'
gcc_amd64.S:39: Error: unrecognized opcode: `popq'
gcc_amd64.S:40: Error: unrecognized opcode: `popq'
gcc_amd64.S:41: Error: unrecognized opcode: `popq'
gcc_amd64.S:42: Error: unrecognized opcode: `popq'
gcc_amd64.S:43: Error: unrecognized opcode: `popq'
gcc_amd64.S:44: Error: unrecognized opcode: `ret'
make: *** [Makefile:63: build-plugins] Error 2
```