### PR TITLE
OCPBUGS-7808: Remove ptp metrics for masterclock on delete of ptpconfig

### DIFF
--- a/plugins/ptp_operator/ptp_operator_plugin.go
+++ b/plugins/ptp_operator/ptp_operator_plugin.go
@@ -350,7 +350,11 @@ func processPtp4lConfigFileUpdates() {
 					eventManager.PublishEvent(ptp.FREERUN, ptpMetrics.FreeRunOffsetValue, ClockRealTime, ptp.OsClockSyncStateChange)
 				}
 				if s, found := ptpStats[MasterClockType]; found {
-					ptpMetrics.DeletedPTPMetrics(s.OffsetSource(), ptp4lProcessName, s.Alias())
+					if s.OffsetSource() == ptp4lProcessName {
+						ptpMetrics.DeletedPTPMetrics(s.OffsetSource(), ptp4lProcessName, s.Alias())
+					} else {
+						ptpMetrics.DeletedPTPMetrics(s.OffsetSource(), ts2PhcProcessName, s.Alias())
+					}
 					masterResource := fmt.Sprintf("%s/%s", s.Alias(), MasterClockType)
 					eventManager.PublishEvent(ptp.FREERUN, ptpMetrics.FreeRunOffsetValue, masterResource, ptp.PtpStateChange)
 				}


### PR DESCRIPTION
fixes bug ts2phc state is LOCKED after the gm ptpconfig is deleted
