### PR TITLE
OCPBUGS-14991: Always fully build plugins with the main program

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ gha:
 	go test ./... --tags=unittests -coverprofile=cover.out
 
 docker-build: #test ## Build docker image with the manager.
-	docker build -t ${IMG} .
+	docker build --no-cache -t ${IMG} .
 
 docker-push: ## Push docker image with the manager.
 	docker push ${IMG}


### PR DESCRIPTION
This commit solves a situation when the sidecar  fails to load plugins with an error: "plugin was built with a different version of package ...".  It appears that some build artifacts were stored in docker cache and reused in future builds, causing this incompatibility. The `--no-cache` flag added to the `docker build` command is fixing the issue.

/cc @aneeshkp @nishant-parekh @jzding