### PR TITLE
Add go linter configuration file .golangci.yaml

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,143 @@
+---
+run:
+  concurrency: 6
+  deadline: 10m
+linters:
+  disable-all: true
+  enable:
+    - deadcode
+    - depguard
+    - dupl
+    - errcheck
+    - exportloopref
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
+    - goimports
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - revive
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unconvert
+    - unparam
+    - varcheck
+linters-settings:
+  gofmt:
+    simplify: false # do not require the -s flag
+  gocritic:
+    enabled-checks:
+      # Diagnostic
+      - argOrder
+      - badCond
+      - caseOrder
+      - codegenComment
+      - commentedOutCode
+      - deprecatedComment
+      - dupArg
+      - dupBranchBody
+      - dupCase
+      - dupSubExpr
+      - exitAfterDefer
+      - flagDeref
+      - flagName
+      - nilValReturn
+      - octalLiteral
+      - offBy1
+      - sloppyReassign
+      - weakCond
+
+      # Performance
+      - equalFold
+      - indexAlloc
+      - rangeExprCopy
+
+      # Style
+      - assignOp
+      - boolExprSimplify
+      - captLocal
+      - commentFormatting
+      - commentedOutImport
+      - defaultCaseOrder
+      - docStub
+      - elseif
+      - emptyFallthrough
+      - hexLiteral
+      - methodExprCall
+      - regexpMust
+      - singleCaseSwitch
+      - sloppyLen
+      - stringXbytes
+      - switchTrue
+      - typeAssertChain
+      - typeSwitchVar
+      - underef
+      - unlabelStmt
+      - unlambda
+      - unslice
+      - valSwap
+      - wrapperFunc
+      - yodaStyleExpr
+
+      # Opinionated
+      - initClause
+      - nestingReduce
+      - paramTypeCombine
+      - ptrToRefParam
+      - typeUnparen
+      - unnecessaryBlock
+  revive:
+    rules:
+      - name: atomic
+      - name: blank-imports
+      - name: bool-literal-in-expr
+      - name: call-to-gc
+      - name: confusing-naming
+      - name: constant-logical-expr
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: deep-exit
+      - name: defer
+      - name: dot-imports
+      - name: duplicated-imports
+      - name: early-return
+      - name: empty-block
+      - name: error-naming
+      - name: error-return
+      - name: error-strings
+      - name: errorf
+      - name: flag-parameter
+      - name: get-return
+      - name: identical-branches
+      - name: if-return
+      - name: import-shadowing
+      - name: imports-blacklist
+      - name: increment-decrement
+      - name: indent-error-flow
+      - name: modifies-parameter
+      - name: modifies-value-receiver
+      - name: package-comments
+      - name: range
+      - name: range-val-address
+      - name: range-val-in-closure
+      - name: receiver-naming
+      - name: redefines-builtin-id
+      - name: string-of-int
+      - name: struct-tag
+      - name: superfluous-else
+      - name: time-naming
+      - name: unconditional-recursion
+      - name: unexported-naming
+      - name: unnecessary-stmt
+      - name: unreachable-code
+      # TODO: Enable these in the future
+      # - name: unused-parameter
+      # - name: unused-receiver
+      - name: var-declaration
+      - name: var-naming
+      - name: waitgroup-by-value

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -48,7 +48,7 @@ import (
 )
 
 var (
-	//defaults
+	// defaults
 	storePath         string
 	amqpHost          string
 	apiPort           int
@@ -104,7 +104,6 @@ func main() {
 		<-sigCh
 		log.Info("exiting...")
 		close(scConfig.CloseCh)
-		//wg.Wait()
 		os.Exit(1)
 	}()
 
@@ -156,9 +155,10 @@ func metricServer(address string) {
 }
 
 // ProcessOutChannel this process the out channel;data put out by amqp
-func ProcessOutChannel(wg *sync.WaitGroup, scConfig *common.SCConfiguration) {
-	//qdr throws out the data on this channel ,listen to data coming out of qdrEventOutCh
-	//Send back the acknowledgement to publisher
+func ProcessOutChannel(wg *sync.WaitGroup, scConfig *common.SCConfiguration) { // nolint:unused
+	// qdr throws out the data on this channel ,listen to data coming out of qdrEventOutCh
+	// Send back the acknowledgement to publisher
+	defer wg.Done()
 	postProcessFn := func(address string, status channel.Status) {
 		if pub, ok := scConfig.PubSubAPI.HasPublisher(address); ok {
 			if status == channel.SUCCESS {
@@ -167,7 +167,7 @@ func ProcessOutChannel(wg *sync.WaitGroup, scConfig *common.SCConfiguration) {
 				localmetrics.UpdateEventAckCount(address, localmetrics.FAILED)
 			}
 			if pub.EndPointURI != nil {
-				log.Debugf("posting event status %s to publisher %s", channel.Status(status), pub.Resource)
+				log.Debugf("posting event status %s to publisher %s", status, pub.Resource)
 				restClient := restclient.New()
 				_ = restClient.Post(pub.EndPointURI,
 					[]byte(fmt.Sprintf(`{eventId:"%s",status:"%s"}`, pub.ID, status)))
@@ -289,12 +289,10 @@ func ProcessInChannel(wg *sync.WaitGroup, scConfig *common.SCConfiguration) {
 
 func loadFromPubSubStore() {
 	pubs := scConfig.PubSubAPI.GetPublishers()
-	//apiMetrics.UpdatePublisherCount(apiMetrics.ACTIVE, len(pubs))
 	for _, pub := range pubs {
 		v1amqp.CreateSender(scConfig.EventInCh, pub.Resource)
 	}
 	subs := scConfig.PubSubAPI.GetSubscriptions()
-	//apiMetrics.UpdateSubscriptionCount(apiMetrics.ACTIVE, len(subs))
 	for _, sub := range subs {
 		v1amqp.CreateListener(scConfig.EventInCh, sub.Resource)
 	}

--- a/pkg/localmetrics/localmetrics.go
+++ b/pkg/localmetrics/localmetrics.go
@@ -18,7 +18,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// MetricStatus  ...
+// MetricStatus  ... status of the metrics
 type MetricStatus string
 
 const (
@@ -29,19 +29,19 @@ const (
 )
 
 var (
-	//cneEventAckCount ...  Total no of events created
+	// cneEventAckCount ...  Total no of events created
 	cneEventAckCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "cne_events_ack",
 			Help: "Metric to get number of events produced",
 		}, []string{"type", "status"})
-	//CNEEventReceivedCount ...  Total no of events received
+	// CNEEventReceivedCount ...  Total no of events received
 	cneEventReceivedCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "cne_events_received",
 			Help: "Metric to get number of events received",
 		}, []string{"type", "status"})
-	//CNEStatusCheckReceivedCount ...  Total no of events received
+	// CNEStatusCheckReceivedCount ...  Total no of events received
 	cneStatusCheckReceivedCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "cne_status_check_received",
@@ -49,26 +49,26 @@ var (
 		}, []string{"type", "status"})
 )
 
-//RegisterMetrics ... register metrics collector with Prometheus
+// RegisterMetrics ... register metrics collector with Prometheus
 func RegisterMetrics() {
 	prometheus.MustRegister(cneEventAckCount)
 	prometheus.MustRegister(cneEventReceivedCount)
 	prometheus.MustRegister(cneStatusCheckReceivedCount)
 }
 
-// UpdateEventReceivedCount ...
+// UpdateEventReceivedCount ... updated count of received events
 func UpdateEventReceivedCount(subType string, status MetricStatus) {
 	cneEventReceivedCount.With(
 		prometheus.Labels{"type": subType, "status": string(status)}).Inc()
 }
 
-// UpdateEventAckCount  ...
+// UpdateEventAckCount  ... update event ack count
 func UpdateEventAckCount(pubType string, status MetricStatus) {
 	cneEventAckCount.With(
 		prometheus.Labels{"type": pubType, "status": string(status)}).Inc()
 }
 
-// UpdateStatusAckCount  ...
+// UpdateStatusAckCount  ... update status ack count
 func UpdateStatusAckCount(pubType string, status MetricStatus) {
 	cneStatusCheckReceivedCount.With(
 		prometheus.Labels{"type": pubType, "status": string(status)}).Inc()

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -33,10 +33,10 @@ type Handler struct {
 
 // LoadAMQPPlugin loads amqp plugin
 func (pl Handler) LoadAMQPPlugin(wg *sync.WaitGroup, scConfig *common.SCConfiguration) (*v1amqp.AMQP, error) {
-	log.Printf("Starting AMQP server")
+	log.Infof("Starting AMQP server")
 	amqpPlugin, err := filepath.Glob(fmt.Sprintf("%s/amqp_plugin.so", pl.Path))
 	if err != nil {
-		log.Fatalf("cannot load amqp plugin %v\n", err)
+		log.Errorf("cannot load amqp plugin %v\n", err)
 		return nil, err
 	}
 	if len(amqpPlugin) == 0 {
@@ -44,23 +44,23 @@ func (pl Handler) LoadAMQPPlugin(wg *sync.WaitGroup, scConfig *common.SCConfigur
 	}
 	p, err := plugin.Open(amqpPlugin[0])
 	if err != nil {
-		log.Fatalf("cannot open amqp plugin %v", err)
+		log.Errorf("cannot open amqp plugin %v", err)
 		return nil, err
 	}
 	symbol, err := p.Lookup("Start")
 	if err != nil {
-		log.Fatalf("cannot open amqp plugin start method %v", err)
+		log.Errorf("cannot open amqp plugin start method %v", err)
 		return nil, err
 	}
 
 	startFunc, ok := symbol.(func(wg *sync.WaitGroup, scConfig *common.SCConfiguration) (*v1amqp.AMQP, error))
 	if !ok {
-		log.Fatalf("Plugin has no 'Start(*sync.WaitGroup,*common.SCConfiguration) (*v1_amqp.AMQP,error)' function")
+		log.Errorf("Plugin has no 'Start(*sync.WaitGroup,*common.SCConfiguration) (*v1_amqp.AMQP,error)' function")
 		return nil, fmt.Errorf("plugin has no 'start(amqpHost string, dataIn <-chan channel.DataChan, dataOut chan<- channel.DataChan, close <-chan bool) (*v1_amqp.AMQP,error)' function")
 	}
 	amqpInstance, err := startFunc(wg, scConfig)
 	if err != nil {
-		log.Printf("error starting amqp at %s error: %v", scConfig.AMQPHost, err)
+		log.Errorf("error starting amqp at %s error: %v", scConfig.AMQPHost, err)
 		return amqpInstance, err
 	}
 	return amqpInstance, nil
@@ -70,25 +70,26 @@ func (pl Handler) LoadAMQPPlugin(wg *sync.WaitGroup, scConfig *common.SCConfigur
 func (pl Handler) LoadPTPPlugin(wg *sync.WaitGroup, scConfig *common.SCConfiguration, fn func(e interface{}) error) error {
 	ptpPlugin, err := filepath.Glob(fmt.Sprintf("%s/ptp_operator_plugin.so", pl.Path))
 	if err != nil {
-		log.Fatalf("cannot load ptp plugin %v", err)
+		log.Errorf("cannot load ptp plugin %v", err)
 	}
 	if len(ptpPlugin) == 0 {
 		return fmt.Errorf("ptp plugin not found in the path %s", pl.Path)
 	}
 	p, err := plugin.Open(ptpPlugin[0])
 	if err != nil {
-		log.Fatalf("cannot open ptp plugin %v", err)
+		log.Errorf("cannot open ptp plugin %v", err)
 		return err
 	}
 
 	symbol, err := p.Lookup("Start")
 	if err != nil {
-		log.Fatalf("cannot open ptp plugin start method %v", err)
+		log.Errorf("cannot open ptp plugin start method %v", err)
 		return err
 	}
 	startFunc, ok := symbol.(func(*sync.WaitGroup, *common.SCConfiguration, func(e interface{}) error) error)
 	if !ok {
-		log.Fatalf("Plugin has no 'Start(*sync.WaitGroup, *common.SCConfiguration,  fn func(e interface{}) error)(error)' function")
+		log.Errorf("Plugin has no 'Start(*sync.WaitGroup, *common.SCConfiguration,  fn func(e interface{}) error)(error)' function")
+		return fmt.Errorf("Plugin has no 'Start(*sync.WaitGroup, *common.SCConfiguration,  fn func(e interface{}) error)(error)' function")
 	}
 	return startFunc(wg, scConfig, fn)
 }
@@ -97,25 +98,25 @@ func (pl Handler) LoadPTPPlugin(wg *sync.WaitGroup, scConfig *common.SCConfigura
 func (pl Handler) LoadMockPlugin(wg *sync.WaitGroup, scConfig *common.SCConfiguration, fn func(e interface{}) error) error {
 	mockPlugin, err := filepath.Glob(fmt.Sprintf("%s/mock_plugin.so", pl.Path))
 	if err != nil {
-		log.Fatalf("cannot load mock plugin %v", err)
+		log.Errorf("cannot load mock plugin %v", err)
 	}
 	if len(mockPlugin) == 0 {
 		return fmt.Errorf("mock plugin not found in the path %s", pl.Path)
 	}
 	p, err := plugin.Open(mockPlugin[0])
 	if err != nil {
-		log.Fatalf("cannot open mock plugin %v", err)
+		log.Errorf("cannot open mock plugin %v", err)
 		return err
 	}
 
 	symbol, err := p.Lookup("Start")
 	if err != nil {
-		log.Fatalf("cannot open mock plugin start method %v", err)
+		log.Errorf("cannot open mock plugin start method %v", err)
 		return err
 	}
 	startFunc, ok := symbol.(func(*sync.WaitGroup, *common.SCConfiguration, func(e interface{}) error) error)
 	if !ok {
-		log.Fatalf("Plugin has no 'Start(*sync.WaitGroup, *common.SCConfiguration,  fn func(e interface{}) error)(error)' function")
+		log.Errorf("Plugin has no 'Start(*sync.WaitGroup, *common.SCConfiguration,  fn func(e interface{}) error)(error)' function")
 	}
 	return startFunc(wg, scConfig, fn)
 }

--- a/pkg/restclient/client.go
+++ b/pkg/restclient/client.go
@@ -30,7 +30,7 @@ import (
 )
 
 var (
-	httpTimeout time.Duration = 2 * time.Second
+	httpTimeout = 2 * time.Second
 )
 
 // Rest client to make http request

--- a/plugins/mock/mock_plugin.go
+++ b/plugins/mock/mock_plugin.go
@@ -33,11 +33,11 @@ import (
 // limitations under the License.
 
 var (
-	resourceAddress      string = "/cluster/node/%s/mock"
+	resourceAddress      = "/cluster/node/%s/mock"
 	config               *common.SCConfiguration
-	mockResourceName     string  = "/mock"
-	mockEventType        string  = "mock"
-	mockEventStateLocked string  = "LOCKED"
+	mockResourceName             = "/mock"
+	mockEventType                = "mock"
+	mockEventStateLocked         = "LOCKED"
 	mockEventValue       float64 = -200
 )
 
@@ -77,7 +77,7 @@ func Start(wg *sync.WaitGroup, configuration *common.SCConfiguration, fn func(e 
 	// create amqp listener
 	v1amqp.CreateNewStatusListener(config.EventInCh, fmt.Sprintf("%s/%s", pub.Resource, "status"), onStatusRequestFn, fn)
 
-	//create events periodically
+	// create events periodically
 	time.Sleep(5 * time.Second)
 	// create periodical events
 	wg.Add(1)

--- a/plugins/ptp_operator/config/config.go
+++ b/plugins/ptp_operator/config/config.go
@@ -40,13 +40,13 @@ const (
 	DefaultUpdateInterval = 60
 	// DefaultProfilePath  default ptp profile path
 	DefaultProfilePath       = "/etc/linuxptp"
-	maxOffsetThreshold int64 = 100 //in nano secs
+	maxOffsetThreshold int64 = 100 // in nano secs
 	minOffsetThreshold int64 = -100
 	holdoverTimeout    int64 = 5
 	ignorePtp4lSection       = "global"
 )
 
-// PtpProfile ...
+// PtpProfile ... ptp profile
 type PtpProfile struct {
 	Name              *string            `json:"name"`
 	Interface         *string            `json:"interface"`
@@ -57,7 +57,7 @@ type PtpProfile struct {
 	Interfaces        []*string
 }
 
-// PtpClockThreshold ...
+// PtpClockThreshold ... ptp clock threshold values
 type PtpClockThreshold struct {
 	// clock state to stay in holdover state in secs
 	HoldOverTimeout int64 `json:"holdOverTimeout,omitempty"`
@@ -69,7 +69,7 @@ type PtpClockThreshold struct {
 	Close chan struct{} `json:"close,omitempty"`
 }
 
-// PtpProcessOpts ...
+// PtpProcessOpts ... prp process options
 type PtpProcessOpts struct {
 	// ptp4lOpts are set
 	Ptp4lOpts *string `json:"Ptp4lOpts,omitempty"`
@@ -99,7 +99,7 @@ func GetPTPProfileName(ptpConfig string) string {
 	return ""
 }
 
-//SafeClose ... handle close channel
+// SafeClose ... handle close channel
 func (pt *PtpClockThreshold) SafeClose() (justClosed bool) {
 	defer func() {
 		if recover() != nil {
@@ -234,7 +234,7 @@ func (l *LinuxPTPConfigMapUpdate) UpdatePTPThreshold() {
 			} else {
 				minOffsetTh = profile.PtpClockThreshold.MinOffsetThreshold
 			}
-			if profile.PtpClockThreshold.HoldOverTimeout > 0 { //secs can't be negative or zero
+			if profile.PtpClockThreshold.HoldOverTimeout > 0 { // secs can't be negative or zero
 				holdOverTh = profile.PtpClockThreshold.HoldOverTimeout
 			} else {
 				log.Infof("invalid holdOverTimeout %d in secs, setting to default %d holdOverTimeout", profile.PtpClockThreshold.HoldOverTimeout, holdOverTh)
@@ -263,7 +263,7 @@ func (l *LinuxPTPConfigMapUpdate) UpdateConfig(nodeProfilesJSON []byte) error {
 		l.appliedNodeProfileJSON = nodeProfilesJSON
 		l.NodeProfiles = nodeProfiles
 		for index, np := range l.NodeProfiles {
-			//duplicate node profiles
+			// duplicate node profiles
 			l.NodeProfiles[index].Interfaces = np.GetInterface()
 			l.NodeProfiles[index].PtpClockThreshold = np.PtpClockThreshold
 		}

--- a/plugins/ptp_operator/config/config_test.go
+++ b/plugins/ptp_operator/config/config_test.go
@@ -9,10 +9,10 @@ import (
 )
 
 var (
-	profile0 string = "profile0"
-	profile1 string = "profile1"
-	inface0  string = "ens5f0"
-	inface1  string = "ens5f1"
+	profile0 = "profile0"
+	profile1 = "profile1"
+	inface0  = "ens5f0"
+	inface1  = "ens5f1"
 )
 
 // StrPtr returns a pointer to a string value. This is useful within expressions where the value is a literal.

--- a/plugins/ptp_operator/metrics/logparser.go
+++ b/plugins/ptp_operator/metrics/logparser.go
@@ -13,8 +13,8 @@ func extractSummaryMetrics(processName, output string) (iface string, ptpOffset,
 	// remove everything before the rms string
 	// This makes the output to equal
 	// 0            1       2              3     4   5      6     7     8       9
-	//phc2sys 5196755.139 ptp4l.0.config ens7f1 rms 3151717 max 3151717 freq -6085106 +/-   0 delay  2746 +/-   0
-	//phc2sys 5196804.326 ptp4l.0.config CLOCK_REALTIME rms 9452637 max 9452637 freq +1196097 +/-   0 delay  1000
+	// phc2sys 5196755.139 ptp4l.0.config ens7f1 rms 3151717 max 3151717 freq -6085106 +/-   0 delay  2746 +/-   0
+	// phc2sys 5196804.326 ptp4l.0.config CLOCK_REALTIME rms 9452637 max 9452637 freq +1196097 +/-   0 delay  1000
 	// ptp4l[74737.942]: [ptp4l.0.config] rms   53 max   74 freq -16642 +/-  40 delay  1089 +/-  20
 
 	indx := strings.Index(output, "rms")
@@ -32,7 +32,7 @@ func extractSummaryMetrics(processName, output string) (iface string, ptpOffset,
 	output = output[indx:]
 	fields := strings.Fields(output)
 
-	//ptp4l.0.config CLOCK_REALTIME rms   31 max   31 freq -77331 +/-   0 delay  1233 +/-   0
+	// ptp4l.0.config CLOCK_REALTIME rms   31 max   31 freq -77331 +/-   0 delay  1233 +/-   0
 	if len(fields) < 8 {
 		log.Infof("%s failed to parse output %s: unexpected number of fields", processName, output)
 		return
@@ -42,11 +42,11 @@ func extractSummaryMetrics(processName, output string) (iface string, ptpOffset,
 	if fields[1] == rms {
 		fields = append(fields, "") // Making space for the new element
 		//  0             1     2
-		//ptp4l.0.config rms   53 max   74 freq -16642 +/-  40 delay  1089 +/-  20
+		// ptp4l.0.config rms   53 max   74 freq -16642 +/-  40 delay  1089 +/-  20
 		copy(fields[2:], fields[1:]) // Shifting elements
 		fields[1] = MasterClockType  // Copying/inserting the value
 		//  0             0       1   2
-		//ptp4l.0.config master rms   53 max   74 freq -16642 +/-  40 delay  1089 +/-  20
+		// ptp4l.0.config master rms   53 max   74 freq -16642 +/-  40 delay  1089 +/-  20
 	} else if fields[1] != ClockRealTime {
 		// phc2sys[5196755.139]: [ptp4l.0.config] ens5f0 rms 3152778 max 3152778 freq -6083928 +/-   0 delay  2791 +/-   0
 		return // do not register offset value for master (interface) port reported by phc2sys
@@ -84,14 +84,14 @@ func extractSummaryMetrics(processName, output string) (iface string, ptpOffset,
 func extractRegularMetrics(processName, output string) (interfaceName string, ptpOffset, maxPtpOffset, frequencyAdjustment, delay float64, clockState ptp.SyncState) {
 	// remove everything before the rms string
 	// This makes the out to equal
-	//ptp4l[5196819.100]: [ptp4l.0.config] master offset   -2162130 s2 freq +22451884 path delay    374976
-	//phc2sys[4268818.286]: [] CLOCK_REALTIME phc offset       -62 s0 freq  -78368 delay   1100
-	//phc2sys[4268818.287]: [] ens5f1 phc offset       -92 s0 freq    -890 delay   2464   ( this is down)
-	/// phc2sys[4268818.287]: [] ens5f0 phc offset       -47 s2 freq   -2047 delay   2438
+	// ptp4l[5196819.100]: [ptp4l.0.config] master offset   -2162130 s2 freq +22451884 path delay    374976
+	// phc2sys[4268818.286]: [] CLOCK_REALTIME phc offset       -62 s0 freq  -78368 delay   1100
+	// phc2sys[4268818.287]: [] ens5f1 phc offset       -92 s0 freq    -890 delay   2464   ( this is down)
+	// phc2sys[4268818.287]: [] ens5f0 phc offset       -47 s2 freq   -2047 delay   2438
 
 	// 0     1            2              3       4         5    6   7     8         9   10       11
 	//                                  1       2           3   4   5     6        7    8         9
-	//ptp4l 5196819.100 ptp4l.0.config master offset   -2162130 s2 freq +22451884 path delay    374976
+	// ptp4l 5196819.100 ptp4l.0.config master offset   -2162130 s2 freq +22451884 path delay    374976
 	output = strings.Replace(output, "path", "", 1)
 	replacer := strings.NewReplacer("[", " ", "]", " ", ":", " ", "phc", "", "sys", "")
 	output = replacer.Replace(output)
@@ -105,7 +105,7 @@ func extractRegularMetrics(processName, output string) (interfaceName string, pt
 	fields := strings.Fields(output)
 
 	//       0         1      2          3    4   5    6          7     8
-	//ptp4l.0.config master offset   -2162130 s2 freq +22451884  delay 374976
+	// ptp4l.0.config master offset   -2162130 s2 freq +22451884  delay 374976
 	if len(fields) < 7 {
 		log.Errorf("%s failed to parse output %s: unexpected number of fields", processName, output)
 		return
@@ -161,23 +161,20 @@ func extractRegularMetrics(processName, output string) (interfaceName string, pt
 }
 
 // ExtractPTP4lEvent ... extract event form ptp4l logs
+//	    "INITIALIZING to LISTENING on INIT_COMPLETE"
+//		"LISTENING to UNCALIBRATED on RS_SLAVE"
+//		"UNCALIBRATED to SLAVE on MASTER_CLOCK_SELECTED"
+//		"SLAVE to FAULTY on FAULT_DETECTED"
+//		"LISTENING to FAULTY on FAULT_DETECTED"
+//		"FAULTY to LISTENING on INIT_COMPLETE"
+//		"FAULTY to SLAVE on INIT_COMPLETE"
+//		"SLAVE to UNCALIBRATED on SYNCHRONIZATION_FAULT"
+//	     "MASTER to PASSIVE"
 func extractPTP4lEventState(output string) (portID int, role types.PtpPortRole, clockState ptp.SyncState) {
 	// This makes the out to equal
-	//phc2sys[187248.740]:[ens5f0] CLOCK_REALTIME phc offset        12 s2 freq   +6879 delay    49
+	// phc2sys[187248.740]:[ens5f0] CLOCK_REALTIME phc offset        12 s2 freq   +6879 delay    49
 	// phc2sys[187248.740]:[ens5f1] CLOCK_REALTIME phc offset        12 s2 freq   +6879 delay    49
-
-	/*
-			"INITIALIZING to LISTENING on INIT_COMPLETE"
-			"LISTENING to UNCALIBRATED on RS_SLAVE"
-			"UNCALIBRATED to SLAVE on MASTER_CLOCK_SELECTED"
-			"SLAVE to FAULTY on FAULT_DETECTED"
-			"LISTENING to FAULTY on FAULT_DETECTED"
-			"FAULTY to LISTENING on INIT_COMPLETE"
-			"FAULTY to SLAVE on INIT_COMPLETE"
-			"SLAVE to UNCALIBRATED on SYNCHRONIZATION_FAULT"
-		     "MASTER to PASSIVE"
-	*/
-	//ptp4l[5199193.712]: [ptp4l.0.config] port 1: SLAVE to UNCALIBRATED on SYNCHRONIZATION_FAULT
+	// ptp4l[5199193.712]: [ptp4l.0.config] port 1: SLAVE to UNCALIBRATED on SYNCHRONIZATION_FAULT
 	replacer := strings.NewReplacer("[", " ", "]", " ", ":", " ")
 	output = replacer.Replace(output)
 
@@ -187,7 +184,7 @@ func extractPTP4lEventState(output string) (portID int, role types.PtpPortRole, 
 	}
 	output = output[index:]
 	fields := strings.Fields(output)
-	//port 1: delay timeout
+	// port 1: delay timeout
 	if len(fields) < 2 {
 		log.Infof("failed to parse output %s: unexpected number of fields", output)
 		return
@@ -219,7 +216,7 @@ func extractPTP4lEventState(output string) (portID int, role types.PtpPortRole, 
 	return
 }
 
-//FindInLogForCfgFileIndex ...
+// FindInLogForCfgFileIndex ... find config name from the log
 func FindInLogForCfgFileIndex(out string) int {
 	match := ptpConfigFileRegEx.FindStringIndex(out)
 	if len(match) == 2 {

--- a/plugins/ptp_operator/metrics/metrics.go
+++ b/plugins/ptp_operator/metrics/metrics.go
@@ -30,11 +30,11 @@ const (
 	clockStep = "s1"
 	locked    = "s2"
 
-	//FreeRunOffsetValue when sync state is FREERUN
+	// FreeRunOffsetValue when sync state is FREERUN
 	FreeRunOffsetValue = -9999999999999999
-	//ClockRealTime is the slave
+	// ClockRealTime is the slave
 	ClockRealTime = "CLOCK_REALTIME"
-	//MasterClockType is the slave sync slave clock to master
+	// MasterClockType is the slave sync slave clock to master
 	MasterClockType = "master"
 
 	// from the logs
@@ -51,7 +51,7 @@ const (
 	master = "master"
 )
 
-// ExtractMetrics ...
+// ExtractMetrics ... extract metrics from ptp logs.
 func (p *PTPEventManager) ExtractMetrics(msg string) {
 	defer func() {
 		if err := recover(); err != nil {
@@ -111,10 +111,10 @@ func (p *PTPEventManager) ExtractMetrics(msg string) {
 			}
 		}
 	} else if strings.Contains(output, " offset ") {
-		//ptp4l[5196819.100]: [ptp4l.0.config] master offset   -2162130 s2 freq +22451884 path delay    374976
-		//phc2sys[4268818.286]: [ptp4l.0.config] CLOCK_REALTIME phc offset       -62 s0 freq  -78368 delay   1100
-		//phc2sys[4268818.287]: [ptp4l.0.config] ens5f1 phc offset       -92 s0 freq    -890 delay   2464   ( this is down)
-		//phc2sys[4268818.287]: [ptp4l.0.config] ens5f0 phc offset       -47 s2 freq   -2047 delay   2438
+		// ptp4l[5196819.100]: [ptp4l.0.config] master offset   -2162130 s2 freq +22451884 path delay    374976
+		// phc2sys[4268818.286]: [ptp4l.0.config] CLOCK_REALTIME phc offset       -62 s0 freq  -78368 delay   1100
+		// phc2sys[4268818.287]: [ptp4l.0.config] ens5f1 phc offset       -92 s0 freq    -890 delay   2464   ( this is down)
+		// phc2sys[4268818.287]: [ptp4l.0.config] ens5f0 phc offset       -47 s2 freq   -2047 delay   2438
 		// Use threshold to CLOCK_REALTIME==SLAVE, rest send clock state to metrics no events
 		interfaceName, ptpOffset, _, frequencyAdjustment, delay, syncState := extractRegularMetrics(processName, output)
 		eventType := ptp.PtpStateChange
@@ -146,7 +146,7 @@ func (p *PTPEventManager) ExtractMetrics(msg string) {
 		ptpInterface, _ = ptp4lCfg.ByRole(types.SLAVE)
 
 		switch interfaceName {
-		case ClockRealTime: //CLOCK_REALTIME is active slave interface
+		case ClockRealTime: // CLOCK_REALTIME is active slave interface
 			// copy  ClockRealTime value to current slave interface
 			p.GenPTPEvent(profileName, ptpStats[interfaceType], interfaceName, int64(ptpOffset), syncState, eventType)
 			UpdateSyncStateMetrics(processName, interfaceName, ptpStats[interfaceType].LastSyncState())
@@ -169,7 +169,7 @@ func (p *PTPEventManager) ExtractMetrics(msg string) {
 			}
 		}
 	}
-	if ptp4lProcessName == processName { //all we get from ptp4l is stats
+	if ptp4lProcessName == processName { // all we get from ptp4l is stats
 		p.ParsePTP4l(processName, configName, profileName, output, fields,
 			ptpInterface, ptp4lCfg, ptpStats)
 	}

--- a/plugins/ptp_operator/metrics/registry.go
+++ b/plugins/ptp_operator/metrics/registry.go
@@ -47,7 +47,7 @@ var (
 			Help:      "",
 		}, []string{"from", "process", "node", "iface"})
 
-	//SyncState metrics to show current clock state
+	// SyncState metrics to show current clock state
 	SyncState = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: ptpNamespace,
@@ -106,7 +106,7 @@ func RegisterMetrics(nodeName string) {
 	})
 }
 
-// UpdatePTPMetrics ...
+// UpdatePTPMetrics ... update ptp metrics
 func UpdatePTPMetrics(metricsType, process, eventResourceName string, offset, maxOffset, frequencyAdjustment, delay float64) {
 	PtpOffset.With(prometheus.Labels{"from": metricsType,
 		"process": process, "node": ptpNodeName, "iface": eventResourceName}).Set(offset)
@@ -145,8 +145,8 @@ func DeleteThresholdMetrics(profile string) {
 		"threshold": "HoldOverTimeout", "node": ptpNodeName, "profile": profile})
 }
 
-// UpdateSyncStateMetrics ...
-func UpdateSyncStateMetrics(process string, iface string, state ptp.SyncState) {
+// UpdateSyncStateMetrics ... update sync state metrics
+func UpdateSyncStateMetrics(process, iface string, state ptp.SyncState) {
 	var clockState float64
 	if state == ptp.LOCKED {
 		clockState = 1
@@ -160,13 +160,13 @@ func UpdateSyncStateMetrics(process string, iface string, state ptp.SyncState) {
 
 }
 
-//UpdateInterfaceRoleMetrics ...
+// UpdateInterfaceRoleMetrics ... update interface role metrics
 func UpdateInterfaceRoleMetrics(process, ptpInterface string, role types.PtpPortRole) {
 	InterfaceRole.With(prometheus.Labels{
 		"process": process, "node": ptpNodeName, "iface": ptpInterface}).Set(float64(role))
 }
 
-//DeleteInterfaceRoleMetrics ...
+// DeleteInterfaceRoleMetrics ... delete interface role metrics
 func DeleteInterfaceRoleMetrics(process, ptpInterface string) {
 	InterfaceRole.Delete(prometheus.Labels{
 		"process": process, "node": ptpNodeName, "iface": ptpInterface})

--- a/plugins/ptp_operator/ptp4lconf/ptp4lConfig_test.go
+++ b/plugins/ptp_operator/ptp4lconf/ptp4lConfig_test.go
@@ -57,30 +57,29 @@ func Test_Config(t *testing.T) {
 	assert.Nil(t, err)
 	select {
 	case ptpConfigEvent := <-notifyConfigUpdates:
-		//assert
+		// assert
 		assert.Equal(t, ptp4l0Conf, *ptpConfigEvent.Name)
 		assert.Equal(t, initialText, *ptpConfigEvent.Ptp4lConf)
 	case <-time.After(1 * time.Second):
 		log.Infof("timeout...")
 	}
 
-	//Update config
+	// Update config
 	newText := fmt.Sprintf("%d", time.Now().UnixNano())
 	log.Infof("writing to %s", filepath.Join(dirToWatch, ptp4l0Conf))
-	err = ioutil.WriteFile(filepath.Join(dirToWatch, ptp4l0Conf), []byte(newText), 0644)
+	err = ioutil.WriteFile(filepath.Join(dirToWatch, ptp4l0Conf), []byte(newText), 0600)
 	assert.Nil(t, err)
 	log.Info("waiting...")
 	// WriteFile creates two events it might be an issue with test only
 	select {
 	case <-notifyConfigUpdates:
-		//assert
+		// assert
 	case <-time.After(1 * time.Second):
 		log.Infof("timeout...")
 	}
 
 	select {
 	case ptpConfigEvent := <-notifyConfigUpdates:
-		//assert
 		assert.Equal(t, ptp4l0Conf, *ptpConfigEvent.Name)
 		assert.Equal(t, newText, *ptpConfigEvent.Ptp4lConf)
 	case <-time.After(1 * time.Second):
@@ -90,7 +89,7 @@ func Test_Config(t *testing.T) {
 	cleanUp()
 	select {
 	case ptpConfigEvent := <-notifyConfigUpdates:
-		//assert
+		// assert
 		log.Println(ptpConfigEvent.String())
 		assert.Nil(t, err)
 		assert.Equal(t, ptp4l0Conf, *ptpConfigEvent.Name)

--- a/plugins/ptp_operator/socket/socket.go
+++ b/plugins/ptp_operator/socket/socket.go
@@ -10,8 +10,8 @@ var (
 	staleSocketTimeout = 100 * time.Millisecond
 )
 
-//Listen ... listen to ptp daemon logs
-func Listen(addr string) (net.Listener, error) {
+// Listen ... listen to ptp daemon logs
+func Listen(addr string) (l net.Listener, e error) {
 	uAddr, err := net.ResolveUnixAddr("unix", addr)
 	if err != nil {
 		return nil, err
@@ -19,9 +19,9 @@ func Listen(addr string) (net.Listener, error) {
 
 	// Try to listen on the socket. If that fails we check to see if it's a stale
 	// socket and remove it if it is. Then we try to listen one more time.
-	l, err := net.ListenUnix("unix", uAddr)
+	l, err = net.ListenUnix("unix", uAddr)
 	if err != nil {
-		if err = removeIfStaleUnixSocket(addr); err != nil {
+		if err := removeIfStaleUnixSocket(addr); err != nil {
 			return nil, err
 		}
 		if l, err = net.ListenUnix("unix", uAddr); err != nil {
@@ -40,7 +40,7 @@ func removeIfStaleUnixSocket(socketPath string) error {
 	}
 	// Try to connect
 	conn, err := net.DialTimeout("unix", socketPath, staleSocketTimeout)
-	if err != nil { //=syscall.ECONNREFUSED {
+	if err != nil { // =syscall.ECONNREFUSED {
 		return os.Remove(socketPath)
 	} else if err == nil {
 		return conn.Close()

--- a/plugins/ptp_operator/socket/socket_test.go
+++ b/plugins/ptp_operator/socket/socket_test.go
@@ -58,7 +58,8 @@ func Test_WriteMetricsToSocket(t *testing.T) {
 	for i := 0; i < logLength; i++ {
 		_, err = c.Write([]byte(logsData[i]))
 		if err != nil {
-			log.Fatal("write error:", err)
+			log.Errorf("write error:%s", err)
+			return
 		}
 	}
 
@@ -93,7 +94,6 @@ func processTestMetrics2(c net.Conn) {
 		if !ok {
 			break
 		}
-		//log.Printf("plugin got %s", scanner.Text())
 		msg := scanner.Text()
 		eventProcessor.ExtractMetrics(msg)
 	}

--- a/plugins/ptp_operator/stats/stats.go
+++ b/plugins/ptp_operator/stats/stats.go
@@ -25,7 +25,7 @@ type Stats struct {
 	aliasName           string
 }
 
-// AddValue ...
+// AddValue ...add value
 func (s *Stats) AddValue(val int64) {
 
 	oldMean := s.mean
@@ -43,7 +43,7 @@ func (s *Stats) AddValue(val int64) {
 
 }
 
-// StDev ...
+// StDev ... set dev
 func (s *Stats) StDev() float64 { //nolint:unused
 	if s.num > 0 {
 		return math.Sqrt(float64(s.sumDiffSqr / s.num))
@@ -51,7 +51,7 @@ func (s *Stats) StDev() float64 { //nolint:unused
 	return 1
 }
 
-// MaxAbs ...
+// MaxAbs ... get Max abs value
 func (s *Stats) MaxAbs() int64 {
 	if s.max > s.min {
 		return s.max
@@ -60,23 +60,23 @@ func (s *Stats) MaxAbs() int64 {
 
 }
 
-// OffsetSource ...
+// OffsetSource ... get offset source
 func (s *Stats) OffsetSource() string {
 	return s.offsetSource
 
 }
 
-// SetOffsetSource ...
+// SetOffsetSource ... set offset source ptp4/phc2sys/master
 func (s *Stats) SetOffsetSource(os string) {
 	s.offsetSource = os
 }
 
-// ProcessName ...
+// ProcessName ... name of the process either ptp4l or phc2sys
 func (s *Stats) ProcessName() string {
 	return s.processName
 }
 
-// SetProcessName ...
+// SetProcessName ... set process name
 func (s *Stats) SetProcessName(processName string) {
 	s.processName = processName
 }
@@ -91,7 +91,7 @@ func (s *Stats) Alias() string {
 	return s.aliasName
 }
 
-// SetAlias ...
+// SetAlias ... set alias name for slave port
 func (s *Stats) SetAlias(val string) {
 	s.aliasName = val
 }
@@ -101,7 +101,7 @@ func (s *Stats) SyncState() ptp.SyncState {
 	return s.lastSyncState
 }
 
-//ConfigName ...
+// ConfigName ...get config name
 func (s *Stats) ConfigName() string {
 	return s.configName
 }
@@ -122,42 +122,42 @@ func NewStats(configName string) *Stats {
 	return &Stats{configName: configName}
 }
 
-// SetFrequencyAdjustment ...
+// SetFrequencyAdjustment ... set frequency adjustment
 func (s *Stats) SetFrequencyAdjustment(val int64) {
 	s.frequencyAdjustment = val
 }
 
-// SetDelay ...
+// SetDelay ... set delay value
 func (s *Stats) SetDelay(val int64) {
 	s.delay = val
 }
 
-// SetLastOffset ...
+// SetLastOffset ... set last offset value
 func (s *Stats) SetLastOffset(val int64) {
 	s.lastOffset = val
 }
 
-// SetLastSyncState ...
+// SetLastSyncState ... set last sync state
 func (s *Stats) SetLastSyncState(val ptp.SyncState) {
 	s.lastSyncState = val
 }
 
-// FrequencyAdjustment ...
+// FrequencyAdjustment ... get frequency adjustment value
 func (s *Stats) FrequencyAdjustment() int64 {
 	return s.frequencyAdjustment
 }
 
-// Delay ...
+// Delay ... get delay value
 func (s *Stats) Delay() int64 {
 	return s.delay
 }
 
-// LastOffset ...
+// LastOffset ... last offset value
 func (s *Stats) LastOffset() int64 {
 	return s.lastOffset
 }
 
-// LastSyncState ...
+// LastSyncState ... last sync state
 func (s *Stats) LastSyncState() ptp.SyncState {
 	return s.lastSyncState
 }

--- a/plugins/ptp_operator/types/types.go
+++ b/plugins/ptp_operator/types/types.go
@@ -8,30 +8,30 @@ import (
 )
 
 type (
-	//ProcessName ...
+	// ProcessName ... process name either ptp4l or phc2sys
 	ProcessName string
-	//PtpPortRole ...
+	// PtpPortRole ...ptp port role
 	PtpPortRole int
-	//IFace ...
+	// IFace ... network interface name
 	IFace string
-	//ConfigName ...
+	// ConfigName ... config name
 	ConfigName string
 )
 
 const (
-	//PASSIVE when two slave are configure other will be passive
+	// PASSIVE when two slave are configure other will be passive
 	PASSIVE PtpPortRole = iota
-	//SLAVE interface
+	// SLAVE interface
 	SLAVE
-	//MASTER interface
+	// MASTER interface
 	MASTER
-	//FAULTY Interface role
+	// FAULTY Interface role
 	FAULTY
-	//UNKNOWN role
+	// UNKNOWN role
 	UNKNOWN
 )
 
-//PtpRoleMappings ...
+// PtpRoleMappings ... set ptp role mapping
 var PtpRoleMappings = map[string]PtpPortRole{
 	"PASSIVE": PASSIVE,
 	"SLAVE":   SLAVE,

--- a/test/cne/cne.go
+++ b/test/cne/cne.go
@@ -14,7 +14,6 @@ import (
 	testclient "github.com/redhat-cne/cloud-event-proxy/test/utils/client"
 	"github.com/redhat-cne/cloud-event-proxy/test/utils/pods"
 	corev1 "k8s.io/api/core/v1"
-	v1core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -74,9 +73,9 @@ var _ = ginkgo.Describe("validation", func() {
 	})
 
 	ginkgo.Describe("[e2e]", func() {
-		producerPod := v1core.Pod{}
-		consumerPod := v1core.Pod{}
-		routerPod := v1core.Pod{}
+		producerPod := corev1.Pod{}
+		consumerPod := corev1.Pod{}
+		routerPod := corev1.Pod{}
 
 		ginkgo.BeforeEach(func() {
 			producerPods, err := testclient.Client.Pods(testutils.NamespaceProducerTesting).List(context.Background(), metav1.ListOptions{

--- a/test/utils/client/clients.go
+++ b/test/utils/client/clients.go
@@ -14,7 +14,7 @@ import (
 	networkv1client "k8s.io/client-go/kubernetes/typed/networking/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	k8sClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Client defines the client set that will be used for testing
@@ -26,7 +26,7 @@ func init() {
 
 // Set provides the struct to talk with relevant API
 type Set struct {
-	client.Client
+	k8sClient.Client
 	corev1client.CoreV1Interface
 	networkv1client.NetworkingV1Client
 	appsv1client.AppsV1Interface
@@ -35,17 +35,17 @@ type Set struct {
 }
 
 // New returns a *ClientBuilder with the given kubeconfig.
-func New(kubeconfig string) *Set {
+func New(kubeConfig string) *Set {
 	var config *rest.Config
 	var err error
 
-	if kubeconfig == "" {
-		kubeconfig = os.Getenv("KUBECONFIG")
+	if kubeConfig == "" {
+		kubeConfig = os.Getenv("KUBECONFIG")
 	}
 
-	if kubeconfig != "" {
-		glog.V(4).Infof("Loading kube client config from path %q", kubeconfig)
-		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if kubeConfig != "" {
+		glog.V(4).Infof("Loading kube client config from path %q", kubeConfig)
+		config, err = clientcmd.BuildConfigFromFlags("", kubeConfig)
 	} else {
 		glog.V(4).Infof("Using in-cluster kube client config")
 		config, err = rest.InClusterConfig()
@@ -71,7 +71,7 @@ func New(kubeconfig string) *Set {
 		panic(err)
 	}
 
-	clientSet.Client, err = client.New(config, client.Options{
+	clientSet.Client, err = k8sClient.New(config, k8sClient.Options{
 		Scheme: myScheme,
 	})
 

--- a/test/utils/namespaces/namespaces.go
+++ b/test/utils/namespaces/namespaces.go
@@ -6,7 +6,7 @@ import (
 
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/pointer"
@@ -35,7 +35,7 @@ func Create(namespace string, cs *testclient.Set) error {
 		metav1.CreateOptions{},
 	)
 
-	if k8serrors.IsAlreadyExists(err) {
+	if errors.IsAlreadyExists(err) {
 		return nil
 	}
 	return err
@@ -44,7 +44,7 @@ func Create(namespace string, cs *testclient.Set) error {
 // Clean cleans all dangling objects from the given namespace.
 func Clean(namespace string, cs *testclient.Set) error {
 	_, err := cs.Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
-	if err != nil && k8serrors.IsNotFound(err) {
+	if err != nil && errors.IsNotFound(err) {
 		return nil
 	}
 
@@ -70,7 +70,7 @@ func Clean(namespace string, cs *testclient.Set) error {
 		}
 		err = cs.Services(namespace).Delete(context.Background(), s.Name, metav1.DeleteOptions{
 			GracePeriodSeconds: pointer.Int64Ptr(0)})
-		if err != nil && k8serrors.IsNotFound(err) {
+		if err != nil && errors.IsNotFound(err) {
 			continue
 		}
 		if err != nil {

--- a/test/utils/nodes/nodes.go
+++ b/test/utils/nodes/nodes.go
@@ -16,29 +16,29 @@ const (
 	EventNodeLabel = "app=local"
 )
 
-// NodeTopology  ...
+// NodeTopology  ... node topology struct
 type NodeTopology struct {
 	NodeName   string
 	NodeObject *corev1.Node
 }
 
-// LabelNode ...
+// LabelNode ... label k8s nodes
 func LabelNode(nodeName, key, value string) (*corev1.Node, error) {
-	NodeObject, err := testclient.Client.Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+	nodeObject, err := testclient.Client.Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
 
-	NodeObject.Labels[key] = value
-	NodeObject, err = testclient.Client.Nodes().Update(context.Background(), NodeObject, metav1.UpdateOptions{})
+	nodeObject.Labels[key] = value
+	nodeObject, err = testclient.Client.Nodes().Update(context.Background(), nodeObject, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, err
 	}
 
-	return NodeObject, nil
+	return nodeObject, nil
 }
 
-// FilterNodes ...
+// FilterNodes ... filter nodes
 func FilterNodes(nodesSelector string, toFilter []NodeTopology) ([]NodeTopology, error) {
 	if nodesSelector == "" {
 		return toFilter, nil
@@ -68,7 +68,7 @@ func FilterNodes(nodesSelector string, toFilter []NodeTopology) ([]NodeTopology,
 	return res, nil
 }
 
-// GetNodes ...
+// GetNodes ... get k8s nodes
 func GetNodes() ([]NodeTopology, error) {
 	nodes, err := testclient.Client.Nodes().List(context.Background(), metav1.ListOptions{})
 	if err != nil {


### PR DESCRIPTION
linter was running without any options enabled.
The PR added .golanci.yaml file and fixed all linter complaints.
Refactored a few areas to fix lint issues

Signed-off-by: Aneesh Puttur <aneeshputtur@gmail.com>