### PR TITLE
Enhance Consumer Application with Periodic Publisher Health Check

### DIFF
--- a/examples/consumer.Dockerfile
+++ b/examples/consumer.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.14 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
 ENV GO111MODULE=on
 ENV CGO_ENABLED=1
 ENV COMMON_GO_ARGS=-race
@@ -9,7 +9,7 @@ COPY . .
 
 RUN hack/build-example-go.sh
 
-FROM registry.ci.openshift.org/ocp/4.14:base AS bin
+FROM registry.ci.openshift.org/ocp/4.16:base-rhel9 AS bin
 COPY --from=builder /go/src/github.com/redhat-cne/cloud-event-proxy/build/cloud-event-consumer /
 
 LABEL io.k8s.display-name="Cloud Event Proxy Sample Consumer" \

--- a/examples/manifests/consumer.yaml
+++ b/examples/manifests/consumer.yaml
@@ -25,6 +25,7 @@ spec:
             - "--local-api-addr=127.0.0.1:9089"
             - "--api-path=/api/ocloudNotifications/v1/"
             - "--api-addr=127.0.0.1:8089"
+            - "--http-event-publishers=ptp-event-publisher-service-NODE_NAME.openshift-ptp.svc.cluster.local:9043"
           env:
             - name: NODE_NAME
               valueFrom:

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -355,12 +355,10 @@ func APIHealthCheck(uri *types.URI, delay time.Duration) (ok bool, err error) {
 		if response != nil && response.StatusCode == http.StatusOK {
 			_ = response.Body.Close()
 			log.Info("rest service returned healthy status")
-			time.Sleep(delay)
 			err = nil
 			ok = true
 			return
 		}
-		response.Body.Close()
 	}
 	if err != nil {
 		err = fmt.Errorf("error connecting to rest api %s", err.Error())
@@ -380,14 +378,12 @@ func HTTPTransportHealthCheck(uri *types.URI, delay time.Duration) (ok bool, err
 			continue
 		}
 		if response != nil && response.StatusCode == http.StatusOK {
-			response.Body.Close()
+			_ = response.Body.Close()
 			log.Info("http transport returned healthy status")
-			time.Sleep(delay)
 			err = nil
 			ok = true
 			return
 		}
-		response.Body.Close()
 	}
 	if err != nil {
 		err = fmt.Errorf("error connecting to http transport %s", err.Error())


### PR DESCRIPTION
Previously, the consumer could only receive events if the producer was already running when the consumer started. This created a dependency issue, where a consumer restart was necessary if the producer was restarted or enabled after the consumer was already running.

This PR addresses this limitation by introducing a publisher health check. The consumer now performs a health check on the producer every second. This check ensures that the producer is healthy before subscribing to its events. This eliminates the need for consumer restarts due to producer restarts or enablement after consumer startup.

Benefits:
    Improved Consumer Resilience: This change enhances the consumer's robustness by making it independent of the producer's initial state.
    Simplified Management: No more consumer restarts are required solely due to producer lifecycle changes.
    Enhanced Reliability: By subscribing only to a healthy producer, the consumer avoids consuming potentially invalid or incomplete data.