### PR TITLE
[release-4.12] BUG OCPBUGS-5526: Amq connection configurable timeout and nohup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,8 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.22.1
 	github.com/prometheus/client_golang v1.13.0
-	github.com/redhat-cne/rest-api v0.1.1-0.20230103192810-2ddf00b9c9ff
-	github.com/redhat-cne/sdk-go v0.1.1-0.20230103161106-062a0d661405
+	github.com/redhat-cne/rest-api v0.1.1-0.20230119134700-82a3aab383a7
+	github.com/redhat-cne/sdk-go v0.1.1-0.20230119124426-1ed827004687
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/net v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -440,10 +440,10 @@ github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5mo=
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/redhat-cne/rest-api v0.1.1-0.20230103192810-2ddf00b9c9ff h1:j9p0Dgmef6j7zq3RNNfVTumCl7kSrFgBKuQxrKk/Qkk=
-github.com/redhat-cne/rest-api v0.1.1-0.20230103192810-2ddf00b9c9ff/go.mod h1:xUvvmFgQmj9wvIAGp0kDMinWgZtJDi4/R2dOUdcIMGI=
-github.com/redhat-cne/sdk-go v0.1.1-0.20230103161106-062a0d661405 h1:YgdHkwJ/gqLZGgG8lE+bd9qiLWo12q8V0fpCnxI2hlY=
-github.com/redhat-cne/sdk-go v0.1.1-0.20230103161106-062a0d661405/go.mod h1:kKOXU8uyHbpwXCKrjzH4WVLq2/RZ5pchiI2LLvmFi5E=
+github.com/redhat-cne/rest-api v0.1.1-0.20230119134700-82a3aab383a7 h1:6100R/UA9xDGIosY5yhgxDfYUNMWYHUXToEqF1PcSxY=
+github.com/redhat-cne/rest-api v0.1.1-0.20230119134700-82a3aab383a7/go.mod h1:H0Vjdn9EB+d/0gFyHumJxCRWz4DMb6P9zzX/n230Ajg=
+github.com/redhat-cne/sdk-go v0.1.1-0.20230119124426-1ed827004687 h1:XVm+cCf2C2n4VnlQd+oCKj88FcmLfq5m4Nco8cFY+J8=
+github.com/redhat-cne/sdk-go v0.1.1-0.20230119124426-1ed827004687/go.mod h1:kKOXU8uyHbpwXCKrjzH4WVLq2/RZ5pchiI2LLvmFi5E=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/pkg/plugins/handler_test.go
+++ b/pkg/plugins/handler_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/redhat-cne/cloud-event-proxy/pkg/common"
 	"github.com/redhat-cne/sdk-go/pkg/channel"
@@ -79,7 +80,8 @@ func TestLoadAMQPPlugin(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			pLoader = Handler{Path: tc.pgPath}
-			_, err := pLoader.LoadAMQPPlugin(wg, scConfig)
+			amqInitTimeout := 1 * time.Second
+			_, err := pLoader.LoadAMQPPlugin(wg, scConfig, amqInitTimeout)
 			if err != nil {
 				switch e := err.(type) {
 				case errorhandler.AMQPConnectionError:

--- a/plugins/amqp/amqp_plugin.go
+++ b/plugins/amqp/amqp_plugin.go
@@ -24,8 +24,8 @@ import (
 )
 
 // Start amqp  services to process events,metrics and status
-func Start(wg *sync.WaitGroup, config *common.SCConfiguration) (amqpInstance *v1amqp.AMQP, err error) { //nolint:deadcode,unused
-	if amqpInstance, err = v1amqp.GetAMQPInstance(config.TransportHost.URL, config.EventInCh, config.EventOutCh, config.CloseCh); err != nil {
+func Start(wg *sync.WaitGroup, config *common.SCConfiguration, amqInitTimeout time.Duration) (amqpInstance *v1amqp.AMQP, err error) { //nolint:deadcode,unused
+	if amqpInstance, err = v1amqp.GetAMQPInstance(config.TransportHost.URL, config.EventInCh, config.EventOutCh, config.CloseCh, amqInitTimeout); err != nil {
 		return
 	}
 	amqpInstance.Router.CancelTimeOut(2 * time.Second)

--- a/plugins/ptp_operator/ptp_operator_plugin_test.go
+++ b/plugins/ptp_operator/ptp_operator_plugin_test.go
@@ -91,7 +91,7 @@ func Test_StartWithAMQP(t *testing.T) {
 	scConfig.CloseCh = make(chan struct{})
 	scConfig.PubSubAPI.EnableTransport()
 	scConfig.TransportHost = &common.TransportHost{
-		Type:   0,
+		Type:   common.AMQ,
 		URL:    "amqp:localhost:5672",
 		Host:   "",
 		Port:   0,
@@ -99,8 +99,9 @@ func Test_StartWithAMQP(t *testing.T) {
 		Err:    nil,
 	}
 	scConfig.TransportHost.ParseTransportHost()
-	log.Printf("loading amqp with host %s", scConfig.TransportHost.URL)
-	amqpInstance, err := v1amqp.GetAMQPInstance(scConfig.TransportHost.URL, scConfig.EventInCh, scConfig.EventOutCh, scConfig.CloseCh)
+	amqInitTimeout := 1 * time.Second
+	log.Printf("loading amqp with host %s, amqInitTimeout set to %v", scConfig.TransportHost.URL, amqInitTimeout)
+	amqpInstance, err := v1amqp.GetAMQPInstance(scConfig.TransportHost.URL, scConfig.EventInCh, scConfig.EventOutCh, scConfig.CloseCh, amqInitTimeout)
 	if err != nil {
 		t.Skipf("ampq.Dial(%#v): %v", amqpInstance, err)
 	}
@@ -146,6 +147,15 @@ func Test_StartWithOutAMQP(t *testing.T) {
 	defer cleanUP()
 	scConfig.CloseCh = make(chan struct{})
 	scConfig.PubSubAPI.DisableTransport()
+	scConfig.TransportHost = &common.TransportHost{
+		Type:   common.AMQ,
+		URL:    "amqp://nohup",
+		Host:   "",
+		Port:   0,
+		Scheme: "",
+		Err:    nil,
+	}
+	scConfig.TransportHost.ParseTransportHost()
 	log.Printf("loading amqp with host %s", scConfig.TransportHost.Host)
 	go ProcessInChannel()
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -193,11 +193,11 @@ github.com/prometheus/common/model
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/redhat-cne/rest-api v0.1.1-0.20230103192810-2ddf00b9c9ff
+# github.com/redhat-cne/rest-api v0.1.1-0.20230119134700-82a3aab383a7
 ## explicit; go 1.17
 github.com/redhat-cne/rest-api
 github.com/redhat-cne/rest-api/pkg/localmetrics
-# github.com/redhat-cne/sdk-go v0.1.1-0.20230103161106-062a0d661405
+# github.com/redhat-cne/sdk-go v0.1.1-0.20230119124426-1ed827004687
 ## explicit; go 1.17
 github.com/redhat-cne/sdk-go/pkg/channel
 github.com/redhat-cne/sdk-go/pkg/errorhandler


### PR DESCRIPTION
Allow configurable timeout for initial amq connection.

Introduce amqp://nohup transportHost for local logging of events when amq connection is not available

Signed-off-by: Jack Ding <jackding@gmail.com>