### PR TITLE
[release-4.10] Bug OCPBUGS-4755: Amq connection configurable timeout and nohup

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -56,6 +56,7 @@ var (
 	scConfig          *common.SCConfiguration
 	metricsAddr       string
 	apiPath           = "/api/cloudNotifications/v1/"
+	amqInitTimeout    = 3 * time.Minute
 )
 
 func main() {
@@ -115,12 +116,17 @@ func main() {
 
 	pl := plugins.Handler{Path: "./plugins"}
 	// load amqp
-	_, err = pl.LoadAMQPPlugin(&wg, scConfig)
-	if err != nil {
-		log.Warnf("requires QPID router installed to function fully %s", err.Error())
+	if scConfig.AMQPHost == "amqp://nohup" {
+		log.Infof("AMQPHost is set to amqp://nohup, events are logged locally")
 		scConfig.PubSubAPI.DisableTransport()
-		wg.Add(1)
-		go ProcessInChannel(&wg, scConfig)
+	} else {
+		_, err = pl.LoadAMQPPlugin(&wg, scConfig, amqInitTimeout)
+		if err != nil {
+			log.Warnf("requires QPID router installed to function fully %s", err.Error())
+			scConfig.PubSubAPI.DisableTransport()
+			wg.Add(1)
+			go ProcessInChannel(&wg, scConfig)
+		}
 	}
 
 	// load all senders and listeners from the existing store files.

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -12,6 +12,7 @@ import (
 
 	"sync"
 	"testing"
+	"time"
 
 	main "github.com/redhat-cne/cloud-event-proxy/cmd"
 	"github.com/redhat-cne/cloud-event-proxy/pkg/plugins"
@@ -64,8 +65,9 @@ func TestSidecar_MainWithAMQP(t *testing.T) {
 	wg.Add(1)
 	go main.ProcessOutChannel(wg, scConfig)
 
-	log.Infof("loading amqp with host %s", scConfig.AMQPHost)
-	_, err = pl.LoadAMQPPlugin(wg, scConfig)
+	amqInitTimeout := 1 * time.Second
+	log.Infof("loading amqp with host %s, amqInitTimeout set to %v", scConfig.AMQPHost, amqInitTimeout)
+	_, err = pl.LoadAMQPPlugin(wg, scConfig, amqInitTimeout)
 	if err != nil {
 		t.Skipf("skipping amqp usage, test will be reading dirctly from in channel. reason: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.17.0
 	github.com/prometheus/client_golang v1.11.0
-	github.com/redhat-cne/rest-api v0.1.1-0.20221207195441-65edd30fe900
-	github.com/redhat-cne/sdk-go v0.1.1-0.20221207165558-2f5cf71ca5a1
+	github.com/redhat-cne/rest-api v0.1.1-0.20230119134742-72495ddcd73c
+	github.com/redhat-cne/sdk-go v0.1.1-0.20230119124501-91da12f31a11
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/net v0.0.0-20220225172249-27dd8689420f

--- a/go.sum
+++ b/go.sum
@@ -376,10 +376,10 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3xv4=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/redhat-cne/rest-api v0.1.1-0.20221207195441-65edd30fe900 h1:4bEVzaJbYV5XACeSYnJbVMWMTKeda7G/vFIeWZpKlsM=
-github.com/redhat-cne/rest-api v0.1.1-0.20221207195441-65edd30fe900/go.mod h1:jb56Vh/1sANSpiibGmF8HO2tqWlhVm6OUTcbWcUyG8k=
-github.com/redhat-cne/sdk-go v0.1.1-0.20221207165558-2f5cf71ca5a1 h1:WmgJy1qAPBBHjk7ckhj8I+kOPWoB+gu/p6V8W8Zn43U=
-github.com/redhat-cne/sdk-go v0.1.1-0.20221207165558-2f5cf71ca5a1/go.mod h1:1FXE/O2PhDnazeCidsAIJJ5lLaaWHBXNP5HxaJ1hf0U=
+github.com/redhat-cne/rest-api v0.1.1-0.20230119134742-72495ddcd73c h1:jDkDZILEehoJ+EepHJ6wxyC7ACcb34xYG5dzIaZod3s=
+github.com/redhat-cne/rest-api v0.1.1-0.20230119134742-72495ddcd73c/go.mod h1:PVgsU6GKVJVg6og0XgQoRknmtllHisIifk9gN7CvCmE=
+github.com/redhat-cne/sdk-go v0.1.1-0.20230119124501-91da12f31a11 h1:MVrGfgD30xcEtWPIqczhJQqXw9KxvzG9nAZI1YDjF08=
+github.com/redhat-cne/sdk-go v0.1.1-0.20230119124501-91da12f31a11/go.mod h1:1FXE/O2PhDnazeCidsAIJJ5lLaaWHBXNP5HxaJ1hf0U=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"plugin"
 	"sync"
+	"time"
 
 	"github.com/redhat-cne/cloud-event-proxy/pkg/common"
 	log "github.com/sirupsen/logrus"
@@ -32,8 +33,8 @@ type Handler struct {
 }
 
 // LoadAMQPPlugin loads amqp plugin
-func (pl Handler) LoadAMQPPlugin(wg *sync.WaitGroup, scConfig *common.SCConfiguration) (*v1amqp.AMQP, error) {
-	log.Printf("Starting AMQP server")
+func (pl Handler) LoadAMQPPlugin(wg *sync.WaitGroup, scConfig *common.SCConfiguration, amqInitTimeout time.Duration) (*v1amqp.AMQP, error) {
+	log.Printf("Starting AMQP server with amqInitTimeout set to %v", amqInitTimeout)
 	amqpPlugin, err := filepath.Glob(fmt.Sprintf("%s/amqp_plugin.so", pl.Path))
 	if err != nil {
 		log.Fatalf("cannot load amqp plugin %v\n", err)
@@ -53,12 +54,12 @@ func (pl Handler) LoadAMQPPlugin(wg *sync.WaitGroup, scConfig *common.SCConfigur
 		return nil, err
 	}
 
-	startFunc, ok := symbol.(func(wg *sync.WaitGroup, scConfig *common.SCConfiguration) (*v1amqp.AMQP, error))
+	startFunc, ok := symbol.(func(wg *sync.WaitGroup, scConfig *common.SCConfiguration, amqInitTimeout time.Duration) (*v1amqp.AMQP, error))
 	if !ok {
 		log.Fatalf("Plugin has no 'Start(*sync.WaitGroup,*common.SCConfiguration) (*v1_amqp.AMQP,error)' function")
 		return nil, fmt.Errorf("plugin has no 'start(amqpHost string, dataIn <-chan channel.DataChan, dataOut chan<- channel.DataChan, close <-chan bool) (*v1_amqp.AMQP,error)' function")
 	}
-	amqpInstance, err := startFunc(wg, scConfig)
+	amqpInstance, err := startFunc(wg, scConfig, amqInitTimeout)
 	if err != nil {
 		log.Printf("error starting amqp at %s error: %v", scConfig.AMQPHost, err)
 		return amqpInstance, err

--- a/pkg/plugins/handler_test.go
+++ b/pkg/plugins/handler_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/redhat-cne/cloud-event-proxy/pkg/common"
 	"github.com/redhat-cne/sdk-go/pkg/channel"
@@ -72,7 +73,8 @@ func TestLoadAMQPPlugin(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			pLoader = Handler{Path: tc.pgPath}
-			_, err := pLoader.LoadAMQPPlugin(wg, scConfig)
+			amqInitTimeout := 1 * time.Second
+			_, err := pLoader.LoadAMQPPlugin(wg, scConfig, amqInitTimeout)
 			if err != nil {
 				switch e := err.(type) {
 				case errorhandler.AMQPConnectionError:

--- a/plugins/amqp/amqp_plugin.go
+++ b/plugins/amqp/amqp_plugin.go
@@ -24,8 +24,8 @@ import (
 )
 
 // Start amqp  services to process events,metrics and status
-func Start(wg *sync.WaitGroup, config *common.SCConfiguration) (amqpInstance *v1amqp.AMQP, err error) { //nolint:deadcode,unused
-	if amqpInstance, err = v1amqp.GetAMQPInstance(config.AMQPHost, config.EventInCh, config.EventOutCh, config.CloseCh); err != nil {
+func Start(wg *sync.WaitGroup, config *common.SCConfiguration, amqInitTimeout time.Duration) (amqpInstance *v1amqp.AMQP, err error) { //nolint:deadcode,unused
+	if amqpInstance, err = v1amqp.GetAMQPInstance(config.AMQPHost, config.EventInCh, config.EventOutCh, config.CloseCh, amqInitTimeout); err != nil {
 		return
 	}
 	amqpInstance.Router.CancelTimeOut(2 * time.Second)

--- a/plugins/ptp_operator/ptp_operator_plugin_test.go
+++ b/plugins/ptp_operator/ptp_operator_plugin_test.go
@@ -80,8 +80,10 @@ func Test_StartWithAMQP(t *testing.T) {
 	defer cleanUP()
 	scConfig.CloseCh = make(chan struct{})
 	scConfig.PubSubAPI.EnableTransport()
-	log.Printf("loading amqp with host %s", scConfig.AMQPHost)
-	amqpInstance, err := v1amqp.GetAMQPInstance(scConfig.AMQPHost, scConfig.EventInCh, scConfig.EventOutCh, scConfig.CloseCh)
+	amqInitTimeout := 1 * time.Second
+	log.Printf("loading amqp with host %s, amqInitTimeout set to %v", scConfig.AMQPHost, amqInitTimeout)
+	amqpInstance, err := v1amqp.GetAMQPInstance(scConfig.AMQPHost, scConfig.EventInCh, scConfig.EventOutCh, scConfig.CloseCh, amqInitTimeout)
+
 	if err != nil {
 		t.Skipf("ampq.Dial(%#v): %v", amqpInstance, err)
 	}

--- a/vendor/github.com/redhat-cne/sdk-go/v1/amqp/amqp.go
+++ b/vendor/github.com/redhat-cne/sdk-go/v1/amqp/amqp.go
@@ -28,9 +28,8 @@ import (
 )
 
 var (
-	instance      *AMQP
-	retryTimeout  = 500 * time.Millisecond
-	cancelTimeout = 30 * time.Second
+	instance     *AMQP
+	retryTimeout = 500 * time.Millisecond
 )
 
 // AMQP exposes amqp api methods
@@ -39,11 +38,12 @@ type AMQP struct {
 }
 
 // GetAMQPInstance get event instance
-func GetAMQPInstance(amqpHost string, dataIn <-chan *channel.DataChan, dataOut chan<- *channel.DataChan, closeCh <-chan struct{}) (*AMQP, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), cancelTimeout)
+func GetAMQPInstance(amqpHost string, dataIn <-chan *channel.DataChan, dataOut chan<- *channel.DataChan, closeCh <-chan struct{}, amqInitTimeout time.Duration) (*AMQP, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), amqInitTimeout)
 	defer cancel()
 	var router *amqp1.Router
 	var err error
+	isFirstFail := true
 	for {
 		select {
 		case <-ctx.Done():
@@ -52,7 +52,10 @@ func GetAMQPInstance(amqpHost string, dataIn <-chan *channel.DataChan, dataOut c
 		}
 		router, err = amqp1.InitServer(amqpHost, dataIn, dataOut, closeCh)
 		if err != nil {
-			log.Info("retrying connecting to amqp.")
+			if isFirstFail {
+				log.Infof("retrying connecting to amqp every %s for %s", retryTimeout, amqInitTimeout)
+				isFirstFail = false
+			}
 			time.Sleep(retryTimeout)
 			continue
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -159,11 +159,11 @@ github.com/prometheus/common/model
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/redhat-cne/rest-api v0.1.1-0.20221207195441-65edd30fe900
+# github.com/redhat-cne/rest-api v0.1.1-0.20230119134742-72495ddcd73c
 ## explicit; go 1.17
 github.com/redhat-cne/rest-api
 github.com/redhat-cne/rest-api/pkg/localmetrics
-# github.com/redhat-cne/sdk-go v0.1.1-0.20221207165558-2f5cf71ca5a1
+# github.com/redhat-cne/sdk-go v0.1.1-0.20230119124501-91da12f31a11
 ## explicit; go 1.17
 github.com/redhat-cne/sdk-go/pkg/channel
 github.com/redhat-cne/sdk-go/pkg/errorhandler


### PR DESCRIPTION
Allow configurable timeout for initial amq connection.

Introduce amqp://nohup transportHost for local logging of events when amq connection is not available

Signed-off-by: Jack Ding <jackding@gmail.com>