### PR TITLE
BUG OCPBUGS-7826: Add multi node support for consumer to identify publishers

### DIFF
--- a/examples/manifests/consumer.yaml
+++ b/examples/manifests/consumer.yaml
@@ -41,7 +41,7 @@ spec:
             - "--store-path=/store"
             #- "--transport-host=amqp://amq-router.$(AMQP_NAMESPACE).svc.cluster.local"
             - "--transport-host=consumer-events-subscription-service.cloud-events.svc.cluster.local:9043"
-            - "--http-event-publishers=ptp-event-publisher-service.openshift-ptp.svc.cluster.local:9043"
+            - "--http-event-publishers=ptp-event-publisher-service-NODE_NAME.openshift-ptp.svc.cluster.local:9043"
             - "--api-port=8089"
           env:
             - name: AMQP_NAMESPACE

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -365,7 +365,6 @@ func APIHealthCheck(uri *types.URI, delay time.Duration) (ok bool, err error) {
 
 // HTTPTransportHealthCheck ... http transport should be ready before starting to consume events
 func HTTPTransportHealthCheck(uri *types.URI, delay time.Duration) (ok bool, err error) {
-	log.Printf("checking for http transport health\n")
 	for i := 0; i <= 5; i++ {
 		log.Infof("health check %s ", uri.String())
 		response, errResp := http.Get(uri.String())


### PR DESCRIPTION
when deploying consumer app, if NODE_NAME is used as placeholder for publisher URL , the sidecar was skipping replacement and this was resulting from identifying valid .publisher service endpoint.