### PR TITLE
Bug 2091599 :event is sent multiple times when non slave port goes to faulty.

### DIFF
--- a/plugins/ptp_operator/metrics/ptp4lParse.go
+++ b/plugins/ptp_operator/metrics/ptp4lParse.go
@@ -106,6 +106,9 @@ func (p *PTPEventManager) ParsePTP4l(processName, configName, profileName, outpu
 			// update role metrics
 			UpdateInterfaceRoleMetrics(processName, ptpIFace, role)
 		}
+		if lastRole != types.SLAVE {
+			return // no need to go to holdover state if the Fault was in master(slave) port
+		}
 		if _, ok := ptpStats[master]; !ok { //
 			log.Errorf("no offset stats found for master for  portid %d with role %s (the port started in fault state)", portID, role)
 			return


### PR DESCRIPTION
The fix makes sure events are not triggered when master port goes to faulty state.


Signed-off-by: Aneesh Puttur <aneeshputtur@gmail.com>