### PR TITLE
[release-4.13] Bug OCPBUGS-26508: PTP metrics still includes metrics for old config after deleting a ptpconfig 

### DIFF
--- a/plugins/ptp_operator/ptp_operator_plugin.go
+++ b/plugins/ptp_operator/ptp_operator_plugin.go
@@ -351,7 +351,7 @@ func processPtp4lConfigFileUpdates() {
 					eventManager.PublishEvent(ptp.FREERUN, ptpMetrics.FreeRunOffsetValue, ClockRealTime, ptp.OsClockSyncStateChange)
 				}
 				if s, found := ptpStats[MasterClockType]; found {
-					if s.OffsetSource() == ptp4lProcessName {
+					if s.ProcessName() == ptp4lProcessName {
 						ptpMetrics.DeletedPTPMetrics(s.OffsetSource(), ptp4lProcessName, s.Alias())
 					} else {
 						ptpMetrics.DeletedPTPMetrics(s.OffsetSource(), ts2PhcProcessName, s.Alias())


### PR DESCRIPTION
fix metrics clean up on delete of ptp config