### PR TITLE
Upgrade to v3 checkout action

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,7 +6,7 @@ jobs:
     name: Linting
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v2
         with:
           go-version: '1.17'
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - uses: actions/setup-go@v2
         with:
           go-version: '1.17'


### PR DESCRIPTION
Similar to: https://github.com/test-network-function/cnf-certification-test/pull/204 

https://github.com/actions/checkout/releases/tag/v3.0.2

`checkout` v3 is the latest available.