### PR TITLE
Add script that creates _test.go files if they don't exist

### DIFF
--- a/hack/create-missing-test-files.sh
+++ b/hack/create-missing-test-files.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+for folder in cmd plugins pkg test ; do
+   echo "./$folder"
+  find ./$folder -name "*.go" | grep -v "_test.go" | grep -v "_moq.go" | grep -v "ginkgo.go" | sed 's/.go//g'|xargs -I{} sh -c "echo {}; if ! test -f '{}_test.go'; then sed '/^package/q' {}.go > {}_test.go; fi"
+done
+rm -f {}_test.go

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -1,0 +1,15 @@
+// Copyright 2020 The Cloud Native Events Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common

--- a/pkg/localmetrics/localmetrics_test.go
+++ b/pkg/localmetrics/localmetrics_test.go
@@ -1,0 +1,15 @@
+// Copyright 2020 The Cloud Native Events Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localmetrics

--- a/pkg/restclient/client_test.go
+++ b/pkg/restclient/client_test.go
@@ -1,0 +1,15 @@
+// Copyright 2020 The Cloud Native Events Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package restclient

--- a/plugins/amqp/amqp_plugin_test.go
+++ b/plugins/amqp/amqp_plugin_test.go
@@ -1,0 +1,15 @@
+// Copyright 2020 The Cloud Native Events Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main

--- a/plugins/mock/mock_plugin_test.go
+++ b/plugins/mock/mock_plugin_test.go
@@ -1,0 +1,1 @@
+package main

--- a/plugins/ptp_operator/metrics/logparser_test.go
+++ b/plugins/ptp_operator/metrics/logparser_test.go
@@ -1,0 +1,1 @@
+package metrics

--- a/plugins/ptp_operator/metrics/manager_test.go
+++ b/plugins/ptp_operator/metrics/manager_test.go
@@ -1,0 +1,1 @@
+package metrics

--- a/plugins/ptp_operator/metrics/metrics_test.go
+++ b/plugins/ptp_operator/metrics/metrics_test.go
@@ -1,0 +1,1 @@
+package metrics

--- a/plugins/ptp_operator/metrics/ptp4lParse_test.go
+++ b/plugins/ptp_operator/metrics/ptp4lParse_test.go
@@ -1,0 +1,1 @@
+package metrics

--- a/plugins/ptp_operator/metrics/registry_test.go
+++ b/plugins/ptp_operator/metrics/registry_test.go
@@ -1,0 +1,1 @@
+package metrics

--- a/plugins/ptp_operator/stats/stats_test.go
+++ b/plugins/ptp_operator/stats/stats_test.go
@@ -1,0 +1,1 @@
+package stats

--- a/plugins/ptp_operator/types/types_test.go
+++ b/plugins/ptp_operator/types/types_test.go
@@ -1,0 +1,1 @@
+package types

--- a/test/cne/cne_test.go
+++ b/test/cne/cne_test.go
@@ -1,0 +1,4 @@
+//go:build !unittests
+// +build !unittests
+
+package cne

--- a/test/cne/test_test.go
+++ b/test/cne/test_test.go
@@ -1,0 +1,1 @@
+package cne

--- a/test/utils/client/clients_test.go
+++ b/test/utils/client/clients_test.go
@@ -1,0 +1,1 @@
+package client

--- a/test/utils/consts_test.go
+++ b/test/utils/consts_test.go
@@ -1,0 +1,1 @@
+package utils

--- a/test/utils/namespaces/namespaces_test.go
+++ b/test/utils/namespaces/namespaces_test.go
@@ -1,0 +1,1 @@
+package namespaces

--- a/test/utils/nodes/nodes_test.go
+++ b/test/utils/nodes/nodes_test.go
@@ -1,0 +1,1 @@
+package nodes

--- a/test/utils/pods/pods_test.go
+++ b/test/utils/pods/pods_test.go
@@ -1,0 +1,1 @@
+package pods


### PR DESCRIPTION
Created `./hack/create-missing-test-files.sh` that creates _test.go files that are missing.

Copied from: https://github.com/test-network-function/cnf-certification-test/pull/50