### PR TITLE
OCPBUGS-14991: bump go version to 1.20

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.19'
+          go-version: '1.20'
       - name: tidy
         run: go mod tidy
       - name: golangci-lint
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.19'
+          go-version: '1.20'
       - name: tidy
         run: go mod tidy
       - name: Run Test Scripts

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhat-cne/cloud-event-proxy
 
-go 1.19
+go 1.20
 
 require (
 	github.com/blang/semver v3.5.1+incompatible


### PR DESCRIPTION
go builder in Dockerfile is 1.20. This commit
makes go directive in go.mod consistent with the change.