### PR TITLE
Fix amq router race condition: update vendors only

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/onsi/gomega v1.22.1
 	github.com/prometheus/client_golang v1.13.0
 	github.com/redhat-cne/rest-api v0.1.1-0.20221026033049-91b95cad7f2d
-	github.com/redhat-cne/sdk-go v0.1.1-0.20221026032709-e226a93f380a
+	github.com/redhat-cne/sdk-go v0.1.1-0.20221202175356-6d25e1b3c0be
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/net v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -442,8 +442,8 @@ github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0ua
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/redhat-cne/rest-api v0.1.1-0.20221026033049-91b95cad7f2d h1:cYiOnh1kqjMYOn+r2JNYqHaIFh32ckd/Pj6ZX601FnI=
 github.com/redhat-cne/rest-api v0.1.1-0.20221026033049-91b95cad7f2d/go.mod h1:Updg3XHuAEljGB2mzvYf6GhPT7oTGACbAz0YOSRFDZ4=
-github.com/redhat-cne/sdk-go v0.1.1-0.20221026032709-e226a93f380a h1:smibMemccT15M8+CxhtCfWub2hyMkd+dYL/LmisQooI=
-github.com/redhat-cne/sdk-go v0.1.1-0.20221026032709-e226a93f380a/go.mod h1:kKOXU8uyHbpwXCKrjzH4WVLq2/RZ5pchiI2LLvmFi5E=
+github.com/redhat-cne/sdk-go v0.1.1-0.20221202175356-6d25e1b3c0be h1:BgSMolt/B9i86ae2RpBMvw4tPz8FdKRsKfFPaF6t01I=
+github.com/redhat-cne/sdk-go v0.1.1-0.20221202175356-6d25e1b3c0be/go.mod h1:kKOXU8uyHbpwXCKrjzH4WVLq2/RZ5pchiI2LLvmFi5E=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -197,7 +197,7 @@ github.com/prometheus/procfs/internal/util
 ## explicit; go 1.17
 github.com/redhat-cne/rest-api
 github.com/redhat-cne/rest-api/pkg/localmetrics
-# github.com/redhat-cne/sdk-go v0.1.1-0.20221026032709-e226a93f380a
+# github.com/redhat-cne/sdk-go v0.1.1-0.20221202175356-6d25e1b3c0be
 ## explicit; go 1.17
 github.com/redhat-cne/sdk-go/pkg/channel
 github.com/redhat-cne/sdk-go/pkg/errorhandler


### PR DESCRIPTION
Add retries when starting AMQP server to deal with the race condition when AMQP router starts later than cloud-event-proxy service, for example when a node is rebooted.

Signed-off-by: Jack Ding <jackding@gmail.com>