### PR TITLE
CNF-4018 Enable Flexible Registration for Multiple PTP Events clock-class-change,status and os-sync

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -59,8 +59,8 @@ mv kustomize /usr/local/bin/
 ### Set Env variables
 ```shell
 export version=latest 
-export SIDECAR_IMG=quay.io/aneeshkp/cloud-event-proxy
-export  CONSUMER_IMG=quay.io/aneeshkp/cloud-event-consumer
+export IMG=quay.io/openshift/origin-cloud-event-proxy
+export  CONSUMER_IMG=quay.io/redhat-cne/cloud-event-consumer
 ```
 
 ### Setup AMQ Interconnect

--- a/examples/consumer/main.go
+++ b/examples/consumer/main.go
@@ -151,17 +151,14 @@ func createSubscription(resourceAddress string) (sub pubsub.PubSub, err error) {
 	if subB, err = json.Marshal(&sub); err == nil {
 		rc := restclient.New()
 		if status, subB = rc.PostWithReturn(subURL, subB); status != http.StatusCreated {
-			err = fmt.Errorf("subscription creation api at %s, returned status %d", subURL, status)
-			return
+			err = fmt.Errorf("error subscription creation api at %s, returned status %d", subURL, status)
+		} else {
+			err = json.Unmarshal(subB, &sub)
 		}
 	} else {
-		log.Error("failed to marshal subscription ")
+		err = fmt.Errorf("failed to marshal subscription or %s", resourceAddress)
 	}
-	if err = json.Unmarshal(subB, &sub); err != nil {
-		return
-	}
-	return sub, err
-
+	return
 }
 
 func createPublisherForStatusPing(resourceAddress string) []byte {

--- a/hack/common/cne.sh
+++ b/hack/common/cne.sh
@@ -44,7 +44,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: cloud-event-proxy
-          image: "$CNE_IMG"
+          image: "$IMG"
           args:
             - "--metrics-addr=127.0.0.1:9091"
             - "--store-path=/store"

--- a/hack/common/common.sh
+++ b/hack/common/common.sh
@@ -10,8 +10,8 @@ label_node() {
   oc label --overwrite node $(oc  get nodes -l node-role.kubernetes.io/worker="" | grep Ready | cut -f1 -d" " | head -1) app=local
 }
 create_namespaces() {
-  action=$1
-  echo "$action namespace "
+action=$1
+echo "$action namespace "
 cat <<EOF | oc $action -f -
 apiVersion: v1
 kind: Namespace
@@ -21,17 +21,12 @@ metadata:
     name: $NamespaceProducerTesting
     #openshift.io/cluster-monitoring: "true"
 EOF
-
- cat <<EOF | oc $action -f -
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: $NamespaceConsumerTesting
-  labels:
-    name: $NamespaceConsumerTesting
-    #openshift.io/cluster-monitoring: "true"
-EOF
-
+create_amq_namespaces $action
+create_consumer_namespaces $action
+}
+create_amq_namespaces() {
+action=$1
+echo "$action namespace "
 cat <<EOF | oc $action -f -
 apiVersion: v1
 kind: Namespace
@@ -39,6 +34,20 @@ metadata:
   name: $NamespaceAMQTesting
   labels:
     name: $NamespaceAMQTesting
+    #openshift.io/cluster-monitoring: "true"
+EOF
+}
+
+create_consumer_namespaces(){
+action=$1
+echo "$action namespace "
+cat <<EOF | oc $action -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: $NamespaceConsumerTesting
+  labels:
+    name: $NamespaceConsumerTesting
     #openshift.io/cluster-monitoring: "true"
 EOF
 }

--- a/hack/common/consumer.sh
+++ b/hack/common/consumer.sh
@@ -57,9 +57,9 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
             - name: CONSUMER_TYPE
-              value: "MOCK"
+              value: "$CONSUMER_TYPE"
         - name: cloud-event-proxy
-          image: "$CNE_IMG"
+          image: "$IMG"
           args:
             - "--metrics-addr=127.0.0.1:9091"
             - "--store-path=/store"

--- a/hack/deploy_test.sh
+++ b/hack/deploy_test.sh
@@ -8,8 +8,9 @@ source "$DIR/common/consumer.sh"
 source "$DIR/common/router.sh"
 
 KUBECONFIG="${KUBECONFIG:-}"
-CNE_IMG="${CNE_IMG:-quay.io/openshift/origin-cloud-event-proxy}"
+IMG="${IMG:-quay.io/openshift/origin-cloud-event-proxy}"
 CONSUMER_IMG="${CONSUMER_IMG:-quay.io/redhat-cne/cloud-event-consumer}"
+CONSUMER_TYPE="${CONSUMER_TYPE:-MOCK}"
 
 
 if [ "$KUBECONFIG" == "" ]; then
@@ -24,6 +25,22 @@ if [ "$action" == "undeploy" ]; then
  deploy_consumer $action $NamespaceConsumerTesting $NamespaceAMQTesting || true
  deploy_producer $action $NamespaceProducerTesting $NamespaceAMQTesting || true
  create_namespaces $action || true
+elif [ "$action" == "deploy-amq" ]; then
+  action="apply"
+  create_amq_namespaces $action || true
+  deploy_amq $action $NamespaceAMQTesting || true
+elif [ "$action" == "delete-amq" ]; then
+  action="delete"
+  deploy_amq $action $NamespaceAMQTesting || true
+  create_amq_namespaces $action || true
+elif [ "$action" == "deploy-consumer" ]; then
+  action="apply"
+  create_consumer_namespaces $action || true
+  deploy_consumer $action $NamespaceConsumerTesting $NamespaceAMQTesting || true
+elif [ "$action" == "delete-consumer" ]; then
+  action="delete"
+  deploy_consumer $action $NamespaceConsumerTesting $NamespaceAMQTesting || true
+  create_consumer_namespaces $action || true
 else
   action="apply"
   label_node || true
@@ -31,10 +48,4 @@ else
  deploy_amq $action $NamespaceAMQTesting || true
  deploy_consumer $action $NamespaceConsumerTesting $NamespaceAMQTesting || true
  deploy_producer $action $NamespaceProducerTesting $NamespaceAMQTesting || true
-
 fi
-
-
-
-
-

--- a/plugins/mock/mock_plugin.go
+++ b/plugins/mock/mock_plugin.go
@@ -82,8 +82,8 @@ func Start(wg *sync.WaitGroup, configuration *common.SCConfiguration, fn func(e 
 		for range time.Tick(5 * time.Second) {
 			// create an event
 			if mEvent, err := createMockEvent(pub); err == nil {
-				mEvent.Type = string(ptp.PtpStateChange)
-				mEvent.Data.Values[0].Value = ptp.LOCKED
+				mEvent.Type = "mock"
+				mEvent.Data.Values[0].Value = "LOCKED"
 				mEvent.Data.Values[1].Value = -200
 				if err = common.PublishEventViaAPI(config, mEvent); err != nil {
 					log.Errorf("error publishing events %s", err)
@@ -113,19 +113,19 @@ func createMockEvent(pub pubsub.PubSub) (ceEvent.Event, error) {
 	data := ceEvent.Data{
 		Version: "v1",
 		Values: []ceEvent.DataValue{{
-			Resource:  string(ptp.SyncStatusState),
+			Resource:  "/mock",
 			DataType:  ceEvent.NOTIFICATION,
 			ValueType: ceEvent.ENUMERATION,
 			Value:     ptp.ACQUIRING_SYNC,
 		},
 			{
-				Resource:  string(ptp.SyncStatusState),
+				Resource:  "/mock",
 				DataType:  ceEvent.METRIC,
 				ValueType: ceEvent.DECIMAL,
 				Value:     "99.6",
 			},
 		},
 	}
-	e, err := common.CreateEvent(pub.ID, pub.Resource, string(ptp.PtpStateChange), data)
+	e, err := common.CreateEvent(pub.ID, pub.Resource, "mock", data)
 	return e, err
 }

--- a/plugins/ptp_operator/ptp_operator_plugin_test.go
+++ b/plugins/ptp_operator/ptp_operator_plugin_test.go
@@ -19,6 +19,7 @@ package main_test
 
 import (
 	"fmt"
+	ptpEvent "github.com/redhat-cne/sdk-go/pkg/event/ptp"
 	"log"
 	"os"
 	"sync"
@@ -26,6 +27,7 @@ import (
 	"time"
 
 	"github.com/redhat-cne/cloud-event-proxy/pkg/common"
+	ptpTypes "github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/types"
 	restapi "github.com/redhat-cne/rest-api"
 	"github.com/redhat-cne/sdk-go/pkg/channel"
 	"github.com/redhat-cne/sdk-go/pkg/types"
@@ -38,15 +40,15 @@ import (
 )
 
 var (
-	wg                    sync.WaitGroup
-	server                *restapi.Server
-	scConfig              *common.SCConfiguration
-	channelBufferSize     int    = 10
-	storePath                    = "../../.."
-	resourceAddress       string = "/cluster/node/test_node/ptp"
-	resourceStatusAddress string = "/cluster/node/test_node/ptp/status"
-	apiPort               int    = 8990
-	c                     chan os.Signal
+	wg                sync.WaitGroup
+	server            *restapi.Server
+	scConfig          *common.SCConfiguration
+	channelBufferSize int = 10
+	storePath             = "../../.."
+	resourcePrefix        = "/cluster/node/%s%s"
+	apiPort           int = 8990
+	c                 chan os.Signal
+	pubsubTypes       map[ptpEvent.EventType]*ptpTypes.EventPublisherType
 )
 
 func TestMain(m *testing.M) {
@@ -66,6 +68,7 @@ func TestMain(m *testing.M) {
 	server, _ = common.StartPubSubService(scConfig)
 	scConfig.APIPort = server.Port()
 	scConfig.BaseURL = server.GetHostPath()
+	pubsubTypes = ptpPlugin.InitPubSubTypes()
 	cleanUP()
 	os.Exit(m.Run())
 }
@@ -90,23 +93,28 @@ func Test_StartWithAMQP(t *testing.T) {
 	// build your client
 	//CLIENT SUBSCRIPTION: create a subscription to consume events
 	endpointURL := fmt.Sprintf("%s%s", scConfig.BaseURL, "dummy")
-	sub := v1pubsub.NewPubSub(types.ParseURI(endpointURL), resourceAddress)
-	sub, _ = common.CreateSubscription(scConfig, sub)
-	assert.NotEmpty(t, sub.ID)
-	assert.NotEmpty(t, sub.URILocation)
-	//create a status ping sender object
-	v1amqp.CreateSender(scConfig.EventInCh, resourceStatusAddress)
+	for _, pTypes := range pubsubTypes {
+		sub := v1pubsub.NewPubSub(types.ParseURI(endpointURL), fmt.Sprintf(resourcePrefix, "test_node", string(pTypes.Resource)))
+		sub, _ = common.CreateSubscription(scConfig, sub)
+		assert.NotEmpty(t, sub.ID)
+		assert.NotEmpty(t, sub.URILocation)
+		//create a status ping sender object
+		v1amqp.CreateSender(scConfig.EventInCh, fmt.Sprintf("%s/%s", sub.Resource, "status"))
+		pTypes.PubID = sub.ID
+		pTypes.Pub = &sub
+	}
 
 	// start ptp plugin
 	err = ptpPlugin.Start(&wg, scConfig, nil)
 	assert.Nil(t, err)
 
 	//status sender object, this wast you can send data to that channel
-	e := v1event.CloudNativeEvent()
-	ce, _ := v1event.CreateCloudEvents(e, sub)
-	ce.SetSource(resourceAddress)
-
-	v1event.SendNewEventToDataChannel(scConfig.EventInCh, resourceStatusAddress, ce)
+	for _, pTypes := range pubsubTypes {
+		e := v1event.CloudNativeEvent()
+		ce, _ := v1event.CreateCloudEvents(e, *pTypes.Pub)
+		ce.SetSource(pTypes.Pub.Resource)
+		v1event.SendNewEventToDataChannel(scConfig.EventInCh, fmt.Sprintf("%s/%s", pTypes.Pub.Resource, "status"), ce)
+	}
 
 	statusEvent := <-scConfig.EventOutCh // status updated
 	assert.Equal(t, channel.SUCCESS, statusEvent.Status)
@@ -114,7 +122,7 @@ func Test_StartWithAMQP(t *testing.T) {
 	log.Printf("Closing the channels")
 	close(scConfig.CloseCh) // close the channel
 	pubs := scConfig.PubSubAPI.GetPublishers()
-	assert.Equal(t, len(pubs), 1)
+	assert.Equal(t, 3, len(pubs))
 }
 
 func Test_StartWithOutAMQP(t *testing.T) {
@@ -128,12 +136,16 @@ func Test_StartWithOutAMQP(t *testing.T) {
 	// build your client
 	//CLIENT SUBSCRIPTION: create a subscription to consume events
 	endpointURL := fmt.Sprintf("%s%s", scConfig.BaseURL, "dummy")
-	sub := v1pubsub.NewPubSub(types.ParseURI(endpointURL), resourceAddress)
-	sub, _ = common.CreateSubscription(scConfig, sub)
-	assert.NotEmpty(t, sub.ID)
-	assert.NotEmpty(t, sub.URILocation)
-	//create a status ping sender object
-	v1amqp.CreateSender(scConfig.EventInCh, resourceStatusAddress)
+	for _, pTypes := range pubsubTypes {
+		sub := v1pubsub.NewPubSub(types.ParseURI(endpointURL), fmt.Sprintf(resourcePrefix, "test_node", string(pTypes.Resource)))
+		sub, _ = common.CreateSubscription(scConfig, sub)
+		assert.NotEmpty(t, sub.ID)
+		assert.NotEmpty(t, sub.URILocation)
+		//create a status ping sender object
+		v1amqp.CreateSender(scConfig.EventInCh, fmt.Sprintf("%s/%s", sub.Resource, "status"))
+		pTypes.PubID = sub.ID
+		pTypes.Pub = &sub
+	}
 
 	// start ptp plugin
 	err := ptpPlugin.Start(&wg, scConfig, nil)
@@ -141,11 +153,13 @@ func Test_StartWithOutAMQP(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	//status sender object, client requesting for an event
-	e := v1event.CloudNativeEvent()
-	ce, _ := v1event.CreateCloudEvents(e, sub)
-	ce.SetSource(resourceAddress)
-	log.Printf("sending event to data channel %v", ce)
-	v1event.SendNewEventToDataChannel(scConfig.EventInCh, resourceStatusAddress, ce)
+	for _, pTypes := range pubsubTypes {
+		e := v1event.CloudNativeEvent()
+		ce, _ := v1event.CreateCloudEvents(e, *pTypes.Pub)
+		ce.SetSource(pTypes.Pub.Resource)
+		log.Printf("sending event to data channel %v", ce)
+		v1event.SendNewEventToDataChannel(scConfig.EventInCh, fmt.Sprintf("%s/%s", pTypes.Pub.Resource, "status"), ce)
+	}
 
 	EventData := <-scConfig.EventOutCh // status updated
 	assert.Equal(t, channel.EVENT, EventData.Type)
@@ -154,9 +168,9 @@ func Test_StartWithOutAMQP(t *testing.T) {
 	log.Printf("Closing the channels")
 	close(scConfig.CloseCh) // close the channel
 	pubs := scConfig.PubSubAPI.GetPublishers()
-	assert.Equal(t, 1, len(pubs))
+	assert.Equal(t, 3, len(pubs))
 	subs := scConfig.PubSubAPI.GetSubscriptions()
-	assert.Equal(t, 1, len(subs))
+	assert.Equal(t, 3, len(subs))
 
 }
 

--- a/plugins/ptp_operator/socket/socket_test.go
+++ b/plugins/ptp_operator/socket/socket_test.go
@@ -34,7 +34,6 @@ var logsData = [logLength]string{
 	"ptp4l[432313.222]: [ens5f1] port 1: SLAVE to FAULTY on FAULT_DETECTED (FT_UNSPECIFIED) " + "\n",
 }
 var eventProcessor *metrics.PTPEventManager
-var pubID = "123"
 var scConfig *common.SCConfiguration
 
 func setup() {
@@ -43,7 +42,7 @@ func setup() {
 
 func Test_WriteMetricsToSocket(t *testing.T) {
 	setup()
-	eventProcessor = metrics.NewPTPEventManager(pubID, "tetsnode", scConfig)
+	eventProcessor = metrics.NewPTPEventManager(nil, "tetsnode", scConfig)
 	eventProcessor.MockTest(true)
 	go listenToTestMetrics()
 	time.Sleep(2 * time.Second)

--- a/plugins/ptp_operator/types/types.go
+++ b/plugins/ptp_operator/types/types.go
@@ -1,6 +1,10 @@
 package types
 
-import "fmt"
+import (
+	"fmt"
+	"github.com/redhat-cne/sdk-go/pkg/event/ptp"
+	"github.com/redhat-cne/sdk-go/pkg/pubsub"
+)
 
 type (
 	//ProcessName ...
@@ -50,4 +54,12 @@ func (r PtpPortRole) String() string {
 	default:
 		return fmt.Sprintf("%d", int(r))
 	}
+}
+
+// EventPublisherType ... define types of publishers
+type EventPublisherType struct {
+	EventType ptp.EventType
+	Resource  ptp.EventResource
+	PubID     string
+	Pub       *pubsub.PubSub
 }


### PR DESCRIPTION
Enable Flexible Registration for Multiple PTP Events
This adds the ability to subscribe to multiple events.
For each Publisher/Subscriber you create separate AMQ sender/listener objects
Signed-off-by: Aneesh Puttur <aneeshputtur@gmail.com>