### PR TITLE
[release-4.10] OCPBUGS-4755: update sdk-go model for increasing amq timeout

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.17.0
 	github.com/prometheus/client_golang v1.11.0
-	github.com/redhat-cne/rest-api v0.1.1-0.20221207195441-65edd30fe900
-	github.com/redhat-cne/sdk-go v0.1.1-0.20221207165558-2f5cf71ca5a1
+	github.com/redhat-cne/rest-api v0.1.1-0.20230103200709-0d304e847857
+	github.com/redhat-cne/sdk-go v0.1.1-0.20230103182453-1daf63f176cd
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/net v0.0.0-20220225172249-27dd8689420f

--- a/go.sum
+++ b/go.sum
@@ -376,10 +376,10 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3xv4=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/redhat-cne/rest-api v0.1.1-0.20221207195441-65edd30fe900 h1:4bEVzaJbYV5XACeSYnJbVMWMTKeda7G/vFIeWZpKlsM=
-github.com/redhat-cne/rest-api v0.1.1-0.20221207195441-65edd30fe900/go.mod h1:jb56Vh/1sANSpiibGmF8HO2tqWlhVm6OUTcbWcUyG8k=
-github.com/redhat-cne/sdk-go v0.1.1-0.20221207165558-2f5cf71ca5a1 h1:WmgJy1qAPBBHjk7ckhj8I+kOPWoB+gu/p6V8W8Zn43U=
-github.com/redhat-cne/sdk-go v0.1.1-0.20221207165558-2f5cf71ca5a1/go.mod h1:1FXE/O2PhDnazeCidsAIJJ5lLaaWHBXNP5HxaJ1hf0U=
+github.com/redhat-cne/rest-api v0.1.1-0.20230103200709-0d304e847857 h1:5Z1wx/cX4BdCtv3XYlXgMFgr2VrKljcbiZbskimCpJI=
+github.com/redhat-cne/rest-api v0.1.1-0.20230103200709-0d304e847857/go.mod h1:qMyR/oQ6av4fBM9fIEYciyMaGWDIlAWNIe2wpfvOSr4=
+github.com/redhat-cne/sdk-go v0.1.1-0.20230103182453-1daf63f176cd h1:dJZ96/Gjd7qaGU4bZNy6qufPT1gOxRos90bMZQ3FMaQ=
+github.com/redhat-cne/sdk-go v0.1.1-0.20230103182453-1daf63f176cd/go.mod h1:1FXE/O2PhDnazeCidsAIJJ5lLaaWHBXNP5HxaJ1hf0U=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/vendor/github.com/redhat-cne/sdk-go/v1/amqp/amqp.go
+++ b/vendor/github.com/redhat-cne/sdk-go/v1/amqp/amqp.go
@@ -30,7 +30,7 @@ import (
 var (
 	instance      *AMQP
 	retryTimeout  = 500 * time.Millisecond
-	cancelTimeout = 30 * time.Second
+	cancelTimeout = 300 * time.Second
 )
 
 // AMQP exposes amqp api methods

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -159,11 +159,11 @@ github.com/prometheus/common/model
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/redhat-cne/rest-api v0.1.1-0.20221207195441-65edd30fe900
+# github.com/redhat-cne/rest-api v0.1.1-0.20230103200709-0d304e847857
 ## explicit; go 1.17
 github.com/redhat-cne/rest-api
 github.com/redhat-cne/rest-api/pkg/localmetrics
-# github.com/redhat-cne/sdk-go v0.1.1-0.20221207165558-2f5cf71ca5a1
+# github.com/redhat-cne/sdk-go v0.1.1-0.20230103182453-1daf63f176cd
 ## explicit; go 1.17
 github.com/redhat-cne/sdk-go/pkg/channel
 github.com/redhat-cne/sdk-go/pkg/errorhandler


### PR DESCRIPTION
Signed-off-by: Jack Ding <jackding@gmail.com>