### PR TITLE
OCPBUGS-7811: remove ptp process metrics when ptpcfig is  deleted

### DIFF
--- a/plugins/ptp_operator/config/config.go
+++ b/plugins/ptp_operator/config/config.go
@@ -53,6 +53,7 @@ type PtpProfile struct {
 	PtpClockThreshold *PtpClockThreshold `json:"ptpClockThreshold,omitempty"`
 	Ptp4lOpts         *string            `json:"ptp4lOpts,omitempty"`
 	Phc2sysOpts       *string            `json:"phc2sysOpts,omitempty"`
+	TS2PhcOpts        *string            `json:"ts2PhcOpts,omitempty"`
 	Ptp4lConf         *string            `json:"ptp4lConf,omitempty"`
 	Interfaces        []*string
 }
@@ -75,6 +76,8 @@ type PtpProcessOpts struct {
 	Ptp4lOpts *string `json:"Ptp4lOpts,omitempty"`
 	// Phc2Opts options are set
 	Phc2Opts *string `json:"Phc2Opts,omitempty"`
+	// TS2PhcOpts
+	TS2PhcOpts *string `json:"TS2PhcOpts,omitempty"`
 }
 
 // Ptp4lEnabled check if ptp4l is enabled
@@ -85,6 +88,11 @@ func (ptpOpts *PtpProcessOpts) Ptp4lEnabled() bool {
 // Phc2SysEnabled check if phc2sys is enabled
 func (ptpOpts *PtpProcessOpts) Phc2SysEnabled() bool {
 	return ptpOpts.Phc2Opts != nil && *ptpOpts.Phc2Opts != ""
+}
+
+// TS2PhcEnabled check if phc2sys is enabled
+func (ptpOpts *PtpProcessOpts) TS2PhcEnabled() bool {
+	return ptpOpts.TS2PhcOpts != nil && *ptpOpts.TS2PhcOpts != ""
 }
 
 // GetPTPProfileName  ... get profile name from ptpconfig
@@ -209,8 +217,9 @@ func (l *LinuxPTPConfigMapUpdate) UpdatePTPProcessOptions() {
 	l.PtpProcessOpts = make(map[string]*PtpProcessOpts)
 	for _, profile := range l.NodeProfiles {
 		l.PtpProcessOpts[*profile.Name] = &PtpProcessOpts{
-			Ptp4lOpts: profile.Ptp4lOpts,
-			Phc2Opts:  profile.Phc2sysOpts}
+			Ptp4lOpts:  profile.Ptp4lOpts,
+			Phc2Opts:   profile.Phc2sysOpts,
+			TS2PhcOpts: profile.TS2PhcOpts}
 	}
 }
 

--- a/plugins/ptp_operator/metrics/logparser.go
+++ b/plugins/ptp_operator/metrics/logparser.go
@@ -265,6 +265,7 @@ func isOffsetInRange(ptpOffset, maxOffsetThreshold, minOffsetThreshold int64) bo
 
 func parsePTPStatus(output string, fields []string) (int64, error) {
 	// ptp4l 5196819.100 ptp4l.0.config PTP_PROCESS_STOPPED:0/1
+
 	if len(fields) < 5 {
 		e := fmt.Errorf("ptp process status is not in right format %s", output)
 		log.Println(e)

--- a/plugins/ptp_operator/metrics/manager.go
+++ b/plugins/ptp_operator/metrics/manager.go
@@ -301,3 +301,8 @@ func (p *PTPEventManager) GenPTPEvent(ptpProfileName string, oStats *stats.Stats
 		oStats.SetLastOffset(ptpOffset)
 	}
 }
+
+// NodeName ...
+func (p *PTPEventManager) NodeName() string {
+	return p.nodeName
+}

--- a/plugins/ptp_operator/metrics/registry.go
+++ b/plugins/ptp_operator/metrics/registry.go
@@ -187,8 +187,11 @@ func UpdateInterfaceRoleMetrics(process, ptpInterface string, role types.PtpPort
 
 // DeleteInterfaceRoleMetrics ... delete interface role metrics
 func DeleteInterfaceRoleMetrics(process, ptpInterface string) {
-	InterfaceRole.Delete(prometheus.Labels{
-		"process": process, "node": ptpNodeName, "iface": ptpInterface})
+	if process != "" {
+		InterfaceRole.Delete(prometheus.Labels{"process": process, "iface": ptpInterface, "node": ptpNodeName})
+	} else {
+		InterfaceRole.Delete(prometheus.Labels{"iface": ptpInterface, "node": ptpNodeName})
+	}
 }
 
 // UpdateProcessStatusMetrics  -- update process status metrics
@@ -198,5 +201,27 @@ func UpdateProcessStatusMetrics(process, cfgName string, status int64) {
 	if status == PtpProcessUp {
 		ProcessReStartCount.With(prometheus.Labels{
 			"process": process, "node": ptpNodeName, "config": cfgName}).Inc()
+	}
+}
+
+// DeleteProcessStatusMetricsForConfig ...
+func DeleteProcessStatusMetricsForConfig(node string, cfgName string, process ...string) {
+	labels := prometheus.Labels{}
+	if node != "" {
+		labels["node"] = node
+	}
+	if cfgName != "" {
+		labels["config"] = cfgName
+	}
+	if len(process) == 0 {
+		ProcessStatus.Delete(labels)
+		ProcessReStartCount.Delete(labels)
+	}
+	for _, p := range process {
+		if p != "" {
+			labels["process"] = p
+			ProcessStatus.Delete(labels)
+			ProcessReStartCount.Delete(labels)
+		}
 	}
 }


### PR DESCRIPTION
This fixes retaining ptp process metrics when ptpconfig is deleted
OCPBUGS-7811 WPC GM - a new process file is created when applying a deleted gm ptpconfig