### PR TITLE
OCPBUGS-8714: With GM config, phc2sys clock lock state is shown as FREERUN in ptp metrics while it should be LOCKED

### DIFF
--- a/examples/simplehttp/common/httpclient.go
+++ b/examples/simplehttp/common/httpclient.go
@@ -63,6 +63,5 @@ func GetEventData(url string) (*cloudevents.Event, *cneevent.Data, error) {
 	if err = json.Unmarshal(event.Data(), &data); err != nil {
 		return nil, nil, err
 	}
-
 	return event, data, nil
 }

--- a/plugins/ptp_operator/metrics/ptp4lParse.go
+++ b/plugins/ptp_operator/metrics/ptp4lParse.go
@@ -64,7 +64,7 @@ func (p *PTPEventManager) ParsePTP4l(processName, configName, profileName, outpu
 		lastRole := ptpInterface.Role
 		ptpIFace := ptpInterface.Name
 
-		if role == types.SLAVE {
+		if role == types.SLAVE || masterOffsetSource == ts2phcProcessName {
 			// initialize
 			if _, found := ptpStats[ClockRealTime]; !found {
 				ptpStats[ClockRealTime] = stats.NewStats(configName)
@@ -72,7 +72,7 @@ func (p *PTPEventManager) ParsePTP4l(processName, configName, profileName, outpu
 			}
 			if _, found := ptpStats[master]; !found {
 				ptpStats[master] = stats.NewStats(configName)
-				ptpStats[master].SetProcessName(ptp4lProcessName)
+				ptpStats[master].SetProcessName(masterOffsetSource)
 			}
 			ptpStats[master].SetRole(role)
 		}
@@ -118,7 +118,7 @@ func (p *PTPEventManager) ParsePTP4l(processName, configName, profileName, outpu
 			// update role metrics
 			UpdateInterfaceRoleMetrics(processName, ptpIFace, role)
 		}
-		if lastRole != types.SLAVE {
+		if lastRole != types.SLAVE { //tsphc doesnt have slave port and doesnt have fault state yet
 			return // no need to go to holdover state if the Fault was not in master(slave) port
 		}
 		if _, ok := ptpStats[master]; !ok { //


### PR DESCRIPTION
Fix CLOCK_REALTIME not updated in metrics with ts2phc enabled