### PR TITLE
Add ptp ha metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,18 @@ docker-build-consumer: #test ## Build docker image with the manager.
 docker-push-consumer: ## Push docker image with the manager.
 	docker push ${CONSUMER_IMG}
 
+podman-build: #test ## Build docker image with the manager.
+	podman build --no-cache -t ${IMG} .
+
+podman-push: ## Push docker image with the manager.
+	podman push ${IMG}
+
+podman-build-consumer: #test ## Build docker image with the manager.
+	podman build -f ./examples/consumer.Dockerfile -t ${CONSUMER_IMG} .
+
+podman-push-consumer: ## Push docker image with the manager.
+	podman push ${CONSUMER_IMG}
+
 fmt: ## Go fmt your code
 	hack/gofmt.sh
 

--- a/plugins/ptp_operator/_testprofile/ptpha
+++ b/plugins/ptp_operator/_testprofile/ptpha
@@ -1,0 +1,1 @@
+[{"name":"profileHA","ptp4lOpts":"","phc2sysOpts":"-a -r -m -n 24 -N 8 -R 16","ptpSettings":{"haProfiles":"profile1,profile2"},"ptpClockThreshold":{"holdOverTimeout":30,"maxOffsetThreshold":100,"minOffsetThreshold":-100}}]

--- a/plugins/ptp_operator/stats/stats.go
+++ b/plugins/ptp_operator/stats/stats.go
@@ -131,6 +131,13 @@ func (s *Stats) reset() { //nolint:unused
 	s.sumSqr = 0
 	s.aliasName = ""
 	s.role = types.UNKNOWN
+	s.frequencyAdjustment = 0
+	s.delay = 0
+	s.clackClass = 0
+	s.configDeleted = false
+	s.processName = ""
+	s.lastOffset = 0
+	s.offsetSource = ""
 }
 
 // NewStats ... create new stats
@@ -308,6 +315,13 @@ func (ps PTPStats) New() PTPStats {
 func (ps PTPStats) SetConfigAsDeleted(state bool) {
 	for _, p := range ps {
 		p.configDeleted = state
+	}
+}
+
+// Reset ...all values to empty
+func (ps PTPStats) Reset() {
+	for _, p := range ps {
+		p.reset()
 	}
 }
 


### PR DESCRIPTION
HELP openshift_ptp_ha_profile_status 0 = INACTIVE 1 = ACTIVE 0 #  TYPE openshift_ptp_ha_profile_status gauge openshift_ptp_ha_profile_status{node="node1",process="phc2sys",profile="profile1"} 1 openshift_ptp_ha_profile_status{node="node1",process="phc2sys",profile="profile2"} 0
known issue 
1. threshold  metrics are not getting cleared when ptp ha are deleted 