### PR TITLE
Amq connection configurable timeout and nohup

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -442,8 +442,6 @@ github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0ua
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/redhat-cne/rest-api v0.1.1-0.20230103192810-2ddf00b9c9ff h1:j9p0Dgmef6j7zq3RNNfVTumCl7kSrFgBKuQxrKk/Qkk=
 github.com/redhat-cne/rest-api v0.1.1-0.20230103192810-2ddf00b9c9ff/go.mod h1:xUvvmFgQmj9wvIAGp0kDMinWgZtJDi4/R2dOUdcIMGI=
-github.com/redhat-cne/sdk-go v0.1.1-0.20230103161106-062a0d661405 h1:YgdHkwJ/gqLZGgG8lE+bd9qiLWo12q8V0fpCnxI2hlY=
-github.com/redhat-cne/sdk-go v0.1.1-0.20230103161106-062a0d661405/go.mod h1:kKOXU8uyHbpwXCKrjzH4WVLq2/RZ5pchiI2LLvmFi5E=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/pkg/plugins/handler_test.go
+++ b/pkg/plugins/handler_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/redhat-cne/cloud-event-proxy/pkg/common"
 	"github.com/redhat-cne/sdk-go/pkg/channel"
@@ -79,7 +80,8 @@ func TestLoadAMQPPlugin(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			pLoader = Handler{Path: tc.pgPath}
-			_, err := pLoader.LoadAMQPPlugin(wg, scConfig)
+			amqInitTimeout := 1 * time.Second
+			_, err := pLoader.LoadAMQPPlugin(wg, scConfig, amqInitTimeout)
 			if err != nil {
 				switch e := err.(type) {
 				case errorhandler.AMQPConnectionError:

--- a/plugins/amqp/amqp_plugin.go
+++ b/plugins/amqp/amqp_plugin.go
@@ -24,8 +24,8 @@ import (
 )
 
 // Start amqp  services to process events,metrics and status
-func Start(wg *sync.WaitGroup, config *common.SCConfiguration) (amqpInstance *v1amqp.AMQP, err error) { //nolint:deadcode,unused
-	if amqpInstance, err = v1amqp.GetAMQPInstance(config.TransportHost.URL, config.EventInCh, config.EventOutCh, config.CloseCh); err != nil {
+func Start(wg *sync.WaitGroup, config *common.SCConfiguration, amqInitTimeout time.Duration) (amqpInstance *v1amqp.AMQP, err error) { //nolint:deadcode,unused
+	if amqpInstance, err = v1amqp.GetAMQPInstance(config.TransportHost.URL, config.EventInCh, config.EventOutCh, config.CloseCh, amqInitTimeout); err != nil {
 		return
 	}
 	amqpInstance.Router.CancelTimeOut(2 * time.Second)

--- a/plugins/ptp_operator/ptp_operator_plugin_test.go
+++ b/plugins/ptp_operator/ptp_operator_plugin_test.go
@@ -91,7 +91,7 @@ func Test_StartWithAMQP(t *testing.T) {
 	scConfig.CloseCh = make(chan struct{})
 	scConfig.PubSubAPI.EnableTransport()
 	scConfig.TransportHost = &common.TransportHost{
-		Type:   0,
+		Type:   common.AMQ,
 		URL:    "amqp:localhost:5672",
 		Host:   "",
 		Port:   0,
@@ -99,8 +99,9 @@ func Test_StartWithAMQP(t *testing.T) {
 		Err:    nil,
 	}
 	scConfig.TransportHost.ParseTransportHost()
-	log.Printf("loading amqp with host %s", scConfig.TransportHost.URL)
-	amqpInstance, err := v1amqp.GetAMQPInstance(scConfig.TransportHost.URL, scConfig.EventInCh, scConfig.EventOutCh, scConfig.CloseCh)
+	amqInitTimeout := 1 * time.Second
+	log.Printf("loading amqp with host %s, amqInitTimeout set to %v", scConfig.TransportHost.URL, amqInitTimeout)
+	amqpInstance, err := v1amqp.GetAMQPInstance(scConfig.TransportHost.URL, scConfig.EventInCh, scConfig.EventOutCh, scConfig.CloseCh, amqInitTimeout)
 	if err != nil {
 		t.Skipf("ampq.Dial(%#v): %v", amqpInstance, err)
 	}
@@ -146,6 +147,15 @@ func Test_StartWithOutAMQP(t *testing.T) {
 	defer cleanUP()
 	scConfig.CloseCh = make(chan struct{})
 	scConfig.PubSubAPI.DisableTransport()
+	scConfig.TransportHost = &common.TransportHost{
+		Type:   common.AMQ,
+		URL:    "amqp://nohup",
+		Host:   "",
+		Port:   0,
+		Scheme: "",
+		Err:    nil,
+	}
+	scConfig.TransportHost.ParseTransportHost()
 	log.Printf("loading amqp with host %s", scConfig.TransportHost.Host)
 	go ProcessInChannel()
 


### PR DESCRIPTION
 Allow configurable timeout for initial amq connection.
    
Introduce amqp://nohup transportHost for local logging of events when amq connection is not available

Signed-off-by: Jack Ding <jackding@gmail.com>