### PR TITLE
OCPBUGS-17322: linuxptp-daemon pod status changes to Error and CrashLoopBackOff after a ptpconfig is loaded

### DIFF
--- a/plugins/ptp_operator/event/event.go
+++ b/plugins/ptp_operator/event/event.go
@@ -194,7 +194,9 @@ func (p *PTPEventState) DeleteAllMetrics() {
 		if d.Metric != nil {
 			// unregister metric
 			for _, v := range d.Metric {
-				v.metricGauge.Delete(prometheus.Labels{"process": d.Process, "iface": *d.IFace, "node": d.NodeName})
+				if v.metricGauge != nil && d.IFace != nil {
+					v.metricGauge.Delete(prometheus.Labels{"process": d.Process, "iface": *d.IFace, "node": d.NodeName})
+				}
 			}
 		}
 		delete(p.DependsOn, d.Process)


### PR DESCRIPTION
Fixed nil pointer check