### PR TITLE
Fix regex for profile name detection

### DIFF
--- a/plugins/ptp_operator/config/config.go
+++ b/plugins/ptp_operator/config/config.go
@@ -32,7 +32,7 @@ import (
 var (
 	sectionHead        = regexp.MustCompile(`\[([^\[\]]*)\]`)
 	ptpConfigFileRegEx = regexp.MustCompile(`ptp4l.[0-9]*.config`)
-	profileRegEx       = regexp.MustCompile(`profile: \s*([a-zA-Z0-9]+)`)
+	profileRegEx       = regexp.MustCompile(`profile: \s*([\w-_]+)`)
 )
 
 const (

--- a/plugins/ptp_operator/ptp4lconf/ptp4lConfig.go
+++ b/plugins/ptp_operator/ptp4lconf/ptp4lConfig.go
@@ -29,7 +29,7 @@ import (
 var (
 	ptpConfigFileRegEx = regexp.MustCompile(`ptp4l.[0-9]*.config`)
 	sectionHead        = regexp.MustCompile(`\[([^\[\]]*)\]`)
-	profileRegEx       = regexp.MustCompile(`profile: \s*([a-zA-Z0-9]+)`)
+	profileRegEx       = regexp.MustCompile(`profile: \s*([\w-_]+)`)
 	fileNameRegEx      = regexp.MustCompile("([^/]+$)")
 )
 

--- a/plugins/ptp_operator/ptp4lconf/ptp4lConfig_test.go
+++ b/plugins/ptp_operator/ptp4lconf/ptp4lConfig_test.go
@@ -101,3 +101,34 @@ func Test_Config(t *testing.T) {
 	}
 	w.Close()
 }
+
+func Test_ProfileName(t *testing.T) {
+	var testResult string
+
+	testCases := []struct {
+		configString   string
+		expectedString string
+	}{
+		{
+			configString:   "  recommend:\n  - profile: ordinary\n    priority: 0\n",
+			expectedString: "ordinary",
+		},
+		{
+			configString:   "  recommend:\n  - profile: ordinary-clock\n    priority: 0\n",
+			expectedString: "ordinary-clock",
+		},
+		{
+			configString:   "  recommend:\n  - profile: ordinary_clock\n    priority: 0\n",
+			expectedString: "ordinary_clock",
+		},
+		{
+			configString:   "  recommend:\n    priority: 0\n",
+			expectedString: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		testResult = ptp4lconf.GetPTPProfileName(tc.configString)
+		assert.Equal(t, tc.expectedString, testResult)
+	}
+}


### PR DESCRIPTION
Previously, the regular expression used to detect the profile name in the PTP coonfiguration only allowed alphanumeric characters. However, profile names can also have "-" and "_", so a new regex is used.

This commit also adds a unit test to verify the different profile name options.

Signed-off-by: Javier Peña <jpena@redhat.com>