### PR TITLE
Bug 2094675: ptp4l and phc2sys process dead event are not releated to actuall proc…

### DIFF
--- a/plugins/ptp_operator/metrics/metrics.go
+++ b/plugins/ptp_operator/metrics/metrics.go
@@ -101,7 +101,7 @@ func (p *PTPEventManager) ExtractMetrics(msg string) {
 	if strings.Contains(output, ptpProcessStatusIdentifier) {
 		if status, e := parsePTPStatus(output, fields); e == nil {
 			if status == PtpProcessDown {
-				if m, ok := ptpStats[master]; ok {
+				if m, ok := ptpStats[master]; ok && processName == ptp4lProcessName {
 					masterResource := fmt.Sprintf("%s/%s", m.Alias(), MasterClockType)
 					p.GenPTPEvent(profileName, m, masterResource, FreeRunOffsetValue, ptp.FREERUN, ptp.PtpStateChange)
 				}


### PR DESCRIPTION
…ess names

Fixed to check process type and fire event releated to the actuall procestasks

Signed-off-by: Aneesh Puttur <aneeshputtur@gmail.com>