### PR TITLE
CNF-4018 Enable Flexible Registration for Multiple PTP Events

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@
 VERSION ?=latest
 # Default image tag
 
-SIDECAR_IMG ?= quay.io/aneeshkp/cloud-event-proxy:$(VERSION)
-CONSUMER_IMG ?= quay.io/aneeshkp/cloud-native-event-consumer:$(VERSION)
+IMG ?= quay.io/redhat-cne/cloud-event-proxy:$(VERSION)
+CONSUMER_IMG ?= quay.io/redhat-cne/cloud-event-consumer:$(VERSION)
 
 
 # Export GO111MODULE=on to enable project to be built from within GOPATH/src
@@ -50,7 +50,7 @@ build-only:
 	go build -o ./build/cloud-event-proxy cmd/main.go
 
 build-examples:
-	go build -o ./build/cloud-native-event-consumer ./examples/consumer/main.go
+	go build -o ./build/cloud-event-consumer ./examples/consumer/main.go
 
 lint:
 	golint -set_exit_status `go list ./... | grep -v vendor`
@@ -60,7 +60,6 @@ build-plugins:
 	go build  -o plugins/amqp_plugin.so -buildmode=plugin plugins/amqp/amqp_plugin.go
 	go build  -o plugins/ptp_operator_plugin.so -buildmode=plugin plugins/ptp_operator/ptp_operator_plugin.go
 	go build  -o plugins/mock_plugin.so -buildmode=plugin plugins/mock/mock_plugin.go
-
 
 build-amqp-plugin:
 	go build -o plugins/amqp_plugin.so -buildmode=plugin plugins/amqp/amqp_plugin.go
@@ -85,12 +84,12 @@ functests:
 
 # Deploy all in the configured Kubernetes cluster in ~/.kube/config
 deploy-example:kustomize
-	cd ./examples/manifests && $(KUSTOMIZE) edit set image cloud-event-proxy=${SIDECAR_IMG} && $(KUSTOMIZE) edit set image cloud-native-event-consumer=${CONSUMER_IMG}
+	cd ./examples/manifests && $(KUSTOMIZE) edit set image cloud-event-proxy=${IMG} && $(KUSTOMIZE) edit set image cloud-event-consumer=${CONSUMER_IMG}
 	$(KUSTOMIZE) build ./examples/manifests | kubectl apply -f -
 
 # Deploy all in the configured Kubernetes cluster in ~/.kube/config
 undeploy-example:kustomize
-	cd ./examples/manifests  && $(KUSTOMIZE) edit set image cloud-event-proxy=${SIDECAR_IMG} && $(KUSTOMIZE) edit set image cloud-native-event-consumer=${CONSUMER_IMG}
+	cd ./examples/manifests  && $(KUSTOMIZE) edit set image cloud-event-proxy=${IMG} && $(KUSTOMIZE) edit set image cloud-event-consumer=${CONSUMER_IMG}
 	$(KUSTOMIZE) build ./examples/manifests | kubectl delete -f -
 
 # For GitHub Actions CI
@@ -100,3 +99,14 @@ gha:
 	go build -o plugins/mock_plugin.so -buildmode=plugin plugins/mock/mock_plugin.go
 	go test ./... --tags=unittests -coverprofile=cover.out
 
+docker-build: #test ## Build docker image with the manager.
+	docker build -t ${IMG} .
+
+docker-push: ## Push docker image with the manager.
+	docker push ${IMG}
+
+docker-build-consumer: #test ## Build docker image with the manager.
+	docker build -f ./examples/consumer.Dockerfile -t ${CONSUMER_IMG} .
+
+docker-push-consumer: ## Push docker image with the manager.
+	docker push ${CONSUMER_IMG}

--- a/docs/development.md
+++ b/docs/development.md
@@ -38,8 +38,8 @@ make run-consumer
 ### Push images to a repo
 
 ```shell
-podman push localhost/cloud-event-proxy:${TAG} quay.io/aneeshkp/cloud-event-proxy:latest
-podman push localhost/cloud-native-event-consumer:${TAG}quay.io/aneeshkp/cloud-native-event-consumer:latest
+podman push localhost/cloud-event-proxy:${TAG} quay.io/redhat-cne/cloud-event-proxy:latest
+podman push localhost/cloud-event-consumer:${TAG}quay.io/redhat-cne/cloud-event-consumer:latest
 ```
 
 Use consumer.yaml and service.yaml from examples/manifests folder to deploy to a cluster.
@@ -59,8 +59,8 @@ mv kustomize /usr/local/bin/
 ### Set Env variables
 ```shell
 export version=latest 
-export SIDECAR_IMG=quay.io/aneeshkp/cloud-event-proxy
-export  CONSUMER_IMG=quay.io/aneeshkp/cloud-native-event-consumer
+export SIDECAR_IMG=quay.io/redhat-cne/cloud-event-proxy
+export  CONSUMER_IMG=quay.io/redhat-cne/cloud-event-consumer
 ```
 
 ### Setup AMQ Interconnect
@@ -74,7 +74,7 @@ Make sure amq-interconnect pods are running before the next step.
 oc get pods -n `<AMQP_NAMESPAVCE>`
 ```
 
-In consumer.yaml, change the `transport-host` args for `cloud-native-event-sidecar` container from
+In consumer.yaml, change the `transport-host` args for `cloud-event-sidecar` container from
 ```
 - "--transport-host=amqp://amq-interconnect"
 ```

--- a/examples/consumer.Dockerfile
+++ b/examples/consumer.Dockerfile
@@ -10,11 +10,11 @@ COPY . .
 RUN hack/build-example-go.sh
 
 FROM openshift/origin-base AS bin
-COPY --from=builder /go/src/github.com/redhat-cne/cloud-event-proxy/build/cloud-native-event-consumer /
+COPY --from=builder /go/src/github.com/redhat-cne/cloud-event-proxy/build/cloud-event-consumer /
 
 LABEL io.k8s.display-name="Cloud Event Proxy Sample Consumer" \
       io.k8s.description="This is a component of OpenShift Container Platform and provides a consumer sample to consume events." \
       io.openshift.tags="openshift" \
       maintainer="Aneesh Puttur <aputtur@redhat.com>"
 
-ENTRYPOINT ["./cloud-native-event-consumer"]
+ENTRYPOINT ["./cloud-event-consumer"]

--- a/examples/consumer.Dockerfile.local
+++ b/examples/consumer.Dockerfile.local
@@ -8,8 +8,8 @@ COPY --from=builder  /go/src/github.com/redhat-cne/cloud-event-proxy/build/libpt
 COPY --from=builder  /go/src/github.com/redhat-cne/cloud-event-proxy/build/libc.so.6 /lib64/
 COPY --from=builder  /go/src/github.com/redhat-cne/cloud-event-proxy/build/ld-linux-x86-64.so.2 /lib64/
 
-COPY --from=builder /go/src/github.com/redhat-cne/cloud-event-proxy/build/cloud-native-event-consumer /
-ENTRYPOINT ["/cloud-native-event-consumer"]
+COPY --from=builder /go/src/github.com/redhat-cne/cloud-event-proxy/build/cloud-event-consumer /
+ENTRYPOINT ["/cloud-event-consumer"]
 
 
 

--- a/examples/consumer/deployment/deployment.yaml
+++ b/examples/consumer/deployment/deployment.yaml
@@ -1,8 +1,8 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: cloud-native-consumer-deployment
-  namespace: cloud-native-events
+  name: cloud-event-consumer-deployment
+  namespace: cloud-events
   labels:
     app: consumer
 spec:
@@ -19,8 +19,8 @@ spec:
       serviceAccountName: sidecar-consumer-sa
       dnsPolicy: ClusterFirstWithHostNet
       containers:
-        - name: cloud-native-event-consumer
-          image: quay.io/aneeshkp/cloud-native-event-consumer
+        - name: cloud-event-consumer
+          image: quay.io/redhat-cne/cloud-event-consumer
           args:
             - "--local-api-addr=127.0.0.1:9089"
             - "--api-path=/api/cloudNotifications/v1/"
@@ -34,8 +34,8 @@ spec:
               value: "PTP"
             - name: ENABLE_STATUS_CHECK
               value: "true"
-        - name: cloud-native-event-sidecar
-          image: quay.io/aneeshkp/cloud-event-proxy
+        - name: cloud-event-sidecar
+          image: quay.io/redhat-cne/cloud-event-proxy
           args:
             - "--metrics-addr=127.0.0.1:9091"
             - "--store-path=/store"

--- a/examples/consumer/deployment/namespace.yaml
+++ b/examples/consumer/deployment/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: cloud-native-events
+  name: cloud-events
   labels:
-    name: cloud-native-events
+    name: cloud-events
     openshift.io/cluster-monitoring: "true"

--- a/examples/consumer/deployment/roles.yaml
+++ b/examples/consumer/deployment/roles.yaml
@@ -21,13 +21,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: sidecar-consumer-sa
-    namespace: cloud-native-events
+    namespace: cloud-events
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: prometheus-k8s
-  namespace: cloud-native-events
+  namespace: cloud-events
 rules:
   - apiGroups:
       - ""
@@ -51,7 +51,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: prometheus-k8s
-  namespace: cloud-native-events
+  namespace: cloud-events
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/examples/consumer/deployment/sa.yaml
+++ b/examples/consumer/deployment/sa.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: sidecar-consumer-sa
-  namespace: cloud-native-events
+  namespace: cloud-events

--- a/examples/consumer/deployment/service.yaml
+++ b/examples/consumer/deployment/service.yaml
@@ -5,7 +5,7 @@ metadata:
     prometheus.io/scrape: "true"
     service.alpha.openshift.io/serving-cert-secret-name: sidecar-consumer-secret
   name: consumer-sidecar-service
-  namespace: cloud-native-events
+  namespace: cloud-events
   labels:
     app: consumer-service
 spec:
@@ -23,9 +23,9 @@ metadata:
   labels:
     k8s-app: consumer-sidecar-service-monitor
   name: consumer-sidecar-service-monitor
-  namespace: cloud-native-events
+  namespace: cloud-events
 spec:
-  jobLabel: cloud-native-events
+  jobLabel: cloud-events
   endpoints:
     - interval: 30s
       port: metrics
@@ -33,11 +33,11 @@ spec:
       scheme: "https"
       tlsConfig:
         caFile: "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt"
-        serverName: "consumer-sidecar-service.cloud-native-events.svc"
+        serverName: "consumer-sidecar-service.cloud-events.svc"
   selector:
     matchLabels:
       app: consumer-service
   namespaceSelector:
     matchNames:
-      - cloud-native-events
+      - cloud-events
 

--- a/examples/consumer/main.go
+++ b/examples/consumer/main.go
@@ -24,6 +24,8 @@ import (
 	"sync"
 	"time"
 
+	ptpEvent "github.com/redhat-cne/sdk-go/pkg/event/ptp"
+
 	"github.com/redhat-cne/cloud-event-proxy/pkg/common"
 	"github.com/redhat-cne/cloud-event-proxy/pkg/restclient"
 	"github.com/redhat-cne/sdk-go/pkg/event"
@@ -51,13 +53,10 @@ const (
 )
 
 var (
-	apiAddr      string = "localhost:8089"
-	apiPath      string = "/api/cloudNotifications/v1/"
-	localAPIAddr string = "localhost:8989"
-
-	resourceAddressMock    string = "/cluster/node/%s/mock"
-	resourceAddressPTP     string = "/cluster/node/%s/ptp"
-	resourceAddressHwEvent string = "/cluster/node/%s/redfish/event"
+	apiAddr        string = "localhost:8089"
+	apiPath        string = "/api/cloudNotifications/v1/"
+	localAPIAddr   string = "localhost:8989"
+	resourcePrefix        = "/cluster/node/%s%s"
 )
 
 func main() {
@@ -81,7 +80,7 @@ func main() {
 	} else {
 		consumerType = ConsumerTypeEnum(consumerTypeEnv)
 	}
-
+	subscribeTo := initSubscribers(consumerType)
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go server() // spin local api
@@ -95,38 +94,28 @@ RETRY:
 	if ok, _ := common.APIHealthCheck(healthURL, 2*time.Second); !ok {
 		goto RETRY
 	}
-
-	subs := []*pubsub.PubSub{&pubsub.PubSub{
-		Resource: fmt.Sprintf(resourceAddressHwEvent, nodeName),
-	}, &pubsub.PubSub{
-		Resource: fmt.Sprintf(resourceAddressMock, nodeName),
-	}, &pubsub.PubSub{
-		Resource: fmt.Sprintf(resourceAddressPTP, nodeName),
-	},
-	}
-
-	var sub *pubsub.PubSub
-	if consumerType == PTP {
-		sub = subs[2]
-	} else if consumerType == MOCK || consumerType == "" {
-		sub = subs[1]
-	} else {
-		sub = subs[0]
+	var subs []*pubsub.PubSub
+	for _, resource := range subscribeTo {
+		subs = append(subs, &pubsub.PubSub{
+			Resource: fmt.Sprintf(resourcePrefix, nodeName, resource),
+		})
 	}
 
 	if enableStatusCheck {
-		createPublisherForStatusPing(sub.Resource) // ptp // disable this for testing else you will see context deadline error
-	}
-
-	var result []byte
-
-	result = createSubscription(sub.Resource)
-	if result != nil {
-		if err := json.Unmarshal(result, sub); err != nil {
-			log.Errorf("failed to create a subscription object %v\n", err)
+		for _, s := range subs {
+			createPublisherForStatusPing(s.Resource) // ptp // disable this for testing else you will see context deadline error
 		}
 	}
-	log.Infof("created subscription: %s\n", sub.String())
+	for _, s := range subs {
+		su, e := createSubscription(s.Resource)
+		if e != nil {
+			log.Errorf("failed to create a subscription object %v\n", e)
+		} else {
+			log.Infof("created subscription: %s\n", su.String())
+			s.URILocation = su.URILocation
+		}
+
+	}
 
 	// ping  for status every n secs
 
@@ -135,7 +124,9 @@ RETRY:
 		go func() {
 			defer wg.Done()
 			for range time.Tick(StatusCheckInterval * time.Second) {
-				pingForStatus(sub.ID)
+				for _, s := range subs {
+					pingForStatus(s.ID)
+				}
 			}
 		}()
 	}
@@ -145,7 +136,8 @@ RETRY:
 
 }
 
-func createSubscription(resourceAddress string) []byte {
+func createSubscription(resourceAddress string) (sub pubsub.PubSub, err error) {
+	var status int
 	subURL := &types.URI{URL: url.URL{Scheme: "http",
 		Host: apiAddr,
 		Path: fmt.Sprintf("%s%s", apiPath, "subscriptions")}}
@@ -153,17 +145,23 @@ func createSubscription(resourceAddress string) []byte {
 		Host: localAPIAddr,
 		Path: fmt.Sprintf("%s", "event")}}
 
-	pub := v1pubsub.NewPubSub(endpointURL, resourceAddress)
-	if b, err := json.Marshal(&pub); err == nil {
+	sub = v1pubsub.NewPubSub(endpointURL, resourceAddress)
+	var subB []byte
+
+	if subB, err = json.Marshal(&sub); err == nil {
 		rc := restclient.New()
-		if status, b := rc.PostWithReturn(subURL, b); status == http.StatusCreated {
-			return b
+		if status, subB = rc.PostWithReturn(subURL, subB); status != http.StatusCreated {
+			err = fmt.Errorf("subscription creation api at %s, returned status %d", subURL, status)
+			return
 		}
-		log.Errorf("subscription create returned error %s", string(b))
 	} else {
-		log.Errorf("failed to create subscription ")
+		log.Error("failed to marshal subscription ")
 	}
-	return nil
+	if err = json.Unmarshal(subB, &sub); err != nil {
+		return
+	}
+	return sub, err
+
 }
 
 func createPublisherForStatusPing(resourceAddress string) []byte {
@@ -250,4 +248,21 @@ func processEvent(data []byte) {
 	latency := (time.Now().UnixNano() - e.Time.UnixNano()) / 1000000
 	// set log to Info level for performance measurement
 	log.Infof("Latency for the event: %v ms\n", latency)
+}
+
+func initSubscribers(cType ConsumerTypeEnum) map[string]string {
+	subscribeTo := make(map[string]string)
+	switch cType {
+	case PTP:
+		subscribeTo[string(ptpEvent.OsClockSyncStateChange)] = string(ptpEvent.OsClockSyncState)
+		subscribeTo[string(ptpEvent.PtpClockClassChange)] = string(ptpEvent.PtpClockClass)
+		subscribeTo[string(ptpEvent.PtpStateChange)] = string(ptpEvent.PtpLockState)
+	case MOCK:
+		subscribeTo["mock"] = "/mock"
+	case HW:
+		subscribeTo["hw"] = "/redfish/event"
+	default:
+		subscribeTo["mock"] = "/mock"
+	}
+	return subscribeTo
 }

--- a/examples/manifests/consumer.yaml
+++ b/examples/manifests/consumer.yaml
@@ -1,8 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: cloud-native-consumer-deployment
-  namespace: cloud-native-events
+  name: cloud-event-consumer-deployment
+  namespace: cloud-events
   labels:
     app: consumer
 spec:
@@ -26,8 +26,8 @@ spec:
                       - local
       serviceAccountName: sidecar-consumer-sa
       containers:
-        - name: cloud-native-event-consumer
-          image: quay.io/jacding/cloud-native-event-consumer
+        - name: cloud-event-consumer
+          image: quay.io/redhat-cne/cloud-event-consumer
           args:
             - "--local-api-addr=127.0.0.1:9089"
             - "--api-path=/api/cloudNotifications/v1/"
@@ -39,8 +39,8 @@ spec:
                   fieldPath: spec.nodeName
             - name: CONSUMER_TYPE
               value: "HW"
-        - name: cloud-native-event-sidecar
-          image: quay.io/jacding/cloud-event-proxy
+        - name: cloud-event-sidecar
+          image: quay.io/redhat-cne/cloud-event-proxy
           args:
             - "--metrics-addr=127.0.0.1:9091"
             - "--store-path=/store"

--- a/examples/manifests/kustomization.yaml
+++ b/examples/manifests/kustomization.yaml
@@ -8,11 +8,11 @@ resources:
 - consumer.yaml
 replicas:
 - count: 1
-  name: cloud-native-consumer-deployment
+  name: cloud-event-consumer-deployment
 images:
 - name: cloud-event-proxy
-  newName: quay.io/aneeshkp/cloud-event-proxy
+  newName: quay.io/redhat-cne/cloud-event-proxy
   newTag: latest
-- name: cloud-native-event-consumer
-  newName: quay.io/aneeshkp/cloud-native-event-consumer
+- name: cloud-event-consumer
+  newName: quay.io/redhat-cne/cloud-event-consumer
   newTag: latest

--- a/examples/manifests/namespace.yaml
+++ b/examples/manifests/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: cloud-native-events
+  name: cloud-events
   labels:
-    name: cloud-native-events
+    name: cloud-events
     openshift.io/cluster-monitoring: "true"

--- a/examples/manifests/roles.yaml
+++ b/examples/manifests/roles.yaml
@@ -21,13 +21,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: sidecar-consumer-sa
-    namespace: cloud-native-events
+    namespace: cloud-events
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: prometheus-k8s
-  namespace: cloud-native-events
+  namespace: cloud-events
 rules:
   - apiGroups:
       - ""
@@ -51,7 +51,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: prometheus-k8s
-  namespace: cloud-native-events
+  namespace: cloud-events
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/examples/manifests/service-account.yaml
+++ b/examples/manifests/service-account.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: sidecar-consumer-sa
-  namespace: cloud-native-events
+  namespace: cloud-events

--- a/examples/manifests/service.yaml
+++ b/examples/manifests/service.yaml
@@ -5,7 +5,7 @@ metadata:
     prometheus.io/scrape: "true"
     service.alpha.openshift.io/serving-cert-secret-name: sidecar-consumer-secret
   name: consumer-sidecar-service
-  namespace: cloud-native-events
+  namespace: cloud-events
   labels:
     app: consumer-service
 spec:
@@ -23,9 +23,9 @@ metadata:
   labels:
     k8s-app: consumer-sidecar-service-monitor
   name: consumer-sidecar-service-monitor
-  namespace: cloud-native-events
+  namespace: cloud-events
 spec:
-  jobLabel: cloud-native-events
+  jobLabel: cloud-events
   endpoints:
     - interval: 30s
       port: metrics
@@ -33,10 +33,10 @@ spec:
       scheme: "https"
       tlsConfig:
         caFile: "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt"
-        serverName: "consumer-sidecar-service.cloud-native-events.svc"
+        serverName: "consumer-sidecar-service.cloud-events.svc"
   selector:
     matchLabels:
       app: consumer-service
   namespaceSelector:
     matchNames:
-      - cloud-native-events
+      - cloud-events

--- a/hack/build-example-image.sh
+++ b/hack/build-example-image.sh
@@ -3,7 +3,7 @@ repo_root=$(dirname $0)/..
 
 BUILDCMD=${BUILDCMD:-podman build}
 
-REPO=${REPO:-cloud-native-event-}
+REPO=${REPO:-cloud-event-}
 if [ -z ${VERSION+a} ]; then
 	VERSION=$(git describe --abbrev=8 --dirty --always)
 fi

--- a/hack/common/cne.sh
+++ b/hack/common/cne.sh
@@ -18,7 +18,7 @@ deploy_cne() {
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: cloud-native-producer-deployment
+  name: cloud-event-producer-deployment
   labels:
     app: producer
 spec:

--- a/hack/common/common.sh
+++ b/hack/common/common.sh
@@ -2,8 +2,8 @@
 
 set -e
 NODE_ROLE="${NODE_ROLE:-node-role.kubernetes.io/worker}"
-NamespaceProducerTesting="cloud-native-event-producer-testing"
-NamespaceConsumerTesting="cloud-native-event-consumer-testing"
+NamespaceProducerTesting="cloud-event-producer-testing"
+NamespaceConsumerTesting="cloud-event-consumer-testing"
 NamespaceAMQTesting="amq-router-testing"
 
 label_node() {

--- a/hack/common/consumer.sh
+++ b/hack/common/consumer.sh
@@ -20,7 +20,7 @@ deploy_event_consumer() {
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: cloud-native-consumer-deployment
+  name: cloud-event-consumer-deployment
   labels:
     app: consumer
 spec:

--- a/hack/deploy_test.sh
+++ b/hack/deploy_test.sh
@@ -8,8 +8,8 @@ source "$DIR/common/consumer.sh"
 source "$DIR/common/router.sh"
 
 KUBECONFIG="${KUBECONFIG:-}"
-CNE_IMG="${CNE_IMG:-quay.io/aneeshkp/cloud-event-proxy}"
-CONSUMER_IMG="${CONSUMER_IMG:-quay.io/aneeshkp/cloud-native-event-consumer}"
+CNE_IMG="${CNE_IMG:-quay.io/redhat-cne/cloud-event-proxy}"
+CONSUMER_IMG="${CONSUMER_IMG:-quay.io/redhat-cne/cloud-event-consumer}"
 
 
 if [ "$KUBECONFIG" == "" ]; then

--- a/plugins/mock/mock_plugin.go
+++ b/plugins/mock/mock_plugin.go
@@ -82,8 +82,8 @@ func Start(wg *sync.WaitGroup, configuration *common.SCConfiguration, fn func(e 
 		for range time.Tick(5 * time.Second) {
 			// create an event
 			if mEvent, err := createMockEvent(pub); err == nil {
-				mEvent.Type = string(ptp.PtpStateChange)
-				mEvent.Data.Values[0].Value = ptp.LOCKED
+				mEvent.Type = "mock"
+				mEvent.Data.Values[0].Value = "LOCKED"
 				mEvent.Data.Values[1].Value = -200
 				if err = common.PublishEventViaAPI(config, mEvent); err != nil {
 					log.Errorf("error publishing events %s", err)
@@ -113,19 +113,19 @@ func createMockEvent(pub pubsub.PubSub) (ceEvent.Event, error) {
 	data := ceEvent.Data{
 		Version: "v1",
 		Values: []ceEvent.DataValue{{
-			Resource:  string(ptp.SyncStatusState),
+			Resource:  "/mock",
 			DataType:  ceEvent.NOTIFICATION,
 			ValueType: ceEvent.ENUMERATION,
 			Value:     ptp.ACQUIRING_SYNC,
 		},
 			{
-				Resource:  string(ptp.SyncStatusState),
+				Resource:  "/mock",
 				DataType:  ceEvent.METRIC,
 				ValueType: ceEvent.DECIMAL,
 				Value:     "99.6",
 			},
 		},
 	}
-	e, err := common.CreateEvent(pub.ID, pub.Resource, string(ptp.PtpStateChange), data)
+	e, err := common.CreateEvent(pub.ID, pub.Resource, "mock", data)
 	return e, err
 }

--- a/plugins/ptp_operator/ptp_operator_plugin_test.go
+++ b/plugins/ptp_operator/ptp_operator_plugin_test.go
@@ -19,6 +19,7 @@ package main_test
 
 import (
 	"fmt"
+	ptpEvent "github.com/redhat-cne/sdk-go/pkg/event/ptp"
 	"log"
 	"os"
 	"sync"
@@ -26,6 +27,7 @@ import (
 	"time"
 
 	"github.com/redhat-cne/cloud-event-proxy/pkg/common"
+	ptpTypes "github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/types"
 	restapi "github.com/redhat-cne/rest-api"
 	"github.com/redhat-cne/sdk-go/pkg/channel"
 	"github.com/redhat-cne/sdk-go/pkg/types"
@@ -38,15 +40,15 @@ import (
 )
 
 var (
-	wg                    sync.WaitGroup
-	server                *restapi.Server
-	scConfig              *common.SCConfiguration
-	channelBufferSize     int    = 10
-	storePath                    = "../../.."
-	resourceAddress       string = "/cluster/node/test_node/ptp"
-	resourceStatusAddress string = "/cluster/node/test_node/ptp/status"
-	apiPort               int    = 8990
-	c                     chan os.Signal
+	wg                sync.WaitGroup
+	server            *restapi.Server
+	scConfig          *common.SCConfiguration
+	channelBufferSize int = 10
+	storePath             = "../../.."
+	resourcePrefix        = "/cluster/node/%s%s"
+	apiPort           int = 8990
+	c                 chan os.Signal
+	pubsubTypes       map[ptpEvent.EventType]*ptpTypes.EventPublisherType
 )
 
 func TestMain(m *testing.M) {
@@ -66,6 +68,7 @@ func TestMain(m *testing.M) {
 	server, _ = common.StartPubSubService(scConfig)
 	scConfig.APIPort = server.Port()
 	scConfig.BaseURL = server.GetHostPath()
+	pubsubTypes = ptpPlugin.InitPubSubTypes()
 	cleanUP()
 	os.Exit(m.Run())
 }
@@ -90,23 +93,28 @@ func Test_StartWithAMQP(t *testing.T) {
 	// build your client
 	//CLIENT SUBSCRIPTION: create a subscription to consume events
 	endpointURL := fmt.Sprintf("%s%s", scConfig.BaseURL, "dummy")
-	sub := v1pubsub.NewPubSub(types.ParseURI(endpointURL), resourceAddress)
-	sub, _ = common.CreateSubscription(scConfig, sub)
-	assert.NotEmpty(t, sub.ID)
-	assert.NotEmpty(t, sub.URILocation)
-	//create a status ping sender object
-	v1amqp.CreateSender(scConfig.EventInCh, resourceStatusAddress)
+	for _, pTypes := range pubsubTypes {
+		sub := v1pubsub.NewPubSub(types.ParseURI(endpointURL), fmt.Sprintf(resourcePrefix, "test_node", string(pTypes.Resource)))
+		sub, _ = common.CreateSubscription(scConfig, sub)
+		assert.NotEmpty(t, sub.ID)
+		assert.NotEmpty(t, sub.URILocation)
+		//create a status ping sender object
+		v1amqp.CreateSender(scConfig.EventInCh, fmt.Sprintf("%s/%s", sub.Resource, "status"))
+		pTypes.PubID = sub.ID
+		pTypes.Pub = &sub
+	}
 
 	// start ptp plugin
 	err = ptpPlugin.Start(&wg, scConfig, nil)
 	assert.Nil(t, err)
 
 	//status sender object, this wast you can send data to that channel
-	e := v1event.CloudNativeEvent()
-	ce, _ := v1event.CreateCloudEvents(e, sub)
-	ce.SetSource(resourceAddress)
-
-	v1event.SendNewEventToDataChannel(scConfig.EventInCh, resourceStatusAddress, ce)
+	for _, pTypes := range pubsubTypes {
+		e := v1event.CloudNativeEvent()
+		ce, _ := v1event.CreateCloudEvents(e, *pTypes.Pub)
+		ce.SetSource(pTypes.Pub.Resource)
+		v1event.SendNewEventToDataChannel(scConfig.EventInCh, fmt.Sprintf("%s/%s", pTypes.Pub.Resource, "status"), ce)
+	}
 
 	statusEvent := <-scConfig.EventOutCh // status updated
 	assert.Equal(t, channel.SUCCESS, statusEvent.Status)
@@ -114,7 +122,7 @@ func Test_StartWithAMQP(t *testing.T) {
 	log.Printf("Closing the channels")
 	close(scConfig.CloseCh) // close the channel
 	pubs := scConfig.PubSubAPI.GetPublishers()
-	assert.Equal(t, len(pubs), 1)
+	assert.Equal(t, 3, len(pubs))
 }
 
 func Test_StartWithOutAMQP(t *testing.T) {
@@ -128,12 +136,16 @@ func Test_StartWithOutAMQP(t *testing.T) {
 	// build your client
 	//CLIENT SUBSCRIPTION: create a subscription to consume events
 	endpointURL := fmt.Sprintf("%s%s", scConfig.BaseURL, "dummy")
-	sub := v1pubsub.NewPubSub(types.ParseURI(endpointURL), resourceAddress)
-	sub, _ = common.CreateSubscription(scConfig, sub)
-	assert.NotEmpty(t, sub.ID)
-	assert.NotEmpty(t, sub.URILocation)
-	//create a status ping sender object
-	v1amqp.CreateSender(scConfig.EventInCh, resourceStatusAddress)
+	for _, pTypes := range pubsubTypes {
+		sub := v1pubsub.NewPubSub(types.ParseURI(endpointURL), fmt.Sprintf(resourcePrefix, "test_node", string(pTypes.Resource)))
+		sub, _ = common.CreateSubscription(scConfig, sub)
+		assert.NotEmpty(t, sub.ID)
+		assert.NotEmpty(t, sub.URILocation)
+		//create a status ping sender object
+		v1amqp.CreateSender(scConfig.EventInCh, fmt.Sprintf("%s/%s", sub.Resource, "status"))
+		pTypes.PubID = sub.ID
+		pTypes.Pub = &sub
+	}
 
 	// start ptp plugin
 	err := ptpPlugin.Start(&wg, scConfig, nil)
@@ -141,11 +153,13 @@ func Test_StartWithOutAMQP(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	//status sender object, client requesting for an event
-	e := v1event.CloudNativeEvent()
-	ce, _ := v1event.CreateCloudEvents(e, sub)
-	ce.SetSource(resourceAddress)
-	log.Printf("sending event to data channel %v", ce)
-	v1event.SendNewEventToDataChannel(scConfig.EventInCh, resourceStatusAddress, ce)
+	for _, pTypes := range pubsubTypes {
+		e := v1event.CloudNativeEvent()
+		ce, _ := v1event.CreateCloudEvents(e, *pTypes.Pub)
+		ce.SetSource(pTypes.Pub.Resource)
+		log.Printf("sending event to data channel %v", ce)
+		v1event.SendNewEventToDataChannel(scConfig.EventInCh, fmt.Sprintf("%s/%s", pTypes.Pub.Resource, "status"), ce)
+	}
 
 	EventData := <-scConfig.EventOutCh // status updated
 	assert.Equal(t, channel.EVENT, EventData.Type)
@@ -154,9 +168,9 @@ func Test_StartWithOutAMQP(t *testing.T) {
 	log.Printf("Closing the channels")
 	close(scConfig.CloseCh) // close the channel
 	pubs := scConfig.PubSubAPI.GetPublishers()
-	assert.Equal(t, 1, len(pubs))
+	assert.Equal(t, 3, len(pubs))
 	subs := scConfig.PubSubAPI.GetSubscriptions()
-	assert.Equal(t, 1, len(subs))
+	assert.Equal(t, 3, len(subs))
 
 }
 

--- a/plugins/ptp_operator/socket/socket_test.go
+++ b/plugins/ptp_operator/socket/socket_test.go
@@ -34,7 +34,6 @@ var logsData = [logLength]string{
 	"ptp4l[432313.222]: [ens5f1] port 1: SLAVE to FAULTY on FAULT_DETECTED (FT_UNSPECIFIED) " + "\n",
 }
 var eventProcessor *metrics.PTPEventManager
-var pubID = "123"
 var scConfig *common.SCConfiguration
 
 func setup() {
@@ -43,7 +42,7 @@ func setup() {
 
 func Test_WriteMetricsToSocket(t *testing.T) {
 	setup()
-	eventProcessor = metrics.NewPTPEventManager(pubID, "tetsnode", scConfig)
+	eventProcessor = metrics.NewPTPEventManager(nil, "tetsnode", scConfig)
 	eventProcessor.MockTest(true)
 	go listenToTestMetrics()
 	time.Sleep(2 * time.Second)

--- a/plugins/ptp_operator/types/types.go
+++ b/plugins/ptp_operator/types/types.go
@@ -1,6 +1,10 @@
 package types
 
-import "fmt"
+import (
+	"fmt"
+	"github.com/redhat-cne/sdk-go/pkg/event/ptp"
+	"github.com/redhat-cne/sdk-go/pkg/pubsub"
+)
 
 type (
 	//ProcessName ...
@@ -50,4 +54,12 @@ func (r PtpPortRole) String() string {
 	default:
 		return fmt.Sprintf("%d", int(r))
 	}
+}
+
+// EventPublisherType ... define types of publishers
+type EventPublisherType struct {
+	EventType ptp.EventType
+	Resource  ptp.EventResource
+	PubID     string
+	Pub       *pubsub.PubSub
 }

--- a/test/utils/consts.go
+++ b/test/utils/consts.go
@@ -2,17 +2,17 @@ package utils
 
 const (
 	// NamespaceForTesting ...
-	NamespaceForTesting = "cne-testing"
+	NamespaceForTesting = "cne-testing1"
 	// NamespaceProducerTesting contains the name of the testing namespace
-	NamespaceProducerTesting = "cloud-native-event-producer-testing"
+	NamespaceProducerTesting = "cloud-event-producer-testing"
 	// NamespaceConsumerTesting ...
-	NamespaceConsumerTesting = "cloud-native-event-consumer-testing"
+	NamespaceConsumerTesting = "cloud-event-consumer-testing"
 	// NamespaceAMQTesting ...
 	NamespaceAMQTesting = "amq-router-testing"
 	// CloudEventProducerDeploymentName ...
-	CloudEventProducerDeploymentName = "cloud-native-producer-deployment"
+	CloudEventProducerDeploymentName = "cloud-event-producer-deployment"
 	// CloudEventConsumerDeploymentName ...
-	CloudEventConsumerDeploymentName = "cloud-native-consumer-deployment"
+	CloudEventConsumerDeploymentName = "cloud-event-consumer-deployment"
 	// AMQDeploymentName ...
 	AMQDeploymentName = "interconnect-deployment"
 


### PR DESCRIPTION
Enable Flexible Registration for Multiple PTP Events
This adds the ability to subscribe to multiple events.
For each Publisher/Subscriber you create separate AMQ sender/listener objects 
Signed-off-by: Aneesh Puttur <aneeshputtur@gmail.com>