### PR TITLE
OCPBUGS-7974: PTP BC: an unnecessary openshift_ptp_clock_state metric is shown

### DIFF
--- a/plugins/ptp_operator/metrics/ptp4lParse.go
+++ b/plugins/ptp_operator/metrics/ptp4lParse.go
@@ -104,7 +104,7 @@ func (p *PTPEventManager) ParsePTP4l(processName, configName, profileName, outpu
 						// Send os clock sync state only if os clock is synced via phc
 						if t, ok := p.PtpConfigMapUpdates.PtpProcessOpts[profileName]; ok && t.Phc2SysEnabled() {
 							p.GenPTPEvent(profileName, ptpStats[ClockRealTime], ClockRealTime, FreeRunOffsetValue, ptp.FREERUN, ptp.OsClockSyncStateChange)
-							UpdateSyncStateMetrics(ptpStats[ClockRealTime].ProcessName(), ClockRealTime, ptp.FREERUN)
+							UpdateSyncStateMetrics(phc2sysProcessName, ClockRealTime, ptp.FREERUN)
 						} else {
 							log.Infof("phc2sys is not enabled for profile %s, skiping os clock syn state ", profileName)
 						}
@@ -145,7 +145,7 @@ func (p *PTPEventManager) ParsePTP4l(processName, configName, profileName, outpu
 				if ptpOpts, ok = p.PtpConfigMapUpdates.PtpProcessOpts[profileName]; ok && ptpOpts != nil && ptpOpts.Phc2SysEnabled() {
 					p.PublishEvent(ptp.FREERUN, ptpStats[ClockRealTime].LastOffset(), ClockRealTime, ptp.OsClockSyncStateChange)
 					ptpStats[ClockRealTime].SetLastSyncState(ptp.FREERUN)
-					UpdateSyncStateMetrics(ptpStats[ClockRealTime].ProcessName(), ClockRealTime, ptp.FREERUN)
+					UpdateSyncStateMetrics(phc2sysProcessName, ClockRealTime, ptp.FREERUN)
 				}
 				threshold := p.PtpThreshold(profileName, true)
 				go handleHoldOverState(p, ptpOpts, configName, profileName, threshold.HoldOverTimeout, MasterClockType, threshold.Close)
@@ -182,7 +182,7 @@ func handleHoldOverState(ptpManager *PTPEventManager,
 				// don't check of os clock sync state if phc2 not enabled
 				if cStats, ok := ptpStats[ClockRealTime]; ok && ptpOpts != nil && ptpOpts.Phc2SysEnabled() {
 					ptpManager.GenPTPEvent(ptpProfileName, cStats, ClockRealTime, FreeRunOffsetValue, ptp.FREERUN, ptp.OsClockSyncStateChange)
-					UpdateSyncStateMetrics(cStats.ProcessName(), ptpIFace, ptp.FREERUN)
+					UpdateSyncStateMetrics(phc2sysProcessName, ClockRealTime, ptp.FREERUN)
 				} else {
 					log.Infof("phc2sys is not enabled for profile %s, skiping os clock syn state ", ptpProfileName)
 				}

--- a/plugins/ptp_operator/metrics/registry.go
+++ b/plugins/ptp_operator/metrics/registry.go
@@ -3,6 +3,8 @@ package metrics
 import (
 	"sync"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/types"
@@ -174,6 +176,11 @@ func UpdateSyncStateMetrics(process, iface string, state ptp.SyncState) {
 		clockState = 0
 	} else if state == ptp.HOLDOVER {
 		clockState = 2
+	}
+	// prevent reporting wrong metrics
+	if iface == master && process == phc2sysProcessName {
+		log.Errorf("wrong meterics are processed, ignoring interface %s with process %s", iface, process)
+		return
 	}
 	SyncState.With(prometheus.Labels{
 		"process": process, "node": ptpNodeName, "iface": iface}).Set(clockState)


### PR DESCRIPTION
Stop reporting wrong metrics 