### PR TITLE
Bug 2000253: fix pod crash

### DIFF
--- a/examples/consumer/deployment/deployment.yaml
+++ b/examples/consumer/deployment/deployment.yaml
@@ -1,12 +1,11 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
   name: cloud-native-consumer-deployment
   namespace: cloud-native-events
   labels:
     app: consumer
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app: consumer
@@ -15,15 +14,8 @@ spec:
       labels:
         app: consumer
     spec:
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: app
-                    operator: In
-                    values:
-                      - local
+      nodeSelector:
+        node-role.kubernetes.io/worker-cnf: ""
       serviceAccountName: sidecar-consumer-sa
       containers:
         - name: cloud-native-event-consumer
@@ -31,7 +23,7 @@ spec:
           args:
             - "--local-api-addr=127.0.0.1:9089"
             - "--api-path=/api/cloudNotifications/v1/"
-            - "--api-addr=127.0.0.1:8080"
+            - "--api-addr=127.0.0.1:8089"
           env:
             - name: NODE_NAME
               valueFrom:
@@ -46,8 +38,8 @@ spec:
           args:
             - "--metrics-addr=127.0.0.1:9091"
             - "--store-path=/store"
-            - "--transport-host=amqp://amq-interconnect.amqp-interconnect.svc.cluster.local"
-            - "--api-port=8080"
+            - "--transport-host=amqp://router.amqp-interconnect.svc.cluster.local"
+            - "--api-port=8089"
           env:
             - name: NODE_NAME
               valueFrom:

--- a/plugins/ptp_operator/config/config.go
+++ b/plugins/ptp_operator/config/config.go
@@ -133,10 +133,14 @@ func (l *LinuxPTPConfigMapUpdate) SetDefaultPTPThreshold(iface string) {
 
 // DeletePTPThreshold ... delete threshold for the interface
 func (l *LinuxPTPConfigMapUpdate) DeletePTPThreshold(iface string) {
-	if t, found := l.EventThreshold[iface]; found {
+	defer func() {
+		if err := recover(); err != nil {
+			log.Errorf("restored from delete ptp threshold")
+		}
+	}()
+	if _, found := l.EventThreshold[iface]; found {
 		l.lock.Lock()
 		defer l.lock.Unlock()
-		close(t.Close) // close any go routine associated with this threshold
 		delete(l.EventThreshold, iface)
 	}
 }


### PR DESCRIPTION
Signed-off-by: Aneesh Puttur <aneeshputtur@gmail.com>
when user edits ptpconfig it triggers a file delete , and throws channel closed error.
This PR fixed close channel and pod crash
also converted consumer to daemonset