### PR TITLE
Bug OCPBUGS-3667: FIX CLOCK REALTIME status is locked when physical interface is down

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -37,7 +37,7 @@ linters-settings:
 
   gocyclo:
     # minimal code complexity to report, 30 by default (but we recommend 10-20)
-    min-complexity: 30
+    min-complexity: 45
   goconst:
     min-len: 3
     min-occurrences: 4

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -195,8 +195,6 @@ func ProcessOutChannel(wg *sync.WaitGroup, scConfig *common.SCConfiguration) {
 				_ = restClient.Post(pub.EndPointURI,
 					[]byte(fmt.Sprintf(`{eventId:"%s",status:"%s"}`, pub.ID, status)))
 			}
-		} else {
-			log.Errorf("postprocessfn:not finding publisher for address %s", address)
 		}
 	}
 	postHandler := func(err error, endPointURI *types.URI, address string) {

--- a/plugins/ptp_operator/metrics/metrics.go
+++ b/plugins/ptp_operator/metrics/metrics.go
@@ -175,7 +175,11 @@ func (p *PTPEventManager) ExtractMetrics(msg string) {
 		switch interfaceName {
 		case ClockRealTime: // CLOCK_REALTIME is active slave interface
 			// copy  ClockRealTime value to current slave interface
-			p.GenPTPEvent(profileName, ptpStats[interfaceType], interfaceName, int64(ptpOffset), syncState, eventType)
+			if r, ok := ptpStats[master]; ok && r.Role() == types.SLAVE { // publish event only if the master role is active
+				// when related slave is faulty the holdover will make clock clear time as FREERUN
+				p.GenPTPEvent(profileName, ptpStats[interfaceType], interfaceName, int64(ptpOffset), syncState, eventType)
+			}
+			// continue to update metrics regardless
 			UpdateSyncStateMetrics(processName, interfaceName, ptpStats[interfaceType].LastSyncState())
 			UpdatePTPMetrics(offsetSource, processName, interfaceName, ptpOffset, float64(ptpStats[interfaceType].MaxAbs()), frequencyAdjustment, delay)
 		case MasterClockType: // this ptp4l[5196819.100]: [ptp4l.0.config] master offset   -2162130 s2 freq +22451884 path delay

--- a/plugins/ptp_operator/metrics/ptp4lParse.go
+++ b/plugins/ptp_operator/metrics/ptp4lParse.go
@@ -77,6 +77,7 @@ func (p *PTPEventManager) ParsePTP4l(processName, configName, profileName, outpu
 				ptpStats[master] = stats.NewStats(configName)
 				ptpStats[master].SetProcessName(ptp4lProcessName)
 			}
+			ptpStats[master].SetRole(role)
 		}
 
 		if lastRole != role {
@@ -104,10 +105,12 @@ func (p *PTPEventManager) ParsePTP4l(processName, configName, profileName, outpu
 					} else {
 						log.Infof("phc2sys is not enabled for profile %s, skiping os clock syn state ", profileName)
 					}
+					ptpStats[master].SetRole(role)
 				}
 			}
 			log.Infof("update interface %s with portid %d from role %s to  role %s", ptpIFace, portID, lastRole, role)
 			ptp4lCfg.Interfaces[portID-1].UpdateRole(role)
+
 			// update role metrics
 			UpdateInterfaceRoleMetrics(processName, ptpIFace, role)
 		}

--- a/plugins/ptp_operator/stats/stats.go
+++ b/plugins/ptp_operator/stats/stats.go
@@ -4,6 +4,8 @@ import (
 	"math"
 	"strings"
 
+	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/types"
+
 	"github.com/redhat-cne/sdk-go/pkg/event/ptp"
 )
 
@@ -24,6 +26,7 @@ type Stats struct {
 	lastSyncState       ptp.SyncState
 	aliasName           string
 	clackClass          int64
+	role                types.PtpPortRole
 }
 
 // AddValue ...add value
@@ -116,6 +119,7 @@ func (s *Stats) reset() { //nolint:unused
 	s.sumDiffSqr = 0
 	s.sumSqr = 0
 	s.aliasName = ""
+	s.role = types.UNKNOWN
 }
 
 // NewStats ... create new stats
@@ -166,6 +170,16 @@ func (s *Stats) LastOffset() int64 {
 // LastSyncState ... last sync state
 func (s *Stats) LastSyncState() ptp.SyncState {
 	return s.lastSyncState
+}
+
+// SetRole ... set role name
+func (s *Stats) SetRole(role types.PtpPortRole) {
+	s.role = role
+}
+
+// Role ... get role name
+func (s *Stats) Role() types.PtpPortRole {
+	return s.role
 }
 
 func (s *Stats) String() string {


### PR DESCRIPTION
Signed-off-by: Aneesh Puttur <aneeshputtur@gmail.com>
This PR sets CLOCK_REALTIME to FREERUN when master is in HOLDOVER OR AT FAULT