### PR TITLE
Updating cloud-event-proxy images to be consistent with ART (#52)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/origin-release:golang-1.15 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.9 AS builder
 ENV GO111MODULE=off
 ENV CGO_ENABLED=1
 ENV COMMON_GO_ARGS=-race
@@ -10,7 +10,7 @@ COPY . .
 
 RUN hack/build-go.sh
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest AS bin
+FROM registry.ci.openshift.org/ocp/4.9:base AS bin
 COPY --from=builder /go/src/github.com/redhat-cne/cloud-event-proxy/build/cloud-event-proxy /
 COPY --from=builder /go/src/github.com/redhat-cne/cloud-event-proxy/plugins/*.so /plugins/
 


### PR DESCRIPTION
Reconciling with https://github.com/openshift/ocp-build-data/tree/645b06463cc0a4c847d252201a9da7d127bf85f5/images/cloud-event-proxy.yml

Co-authored-by: AOS Automation Release Team <noreply@redhat.com>