### PR TITLE
Add timeout to CI golangci-lint (#99)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,7 +19,8 @@ jobs:
           skip-pkg-cache: true
           skip-build-cache: true
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.41
+          version: v1.42
+          args: --timeout 3m0s
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-20.04


### PR DESCRIPTION
CI Linting job fails intermittently due to timeout.
Increase the timeout to 3m. The timeout issue and suggested
solution can be found at
https://github.com/golangci/golangci-lint-action/issues/297

Also update the golangci-lint version to 1.42 since
golangci-lint starts to build docker image with go1.17 with
version 1.42.1.

Signed-off-by: Jack Ding <jacding@redhat.com>

Co-authored-by: Jack Ding <jacding@redhat.com>