### PR TITLE
OCPBUGS-8249: Backport HTTP support fixes to 4.12 with nodename replaced

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"os/signal"
 	"path"
-	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -85,12 +84,9 @@ func main() {
 	prometheus.Unregister(collectors.NewGoCollector())
 
 	nodeIP := os.Getenv("NODE_IP")
-	if nodeIP != "" {
-		transportHost = strings.Replace(transportHost, "NODE_IP", nodeIP, 1)
-		log.Infof("transport host path is set to %s", transportHost)
-	}
 	nodeName := os.Getenv("NODE_NAME")
 	transportHost = common.SanitizeTransportHost(transportHost, nodeIP, nodeName)
+	eventPublishers := updateHTTPPublishers(nodeIP, nodeName, httpEventPublisher)
 
 	parsedTransportHost := &common.TransportHost{URL: transportHost}
 
@@ -142,7 +138,7 @@ func main() {
 			}
 		}
 	} else if scConfig.TransportHost.Type == common.HTTP {
-		transportEnabled = enableHTTPTransport(&wg)
+		transportEnabled = enableHTTPTransport(&wg, eventPublishers)
 	} else {
 		transportEnabled = false
 	}
@@ -344,7 +340,7 @@ func loadFromPubSubStore() {
 	}
 }
 
-func enableHTTPTransport(wg *sync.WaitGroup) bool {
+func enableHTTPTransport(wg *sync.WaitGroup, eventPublishers []string) bool {
 	log.Infof("HTTP enabled as event transport %s", scConfig.TransportHost.String())
 	var httpServer *v1http.HTTP
 	httpServer, err := pluginHandler.LoadHTTPPlugin(wg, scConfig, nil, nil)
@@ -366,28 +362,38 @@ RETRY:
 	if common.GetBoolEnv("PTP_PLUGIN") || common.GetBoolEnv("HW_PLUGIN") {
 		httpServer.RegisterPublishers(types.ParseURI(scConfig.TransportHost.URL))
 	}
-	func(addr ...string) {
-		for _, s := range addr {
-			if s == "" {
-				continue
-			}
-			th := common.TransportHost{URL: s}
-			th.ParseTransportHost()
-			if th.URI != nil {
-				s = th.URI.String()
-				th.URI.Path = path.Join(th.URI.Path, "health")
-				if ok, _ := common.HTTPTransportHealthCheck(th.URI, 2*time.Second); ok {
-					log.Infof("Registering publisher %s", s)
-					httpServer.RegisterPublishers(types.ParseURI(s))
-				} else {
-					log.Errorf("health check failed, skipping registration for %s", s)
-				}
-			} else {
-				log.Errorf("failed to parse publisher url %s", s)
-			}
+	for _, s := range eventPublishers {
+		if s == "" {
+			continue
 		}
-	}(httpEventPublisher)
+		th := common.TransportHost{URL: s}
+		th.ParseTransportHost()
+		if th.URI != nil {
+			s = th.URI.String()
+			th.URI.Path = path.Join(th.URI.Path, "health")
+			if ok, _ := common.HTTPTransportHealthCheck(th.URI, 2*time.Second); ok {
+				log.Infof("Registering publisher %s", s)
+				httpServer.RegisterPublishers(types.ParseURI(s))
+			} else {
+				log.Errorf("health check failed, skipping registration for %s", s)
+			}
+		} else {
+			log.Errorf("failed to parse publisher url %s", s)
+		}
+	}
 
-	log.Infof("following publishers are registered %s", httpEventPublisher)
+	log.Infof("following publishers are registered %s", eventPublishers)
 	return true
+}
+
+func updateHTTPPublishers(nodeIP, nodeName string, addr ...string) (httpPublishers []string) {
+	for _, s := range addr {
+		if s == "" {
+			continue
+		}
+		publisherServiceName := common.SanitizeTransportHost(s, nodeIP, nodeName)
+		httpPublishers = append(httpPublishers, publisherServiceName)
+		log.Infof("publisher endpoint updated from %s to %s", s, publisherServiceName)
+	}
+	return httpPublishers
 }

--- a/examples/consumer/main.go
+++ b/examples/consumer/main.go
@@ -25,6 +25,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/redhat-cne/cloud-event-proxy/pkg/common"
 	"github.com/redhat-cne/cloud-event-proxy/pkg/restclient"
 	"github.com/redhat-cne/sdk-go/pkg/event"
@@ -100,6 +102,7 @@ RETRY:
 	var subs []*pubsub.PubSub
 	for _, resource := range subscribeTo {
 		subs = append(subs, &pubsub.PubSub{
+			ID:       getUUID(fmt.Sprintf(resourcePrefix, nodeName, resource)).String(),
 			Resource: fmt.Sprintf(resourcePrefix, nodeName, resource),
 		})
 	}
@@ -245,4 +248,10 @@ func initSubscribers(cType ConsumerTypeEnum) map[string]string {
 		subscribeTo[mockResourceKey] = mockResource
 	}
 	return subscribeTo
+}
+
+func getUUID(s string) uuid.UUID {
+	var namespace = uuid.NameSpaceURL
+	var url = []byte(s)
+	return uuid.NewMD5(namespace, url)
 }

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -365,7 +365,6 @@ func APIHealthCheck(uri *types.URI, delay time.Duration) (ok bool, err error) {
 
 // HTTPTransportHealthCheck ... http transport should be ready before starting to consume events
 func HTTPTransportHealthCheck(uri *types.URI, delay time.Duration) (ok bool, err error) {
-	log.Printf("checking for http transport health\n")
 	for i := 0; i <= 5; i++ {
 		log.Infof("health check %s ", uri.String())
 		response, errResp := http.Get(uri.String())


### PR DESCRIPTION
fixed node name requirement for HTTP