### PR TITLE
Add Clock Class change event to CurrentState API call

### DIFF
--- a/examples/manifests/kustomization.yaml
+++ b/examples/manifests/kustomization.yaml
@@ -11,7 +11,7 @@ replicas:
   name: cloud-consumer-deployment
 images:
 - name: cloud-event-consumer
-  newName: quay.io/aneeshkp/cloud-event-consumer
+  newName: quay.io/redhat-cne/cloud-event-consumer
   newTag: latest
 - name: cloud-event-sidecar
   newName: quay.io/redhat-cne/cloud-event-proxy

--- a/plugins/ptp_operator/metrics/metrics.go
+++ b/plugins/ptp_operator/metrics/metrics.go
@@ -36,6 +36,8 @@ const (
 	ClockRealTime = "CLOCK_REALTIME"
 	// MasterClockType is the slave sync slave clock to master
 	MasterClockType = "master"
+	// ClockClass number
+	ClockClass = "CLOCK_CLASS"
 
 	// from the logs
 	processNameIndex = 0

--- a/plugins/ptp_operator/metrics/ptp4lParse.go
+++ b/plugins/ptp_operator/metrics/ptp4lParse.go
@@ -26,6 +26,10 @@ func (p *PTPEventManager) ParsePTP4l(processName, configName, profileName, outpu
 			log.Errorf("clock class not in right format %s", output)
 			return
 		}
+		if _, found := ptpStats[master]; !found {
+			ptpStats[master] = stats.NewStats(configName)
+			ptpStats[master].SetProcessName(ptp4lProcessName)
+		}
 		// ptp4l 1646672953  ptp4l.0.config  CLOCK_CLASS_CHANGE 165.000000
 		clockClass, err := strconv.ParseFloat(fields[4], 64)
 		if err != nil {
@@ -39,7 +43,7 @@ func (p *PTPEventManager) ParsePTP4l(processName, configName, profileName, outpu
 				alias, _ = ptp4lCfg.GetUnknownAlias()
 			}
 			masterResource := fmt.Sprintf("%s/%s", alias, MasterClockType)
-
+			ptpStats[master].SetClockClass(int64(clockClass))
 			ClockClassMetrics.With(prometheus.Labels{
 				"process": processName, "node": ptpNodeName}).Set(clockClass)
 

--- a/plugins/ptp_operator/stats/stats.go
+++ b/plugins/ptp_operator/stats/stats.go
@@ -23,6 +23,7 @@ type Stats struct {
 	lastOffset          int64
 	lastSyncState       ptp.SyncState
 	aliasName           string
+	clackClass          int64
 }
 
 // AddValue ...add value
@@ -81,6 +82,11 @@ func (s *Stats) Offset() int64 {
 	return s.lastOffset
 }
 
+// ClockClass return last known ClockClass
+func (s *Stats) ClockClass() int64 {
+	return s.clackClass
+}
+
 // Alias return alias name
 func (s *Stats) Alias() string {
 	return s.aliasName
@@ -130,6 +136,11 @@ func (s *Stats) SetDelay(val int64) {
 // SetLastOffset ... set last offset value
 func (s *Stats) SetLastOffset(val int64) {
 	s.lastOffset = val
+}
+
+// SetClockClass ... set last clock class value
+func (s *Stats) SetClockClass(val int64) {
+	s.clackClass = val
 }
 
 // SetLastSyncState ... set last sync state


### PR DESCRIPTION
Signed-off-by: Aneesh Puttur <aneeshputtur@gmail.com>
PR ads ability to call 3 events via CurrentState API
`
curl http://localhost:9085/api/cloudNotifications/v1/cluster/node/{node_name}/sync/ptp-status/ptp-clock-class-change/CurrentState
curl  http://localhost:9085/api/cloudNotifications/v1/cluster/node/{node_name}/sync/sync-status/os-clock-sync-state/CurrentState
curl  http://localhost:9085/api/cloudNotifications/v1/cluster/node/{node_name}/sync/ptp-status/lock-state/CurrentState
`
