### PR TITLE
Fix ioutil deprecations

### DIFF
--- a/examples/consumer/main.go
+++ b/examples/consumer/main.go
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -212,7 +212,7 @@ func server() {
 
 func getEvent(w http.ResponseWriter, req *http.Request) {
 	defer req.Body.Close()
-	bodyBytes, err := ioutil.ReadAll(req.Body)
+	bodyBytes, err := io.ReadAll(req.Body)
 	if err != nil {
 		log.Errorf("error reading event %v", err)
 	}
@@ -227,7 +227,7 @@ func getEvent(w http.ResponseWriter, req *http.Request) {
 
 func ackEvent(w http.ResponseWriter, req *http.Request) {
 	defer req.Body.Close()
-	bodyBytes, err := ioutil.ReadAll(req.Body)
+	bodyBytes, err := io.ReadAll(req.Body)
 	if err != nil {
 		log.Errorf("error reading acknowledgment  %v", err)
 	}

--- a/examples/producer/main.go
+++ b/examples/producer/main.go
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"sync"
@@ -151,7 +151,7 @@ func server() {
 
 func ackEvent(w http.ResponseWriter, req *http.Request) {
 	defer req.Body.Close()
-	bodyBytes, err := ioutil.ReadAll(req.Body)
+	bodyBytes, err := io.ReadAll(req.Body)
 	if err != nil {
 		log.Errorf("error reading acknowledgment  %v", err)
 	}

--- a/pkg/restclient/client.go
+++ b/pkg/restclient/client.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -80,7 +80,7 @@ func (r *Rest) Post(url *types.URI, data []byte) int {
 	if response.Body != nil {
 		defer response.Body.Close()
 		// read any content and print
-		body, readErr := ioutil.ReadAll(response.Body)
+		body, readErr := io.ReadAll(response.Body)
 		if readErr == nil && len(body) > 0 {
 			log.Debugf("%s return response %s\n", url.String(), string(body))
 		}
@@ -108,7 +108,7 @@ func (r *Rest) PostWithReturn(url *types.URI, data []byte) (int, []byte) {
 		defer res.Body.Close()
 	}
 
-	body, readErr := ioutil.ReadAll(res.Body)
+	body, readErr := io.ReadAll(res.Body)
 	if readErr != nil {
 		return http.StatusBadRequest, nil
 	}

--- a/plugins/ptp_operator/config/config.go
+++ b/plugins/ptp_operator/config/config.go
@@ -18,7 +18,6 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -339,7 +338,7 @@ func (l *LinuxPTPConfigMapUpdate) updatePtpConfig(nodeName string) {
 		log.Errorf("error stating node profile %v: %v", nodeName, err)
 		return
 	}
-	nodeProfilesJSON, err := ioutil.ReadFile(nodeProfile)
+	nodeProfilesJSON, err := os.ReadFile(nodeProfile)
 	if err != nil {
 		log.Errorf("error reading node profile: %v", nodeProfile)
 		return

--- a/plugins/ptp_operator/ptp4lconf/ptp4lConfig.go
+++ b/plugins/ptp_operator/ptp4lconf/ptp4lConfig.go
@@ -2,7 +2,7 @@ package ptp4lconf
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -216,7 +216,7 @@ func NewPtp4lConfigWatcher(dirToWatch string, updatedConfig chan<- *PtpConfigUpd
 
 func readAllConfig(dir string) []*PtpConfigUpdate {
 	var ptpConfigs []*PtpConfigUpdate
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		log.Errorf("error reading all config fils %s", err)
 	}
@@ -231,7 +231,7 @@ func readAllConfig(dir string) []*PtpConfigUpdate {
 }
 func readConfig(path string) (*PtpConfigUpdate, error) {
 	fName := filename(path)
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		log.Errorf("error reading ptpconfig %s error %s", path, err)
 		return nil, err

--- a/plugins/ptp_operator/ptp4lconf/ptp4lConfig_test.go
+++ b/plugins/ptp_operator/ptp4lconf/ptp4lConfig_test.go
@@ -3,7 +3,6 @@ package ptp4lconf_test
 import (
 	"fmt"
 
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -67,7 +66,7 @@ func Test_Config(t *testing.T) {
 	// Update config
 	newText := fmt.Sprintf("%d", time.Now().UnixNano())
 	log.Infof("writing to %s", filepath.Join(dirToWatch, ptp4l0Conf))
-	err = ioutil.WriteFile(filepath.Join(dirToWatch, ptp4l0Conf), []byte(newText), 0600)
+	err = os.WriteFile(filepath.Join(dirToWatch, ptp4l0Conf), []byte(newText), 0600)
 	assert.Nil(t, err)
 	log.Info("waiting...")
 	// WriteFile creates two events it might be an issue with test only


### PR DESCRIPTION
Since this repo is using Go 1.17 it's safe to make these Go 1.16 deprecation changes.

https://go.dev/doc/go1.16#ioutil