### PR TITLE
fix lint errors

### DIFF
--- a/examples/simplehttp/common/server.go
+++ b/examples/simplehttp/common/server.go
@@ -55,7 +55,7 @@ func StartServer(wg *sync.WaitGroup, clientAddress string, stopHTTPServerChan ch
 	fmt.Println("Server closed - Channels")
 }
 
-func getRoot(w http.ResponseWriter, r *http.Request) {
+func getRoot(w http.ResponseWriter, _ *http.Request) {
 	io.WriteString(w, "I am groot!\n")
 }
 

--- a/examples/simplehttp/common/subscribe.go
+++ b/examples/simplehttp/common/subscribe.go
@@ -19,7 +19,7 @@ func GetResources() map[string]string {
 }
 
 // Subscribe create subscription
-func Subscribe(clientID uuid.UUID, subs []pubsub.PubSub, nodeName, publisherURL, returnEndPoint string) error {
+func Subscribe(clientID uuid.UUID, subs []pubsub.PubSub, publisherURL, returnEndPoint string) error {
 	// Post it to the address that has been specified : to target URL
 	eventSubscriber := subscriber.New(clientID)
 	//Self URL

--- a/examples/simplehttp/main.go
+++ b/examples/simplehttp/main.go
@@ -73,7 +73,7 @@ func main() {
 	// EVENT subscription and consuming
 	initResources()
 	// 1.first subscribe to all resources
-	if e := common.Subscribe(clientID, subs, nodeName, fmt.Sprintf("%s/subscription", publisherServiceName),
+	if e := common.Subscribe(clientID, subs, fmt.Sprintf("%s/subscription", publisherServiceName),
 		clientExternalEndPoint); e != nil {
 		log.Printf("error processing subscription %s", e)
 		stopHTTPServerChan <- true


### PR DESCRIPTION
This commit fixes `golangci-lint run` errors
happening due to unused function parameters

/cc @aneeshkp @nishant-parekh @jzding