### PR TITLE
clock class event

### DIFF
--- a/examples/consumer/deployment/deployment.yaml
+++ b/examples/consumer/deployment/deployment.yaml
@@ -35,7 +35,7 @@ spec:
             - name: ENABLE_STATUS_CHECK
               value: "true"
         - name: cloud-event-sidecar
-          image: quay.io/aneeshkp/cloud-event-proxy
+          image: quay.io/redhat-cne/cloud-event-proxy
           args:
             - "--metrics-addr=127.0.0.1:9091"
             - "--store-path=/store"


### PR DESCRIPTION
This PR depends on https://github.com/openshift/linuxptp-daemon/pull/76.
The PR generates event on PTP clock class change 
Linux PTP daemon will be sending log information on clock class change in the following format
`ptp4l[5196819.100]: [ptp4l.0.config] CLOCK_CLASS_CHANGE:248`
The event sidecar will parse the log and generate the event in the following format.

```
{
   "id":"ebe86417-fe09-4ca0-93a0-4896cef6f5c7",
   "type":"event.sync.ptp-status.ptp-clock-class-change",
   "source":"/cluster/cnfde7.ptp.lab.eng.bos.redhat.com/ptp/unknown/master",
   "dataContentType":"application/json",
   "time":"2022-03-07T19:21:07.992550137Z",
   "data":{
      "version":"v1",
      "values":[
         {
            "resource":"/sync/ptp-status/ptp-clock-class-change",
            "dataType":"metric",
            "valueType":"decimal64.3",
            "value":"165"
         }
      ]
   }
}
```
The source will be `unknown` when ports is not set with valid sate
   "source":"/cluster/cnfde7.ptp.lab.eng.bos.redhat.com/ptp/unknown/master"
Once it is set it will be 
  "source":"/cluster/cnfde7.ptp.lab.eng.bos.redhat.com/ptp/ens5fx/master"

 
Signed-off-by: Aneesh Puttur <aneeshputtur@gmail.com>