### PR TITLE
Add source in event

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ run-consumer:
 	go run examples/consumer/main.go
 
 test:
-	go test ./...  -coverprofile=cover.out
+	go test ./... --tags=unittests -coverprofile=cover.out
 
 functests:
 	SUITE=./test/cne hack/run-functests.sh

--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.17.0
 	github.com/prometheus/client_golang v1.11.0
-	github.com/redhat-cne/rest-api v0.1.1-0.20211206194632-bc3eb46ad9d0
-	github.com/redhat-cne/sdk-go v0.1.1-0.20211206194140-5b52c616af2b
+	github.com/redhat-cne/rest-api v0.1.1-0.20220105171308-cc511366a079
+	github.com/redhat-cne/sdk-go v0.1.1-0.20220105170230-b17827c91503
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0
 	github.com/valyala/fasthttp v1.29.0

--- a/go.sum
+++ b/go.sum
@@ -381,10 +381,10 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3xv4=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/redhat-cne/rest-api v0.1.1-0.20211206194632-bc3eb46ad9d0 h1:dtm5GyMpu17/En+GmS7ojvRsEuG2e719MXH8CI8JXSY=
-github.com/redhat-cne/rest-api v0.1.1-0.20211206194632-bc3eb46ad9d0/go.mod h1:sGK4icx3lVW0vDFRIx2m/lRMwW/axcmADh7o0Y3ZiVE=
-github.com/redhat-cne/sdk-go v0.1.1-0.20211206194140-5b52c616af2b h1:Z7Y2QrpCyLiAWTGz0yyJtxOu3T7f9GCXAD/sYHdpcVk=
-github.com/redhat-cne/sdk-go v0.1.1-0.20211206194140-5b52c616af2b/go.mod h1:1FXE/O2PhDnazeCidsAIJJ5lLaaWHBXNP5HxaJ1hf0U=
+github.com/redhat-cne/rest-api v0.1.1-0.20220105171308-cc511366a079 h1:Qb9+5k3gES0qQfxLWfsEuzFpCkFMcV3LcTTE2p/ZtG0=
+github.com/redhat-cne/rest-api v0.1.1-0.20220105171308-cc511366a079/go.mod h1:vb1QG25ojKDcT4KMboBP2QRWZG7SNH9senqSsS4Khhk=
+github.com/redhat-cne/sdk-go v0.1.1-0.20220105170230-b17827c91503 h1:gfwZqJ0xiWF6eDrtQuYhzRblG7LBHYUbskUl0A+IANs=
+github.com/redhat-cne/sdk-go v0.1.1-0.20220105170230-b17827c91503/go.mod h1:1FXE/O2PhDnazeCidsAIJJ5lLaaWHBXNP5HxaJ1hf0U=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -132,7 +132,7 @@ func CreateSubscription(config *SCConfiguration, subscription pubsub.PubSub) (su
 }
 
 // CreateEvent create an event
-func CreateEvent(pubSubID, eventType string, data ceevent.Data) (ceevent.Event, error) {
+func CreateEvent(pubSubID, eventType, source string, data ceevent.Data) (ceevent.Event, error) {
 	// create an event
 	if pubSubID == "" {
 		return ceevent.Event{}, fmt.Errorf("id is a required field")
@@ -143,6 +143,7 @@ func CreateEvent(pubSubID, eventType string, data ceevent.Data) (ceevent.Event, 
 	event := v1event.CloudNativeEvent()
 	event.ID = pubSubID
 	event.Type = eventType
+	event.SetSource(source)
 	event.SetTime(types.Timestamp{Time: time.Now().UTC()}.Time)
 	event.SetDataContentType(ceevent.ApplicationJSON)
 	event.SetData(data)

--- a/plugins/mock/mock_plugin.go
+++ b/plugins/mock/mock_plugin.go
@@ -113,19 +113,19 @@ func createMockEvent(pub pubsub.PubSub) (ceEvent.Event, error) {
 	data := ceEvent.Data{
 		Version: "v1",
 		Values: []ceEvent.DataValue{{
-			Resource:  pub.Resource,
+			Resource:  string(ptp.SyncStatusState),
 			DataType:  ceEvent.NOTIFICATION,
 			ValueType: ceEvent.ENUMERATION,
 			Value:     ptp.ACQUIRING_SYNC,
 		},
 			{
-				Resource:  pub.Resource,
+				Resource:  string(ptp.SyncStatusState),
 				DataType:  ceEvent.METRIC,
 				ValueType: ceEvent.DECIMAL,
 				Value:     "99.6",
 			},
 		},
 	}
-	e, err := common.CreateEvent(pub.ID, string(ptp.PtpStateChange), data)
+	e, err := common.CreateEvent(pub.ID, pub.Resource, string(ptp.PtpStateChange), data)
 	return e, err
 }

--- a/plugins/ptp_operator/metrics/metrics.go
+++ b/plugins/ptp_operator/metrics/metrics.go
@@ -544,22 +544,23 @@ func (p *PTPEventManager) PublishEvent(state ptp.SyncState, ptpOffset int64, ifa
 	if state == "" {
 		return
 	}
+	source := fmt.Sprintf("/cluster/%s/ptp/interface/%s", p.nodeName, iface)
 	data := ceevent.Data{
 		Version: "v1",
 		Values: []ceevent.DataValue{{
-			Resource:  fmt.Sprintf("/cluster/%s/ptp/interface/%s", p.nodeName, iface),
+			Resource:  string(ptp.SyncStatusState),
 			DataType:  ceevent.NOTIFICATION,
 			ValueType: ceevent.ENUMERATION,
 			Value:     state,
 		}, {
-			Resource:  fmt.Sprintf("/cluster/%s/ptp/interface/%s", p.nodeName, iface),
+			Resource:  string(ptp.SyncStatusState),
 			DataType:  ceevent.METRIC,
 			ValueType: ceevent.DECIMAL,
 			Value:     float64(ptpOffset),
 		},
 		},
 	}
-	e, err := common.CreateEvent(p.publisherID, string(eventType), data)
+	e, err := common.CreateEvent(p.publisherID, string(eventType), source, data)
 	if err != nil {
 		log.Errorf("failed to create ptp event, %s", err)
 		return

--- a/vendor/github.com/redhat-cne/sdk-go/pkg/event/event.go
+++ b/vendor/github.com/redhat-cne/sdk-go/pkg/event/event.go
@@ -28,30 +28,20 @@ import (
 //{
 //	"id": "5ce55d17-9234-4fee-a589-d0f10cb32b8e",
 //	"type": "event.sync.sync-status.synchronization-state-change",
+//	"source": "/cluster/node/example.com/ptp/clock_realtime",
 //	"time": "2021-02-05T17:31:00Z",
 //	"data": {
 //		"version": "v1.0",
 //		"values": [{
-//			"resource": "/cluster/node/ptp",
+//			"resource": "/sync/sync-status/sync-state",
 //			"dataType": "notification",
 //			"valueType": "enumeration",
 //			"value": "ACQUIRING-SYNC"
 //			}, {
-//			"resource": "/cluster/node/clock",
+//			"resource": "/sync/sync-status/sync-state",
 //			"dataType": "metric",
 //			"valueType": "decimal64.3",
 //			"value": 100.3
-//			}, {
-//			"resource": "/cluster/node/temp",
-//			"dataType": "notification",
-//			"valueType": "redfish-event",
-//			"value": {
-//			"@odata.context": "/redfish/v1/$metadata#Event.Event",
-//			"@odata.type": "#Event.v1_3_0.Event",
-//			"Context": "any string is valid",
-//			"Events": [{"EventId": "2162", "MemberId": "615703", "MessageId": "TMP0100"}],
-//			"Id": "5e004f5a-e3d1-11eb-ae9c-3448edf18a38",
-//			"Name": "Event Array"
 //			}]
 //		}
 //}
@@ -63,6 +53,9 @@ type Event struct {
 	// Type - The type of the occurrence which has happened.
 	// +required
 	Type string `json:"type" example:"event.sync.sync-status.synchronization-state-change"`
+	// Source - The source of the occurrence which has happened.
+	// +required
+	Source string `json:"source" example:"/cluster/node/example.com/ptp/clock_realtime"`
 	// DataContentType - the Data content type
 	// +required
 	DataContentType *string `json:"dataContentType" example:"application/json"`

--- a/vendor/github.com/redhat-cne/sdk-go/pkg/event/event_ce.go
+++ b/vendor/github.com/redhat-cne/sdk-go/pkg/event/event_ce.go
@@ -50,6 +50,7 @@ func (e *Event) GetCloudNativeEvents(ce *cloudevent.Event) (err error) {
 	e.SetDataContentType(ApplicationJSON)
 	e.SetTime(ce.Time())
 	e.SetType(ce.Type())
+	e.SetSource(ce.Source())
 	e.SetData(data)
 	return
 }

--- a/vendor/github.com/redhat-cne/sdk-go/pkg/event/event_data.go
+++ b/vendor/github.com/redhat-cne/sdk-go/pkg/event/event_data.go
@@ -46,17 +46,17 @@ const (
 //{
 //	"version": "v1.0",
 //	"values": [{
-//		"resource": "/cluster/node/ptp",
+//		"resource": "/sync/sync-status/sync-state",
 //		"dataType": "notification",
 //		"valueType": "enumeration",
 //		"value": "ACQUIRING-SYNC"
 //		}, {
-//		"resource": "/cluster/node/clock",
+//		"resource": "/sync/sync-status/sync-state",
 //		"dataType": "metric",
 //		"valueType": "decimal64.3",
 //		"value": 100.3
 //		}, {
-//		"resource": "/cluster/node/temp",
+//		"resource": "/redfish/v1/Systems",
 //		"dataType": "notification",
 //		"valueType": "redfish-event",
 //		"value": {

--- a/vendor/github.com/redhat-cne/sdk-go/pkg/event/event_marshal.go
+++ b/vendor/github.com/redhat-cne/sdk-go/pkg/event/event_marshal.go
@@ -39,6 +39,10 @@ func WriteJSON(in *Event, writer io.Writer) error {
 
 			stream.WriteObjectField("type")
 			stream.WriteString(in.GetType())
+			stream.WriteMore()
+
+			stream.WriteObjectField("source")
+			stream.WriteString(in.GetSource())
 
 			if in.GetDataContentType() != "" {
 				stream.WriteMore()

--- a/vendor/github.com/redhat-cne/sdk-go/pkg/event/event_reader.go
+++ b/vendor/github.com/redhat-cne/sdk-go/pkg/event/event_reader.go
@@ -25,6 +25,11 @@ func (e *Event) GetType() string {
 	return e.Type
 }
 
+// GetSource implements Reader.Source
+func (e *Event) GetSource() string {
+	return e.Source
+}
+
 // GetID implements Reader.ID
 func (e *Event) GetID() string {
 	return e.ID

--- a/vendor/github.com/redhat-cne/sdk-go/pkg/event/event_unmarshal.go
+++ b/vendor/github.com/redhat-cne/sdk-go/pkg/event/event_unmarshal.go
@@ -85,11 +85,12 @@ func readDataJSONFromIterator(out *Data, iterator *jsoniter.Iterator) error {
 func readJSONFromIterator(out *Event, iterator *jsoniter.Iterator) error {
 	var (
 		// Universally parseable fields.
-		id   string
-		typ  string
-		time *types.Timestamp
-		data *Data
-		err  error
+		id     string
+		typ    string
+		source string
+		time   *types.Timestamp
+		data   *Data
+		err    error
 
 		// These fields require knowledge about the specversion to be parsed.
 		//schemaurl jsoniter.Any
@@ -107,6 +108,8 @@ func readJSONFromIterator(out *Event, iterator *jsoniter.Iterator) error {
 			id = iterator.ReadString()
 		case "type":
 			typ = iterator.ReadString()
+		case "source":
+			source = iterator.ReadString()
 		case "time":
 			time = readTimestamp(iterator)
 		case "data":
@@ -130,6 +133,7 @@ func readJSONFromIterator(out *Event, iterator *jsoniter.Iterator) error {
 	out.Time = time
 	out.ID = id
 	out.Type = typ
+	out.Source = source
 	if data != nil {
 		out.SetData(*data)
 	}

--- a/vendor/github.com/redhat-cne/sdk-go/pkg/event/event_writer.go
+++ b/vendor/github.com/redhat-cne/sdk-go/pkg/event/event_writer.go
@@ -29,6 +29,11 @@ func (e *Event) SetType(t string) {
 	e.Type = t
 }
 
+// SetSource implements Writer.SetSource
+func (e *Event) SetSource(s string) {
+	e.Source = s
+}
+
 // SetID implements Writer.SetID
 func (e *Event) SetID(id string) {
 	e.ID = id

--- a/vendor/github.com/redhat-cne/sdk-go/pkg/event/ptp/resource.go
+++ b/vendor/github.com/redhat-cne/sdk-go/pkg/event/ptp/resource.go
@@ -14,31 +14,31 @@
 
 package ptp
 
-// EventSource ...
-type EventSource string
+// EventResource ...
+type EventResource string
 
 const (
 	// GnssSyncStatus notification is signalled from equipment at state change
-	GnssSyncStatus EventSource = "/sync/gnss-status/gnss-sync-status"
+	GnssSyncStatus EventResource = "/sync/gnss-status/gnss-sync-status"
 
 	// OsClockSyncState State of node OS clock synchronization is notified at state change
-	OsClockSyncState EventSource = "/sync/sync-status/os-clock-sync-state"
+	OsClockSyncState EventResource = "/sync/sync-status/os-clock-sync-state"
 
 	// PtpClockClass notification is generated when the clock-class changes.
-	PtpClockClass EventSource = "/sync/ptp-status/ptp-clock-class-change"
+	PtpClockClass EventResource = "/sync/ptp-status/ptp-clock-class-change"
 
 	// PtpLockState notification is signalled from equipment at state change
-	PtpLockState EventSource = "/sync/ptp-status/lock-state"
+	PtpLockState EventResource = "/sync/ptp-status/lock-state"
 
 	// SynceClockQuality notification is generated when the clock-quality changes.
-	SynceClockQuality EventSource = "/sync/synce-status/clock-quality"
+	SynceClockQuality EventResource = "/sync/synce-status/clock-quality"
 
 	// SynceLockState Notification used to inform about synce synchronization state change
-	SynceLockState EventSource = "/sync/synce-status/lock-state"
+	SynceLockState EventResource = "/sync/synce-status/lock-state"
 
 	// SynceLockStateExtended notification is signalled from equipment at state change, enhanced information
-	SynceLockStateExtended EventSource = "/sync/synce-status/lock-state-extended"
+	SynceLockStateExtended EventResource = "/sync/synce-status/lock-state-extended"
 
 	// SyncStatusState State of equipment synchronization is notified at state change
-	SyncStatusState EventSource = "/sync/sync-status/sync-state"
+	SyncStatusState EventResource = "/sync/sync-status/sync-state"
 )

--- a/vendor/github.com/redhat-cne/sdk-go/pkg/event/redfish/resource.go
+++ b/vendor/github.com/redhat-cne/sdk-go/pkg/event/redfish/resource.go
@@ -1,0 +1,23 @@
+// Copyright 2021 The Cloud Native Events Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redfish
+
+// EventResource ...
+type EventResource string
+
+const (
+	// Systems is odata.id of the generic origin of redfish events
+	Systems EventResource = "/redfish/v1/Systems"
+)

--- a/vendor/github.com/redhat-cne/sdk-go/v1/event/event.go
+++ b/vendor/github.com/redhat-cne/sdk-go/v1/event/event.go
@@ -110,6 +110,7 @@ func GetCloudNativeEvents(ce cloudevents.Event) (e event.Event, err error) {
 	e.SetDataContentType(event.ApplicationJSON)
 	e.SetTime(ce.Time())
 	e.SetType(ce.Type())
+	e.SetSource(ce.Source())
 	e.SetData(data)
 	return
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -167,11 +167,11 @@ github.com/prometheus/common/model
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/redhat-cne/rest-api v0.1.1-0.20211206194632-bc3eb46ad9d0
+# github.com/redhat-cne/rest-api v0.1.1-0.20220105171308-cc511366a079
 ## explicit; go 1.17
 github.com/redhat-cne/rest-api
 github.com/redhat-cne/rest-api/pkg/localmetrics
-# github.com/redhat-cne/sdk-go v0.1.1-0.20211206194140-5b52c616af2b
+# github.com/redhat-cne/sdk-go v0.1.1-0.20220105170230-b17827c91503
 ## explicit; go 1.17
 github.com/redhat-cne/sdk-go/pkg/channel
 github.com/redhat-cne/sdk-go/pkg/errorhandler


### PR DESCRIPTION
Add `source` as a required attribute in event.
Update the `resource` under `event.data.values` to be resource
type instead of the source.

Signed-off-by: Jack Ding <jacding@redhat.com>