### PR TITLE
Bug 2004137: Fixed ptp threshold updates not updating values for CLOCK_REALTIME

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -81,7 +81,7 @@ func main() {
 	nodeIP := os.Getenv("NODE_IP")
 	if nodeIP != "" {
 		amqpHost = strings.Replace(amqpHost, "NODE_IP", nodeIP, 1)
-		log.Infof("amqp host path is set to %s",amqpHost)
+		log.Infof("amqp host path is set to %s", amqpHost)
 	}
 
 	scConfig = &common.SCConfiguration{

--- a/examples/consumer/deployment/deployment.yaml
+++ b/examples/consumer/deployment/deployment.yaml
@@ -17,6 +17,7 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/worker: ""
       serviceAccountName: sidecar-consumer-sa
+      dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: cloud-native-event-consumer
           image: quay.io/aneeshkp/cloud-native-event-consumer

--- a/plugins/ptp_operator/ptp_operator_plugin.go
+++ b/plugins/ptp_operator/ptp_operator_plugin.go
@@ -239,7 +239,6 @@ func Start(wg *sync.WaitGroup, configuration *common.SCConfiguration, fn func(e 
 					}
 				}
 				if publishStatus {
-					log.Infof(" publishing event for %s with clock state %s and offset %d", string(i), s.SyncState(), s.Offset())
 					eventManager.PublishEvent(s.SyncState(), s.Offset(), string(i), "PTP_STATUS")
 				}
 			}


### PR DESCRIPTION
Signed-off-by: Aneesh Puttur <aneeshputtur@gmail.com>
ptp event threshold values are set in ptpconfig and they are read in every 60 secs interval and update the threshold values mapped to interface name identified from ptp4l config file.
The bug was missing to identify interface names such as CLOCK_REALTIME, which is worker interface and was causing to miss new threshold values.
This PR also fixes a change to load the threshold values during the startup and then follow 60 secs interval to watch and update. By fixing this change, it allows to fetch real values during startup and not relaying on default values till the 60 secs interval is met.