### PR TITLE
Bug 1999185: Fixed parse error when summary interval is set to 0

### DIFF
--- a/plugins/ptp_operator/metrics/metrics.go
+++ b/plugins/ptp_operator/metrics/metrics.go
@@ -691,10 +691,8 @@ func extractSummaryMetrics(processName, output string) (iface string, offsetFrom
 	// This makes the out to equals
 	// 0            1       2              3     4   5      6     7     8       9
 	//phc2sys 5196755.139 ptp4l.0.config ens7f1 rms 3151717 max 3151717 freq -6085106 +/-   0 delay  2746 +/-   0
-	//phc2sys 5196755.139 ptp4l.0.config ens5f0 rms 3152778 max 3152778 freq -6083928 +/-   0 delay  2791 +/-   0
 	//phc2sys 5196804.326 ptp4l.0.config CLOCK_REALTIME rms 9452637 max 9452637 freq +1196097 +/-   0 delay  1000
-	// remove everything before the rms string
-	// This makes the out to equals
+	// ptp4l[74737.942]: [ptp4l.0.config] rms   53 max   74 freq -16642 +/-  40 delay  1089 +/-  20
 
 	indx := strings.Index(output, "rms")
 	if indx < 0 {
@@ -717,6 +715,16 @@ func extractSummaryMetrics(processName, output string) (iface string, offsetFrom
 		return
 	}
 
+	// when ptp4l log is missing interface name
+	if fields[1] == "rms" {
+		fields = append(fields, "") // Making space for the new element
+		//  0             1     2
+		//ptp4l.0.config rms   53 max   74 freq -16642 +/-  40 delay  1089 +/-  20
+		copy(fields[2:], fields[1:]) // Shifting elements
+		fields[1] = "master"         // Copying/inserting the value
+		//  0             0       1   2
+		//ptp4l.0.config master rms   53 max   74 freq -16642 +/-  40 delay  1089 +/-  20
+	}
 	iface = fields[1]
 
 	offsetFromMaster, err := strconv.ParseFloat(fields[3], 64)


### PR DESCRIPTION
Signed-off-by: Aneesh Puttur <aneeshputtur@gmail.com>
with summary_interval=0 in ptp config, the ptp4l log will produce rms log without interface name , this was causing parsing error because parsing logic is based on position of the fields in the logs and expected to have interface name.
This PR takes care of both conditions with interface and without interface name in the ptp4l rms logs

