### PR TITLE
[release-4.15] OCPBUGS-32305: fix missing openshift_ptp_process_status metric after initial installation

### DIFF
--- a/plugins/ptp_operator/config/config_test.go
+++ b/plugins/ptp_operator/config/config_test.go
@@ -112,7 +112,7 @@ func Test_Config(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			ptpUpdate := ptpConfig.NewLinuxPTPConfUpdate()
-			go ptpUpdate.WatchConfigMapUpdate(tc.nodeName, closeCh)
+			go ptpUpdate.WatchConfigMapUpdate(tc.nodeName, closeCh, true)
 			<-ptpUpdate.UpdateCh
 			ptpUpdate.UpdatePTPThreshold()
 			assert.Equal(t, tc.len, len(ptpUpdate.NodeProfiles))

--- a/plugins/ptp_operator/metrics/manager.go
+++ b/plugins/ptp_operator/metrics/manager.go
@@ -29,7 +29,7 @@ type PTPEventManager struct {
 	mockEvent      ptp.EventType
 	// PtpConfigMapUpdates holds ptp-configmap updated details
 	PtpConfigMapUpdates *ptpConfig.LinuxPTPConfigMapUpdate
-	// Ptp4lConfigInterfaces holds interfaces and its roles , after reading from ptp4l config files
+	// Ptp4lConfigInterfaces holds interfaces and its roles, after reading from ptp4l config files
 	Ptp4lConfigInterfaces map[types.ConfigName]*ptp4lconf.PTP4lConfig
 }
 
@@ -114,10 +114,30 @@ func (p *PTPEventManager) GetPTPConfig(configName types.ConfigName) *ptp4lconf.P
 		return p.Ptp4lConfigInterfaces[configName]
 	}
 	pc := &ptp4lconf.PTP4lConfig{
-		Name: string(configName),
+		Name:    string(configName),
+		Profile: "",
 	}
 	pc.Interfaces = []*ptp4lconf.PTPInterface{}
 	p.AddPTPConfig(configName, pc)
+	return pc
+}
+
+// GetPTPConfigDeepCopy  ... Add PtpConfigUpdate obj
+func (p *PTPEventManager) GetPTPConfigDeepCopy(configName types.ConfigName) *ptp4lconf.PTP4lConfig {
+	if _, ok := p.Ptp4lConfigInterfaces[configName]; ok && p.Ptp4lConfigInterfaces[configName] != nil {
+		pc := &ptp4lconf.PTP4lConfig{
+			Name:       p.Ptp4lConfigInterfaces[configName].Name,
+			Profile:    p.Ptp4lConfigInterfaces[configName].Profile,
+			Interfaces: []*ptp4lconf.PTPInterface{},
+		}
+		pc.Interfaces = append(pc.Interfaces, p.Ptp4lConfigInterfaces[configName].Interfaces...)
+		return pc
+	}
+	pc := &ptp4lconf.PTP4lConfig{
+		Name:    string(configName),
+		Profile: "",
+	}
+
 	return pc
 }
 

--- a/plugins/ptp_operator/metrics/metrics.go
+++ b/plugins/ptp_operator/metrics/metrics.go
@@ -102,18 +102,15 @@ func (p *PTPEventManager) ExtractMetrics(msg string) {
 	// if  is has ts2phc then it will replace it with ptp4l
 	configName = strings.Replace(configName, ts2phcProcessName, ptp4lProcessName, 1)
 	ptp4lCfg := p.GetPTPConfig(types.ConfigName(configName))
+
 	// ptp stats goes by config either ptp4l ot pch2sys
 	// master (slave) interface can be configured in ptp4l but  offset provided by ts2phc
 
 	ptpStats := p.GetStats(types.ConfigName(configName))
 	profileName := ptp4lCfg.Profile
 
-	if len(ptp4lCfg.Interfaces) == 0 { //TODO: Use PMC to update port and roles
-		log.Errorf("file watcher have not picked the files yet or ptp4l doesn't have config")
-		return
-	}
-	if profileName == "" {
-		log.Errorf("ptp4l config does not have profile name, aborting. ")
+	if !p.validLogToProcess(profileName, processName, len(ptp4lCfg.Interfaces)) {
+		log.Infof("skipped parsing %s", output)
 		return
 	}
 
@@ -319,6 +316,18 @@ func (p *PTPEventManager) processDownEvent(profileName, processName string, ptpS
 			p.GenPTPEvent(profileName, s, ClockRealTime, FreeRunOffsetValue, ptp.FREERUN, ptp.OsClockSyncStateChange)
 		}
 	}
+}
+
+func (p *PTPEventManager) validLogToProcess(profileName, processName string, iFaceSize int) bool {
+	if profileName == "" {
+		log.Info("ptp4l config does not have profile name, skipping. ")
+		return false
+	}
+	if iFaceSize == 0 { //TODO: Use PMC to update port and roles
+		log.Errorf("file watcher have not picked the files yet or ptp4l doesn't have config for %s by process %s", profileName, processName)
+		return false
+	}
+	return true
 }
 
 func getAlias(iface string) string {

--- a/plugins/ptp_operator/metrics/registry.go
+++ b/plugins/ptp_operator/metrics/registry.go
@@ -172,7 +172,7 @@ func DeletedPTPMetrics(clockType, processName, eventResourceName string) {
 		"process": processName, "node": ptpNodeName, "iface": eventResourceName})
 }
 
-// DeleteThresholdMetrics .. delete threshold metrics
+// DeleteThresholdMetrics ... delete threshold metrics
 func DeleteThresholdMetrics(profile string) {
 	Threshold.Delete(prometheus.Labels{
 		"threshold": "MinOffsetThreshold", "node": ptpNodeName, "profile": profile})

--- a/plugins/ptp_operator/ptp4lconf/ptp4lConfig.go
+++ b/plugins/ptp_operator/ptp4lconf/ptp4lConfig.go
@@ -207,7 +207,7 @@ func NewPtp4lConfigWatcher(dirToWatch string, updatedConfig chan<- *PtpConfigUpd
 							Ptp4lConf: nil,
 							Removed:   true,
 						}
-						log.Println("config removed file:", event.Name)
+						log.Infof("config removed file:%s", event.Name)
 						updatedConfig <- ptpConfig
 					}
 				}

--- a/plugins/ptp_operator/ptp_operator_plugin.go
+++ b/plugins/ptp_operator/ptp_operator_plugin.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"k8s.io/utils/pointer"
 
@@ -104,19 +105,20 @@ func Start(wg *sync.WaitGroup, configuration *common.SCConfiguration, fn func(e 
 	// create socket listener
 	go listenToSocket(wg)
 	// watch for ptp any config updates
-	go eventManager.PtpConfigMapUpdates.WatchConfigMapUpdate(nodeName, configuration.CloseCh)
-
+	go eventManager.PtpConfigMapUpdates.WatchConfigMapUpdate(nodeName, configuration.CloseCh, false)
 	// watch and monitor ptp4l config file creation and deletion
 	// create a ptpConfigDir directory watcher for config changes
-	notifyConfigDirUpdates = make(chan *ptp4lconf.PtpConfigUpdate)
+	notifyConfigDirUpdates = make(chan *ptp4lconf.PtpConfigUpdate, 20) // max 20 profiles since all files will be deleted in reapply
 	fileWatcher, err = ptp4lconf.NewPtp4lConfigWatcher(ptpConfigDir, notifyConfigDirUpdates)
 	if err != nil {
 		log.Errorf("cannot monitor ptp4l configuation folder at %s : %s", ptpConfigDir, err)
 		return err
 	}
+
 	// process ptp4l conf file updates under /var/run/ptp4l.X.conf
 	go processPtp4lConfigFileUpdates()
 
+	// Reading configmap on any updates to configmap
 	// get threshold data on change of ptp config
 	// update node profile when configmap changes
 	go func() {
@@ -124,7 +126,7 @@ func Start(wg *sync.WaitGroup, configuration *common.SCConfiguration, fn func(e 
 			select {
 			case <-eventManager.PtpConfigMapUpdates.UpdateCh:
 				log.Infof("updating ptp profile changes %d", len(eventManager.PtpConfigMapUpdates.NodeProfiles))
-				// clean up
+				// clean up when no profiles found in configmap
 				if len(eventManager.PtpConfigMapUpdates.NodeProfiles) == 0 {
 					log.Infof("Zero Profile to update: cleaning up threshold")
 					eventManager.PtpConfigMapUpdates.DeleteAllPTPThreshold()
@@ -134,9 +136,10 @@ func Start(wg *sync.WaitGroup, configuration *common.SCConfiguration, fn func(e 
 					// delete all metrics related to process
 					ptpMetrics.DeleteProcessStatusMetricsForConfig(nodeName, "", "")
 				} else {
-					// updates
+					// updates found in configmap
 					eventManager.PtpConfigMapUpdates.UpdatePTPProcessOptions()
 					eventManager.PtpConfigMapUpdates.UpdatePTPThreshold()
+					eventManager.PtpConfigMapUpdates.UpdatePTPSetting()
 					for key, np := range eventManager.PtpConfigMapUpdates.EventThreshold {
 						ptpMetrics.Threshold.With(prometheus.Labels{
 							"threshold": "MinOffsetThreshold", "node": nodeName, "profile": key}).Set(float64(np.MinOffsetThreshold))
@@ -253,8 +256,19 @@ func getCurrentStatOverrideFn() func(e v2.Event, d *channel.DataChan) error {
 	}
 }
 
-// update interface and threshold details when ptpConfig change found
+// update interface details and threshold details when ptpConfig change found.
+// These are updated when config file is created or deleted under /var/run folder
+// by linuxptp-daemon.
+// issue to resolve: linuxptp-daemon-container will read ptpconfig and update ptpConfigMap
+// the updates are incremental and file creation happens when ptpConfigMap is updated
+// NOTE: there is delay between configmap updates and file creation
+// FIRST ptpConfigMap created and then the daemon ticker when starting the process
+// creates the files or deletes the file when process is stopped
+// This routine tries to rely on file creation to detect ptp config updates
+// and on file creation call ptpConfig updates
+// on file deletion reset to read fresh ptpconfig updates
 func processPtp4lConfigFileUpdates() {
+	fileModified := false
 	for {
 		select {
 		case ptpConfigEvent := <-notifyConfigDirUpdates:
@@ -268,14 +282,19 @@ func processPtp4lConfigFileUpdates() {
 				ptpConfigFileName := ptpTypes.ConfigName(*ptpConfigEvent.Name)
 				// read all interface names from the config
 				newInterfaces := ptpConfigEvent.GetAllInterface()
+				ptp4lConfig := eventManager.GetPTPConfig(ptpConfigFileName)
 
-				if _, ok := eventManager.Ptp4lConfigInterfaces[ptpConfigFileName]; !ok { // config file name is the key here
-					eventManager.Ptp4lConfigInterfaces[ptpConfigFileName] = nil
+				if ptp4lConfig.Profile == "" {
+					ptp4lConfig.Profile = *ptpConfigEvent.Profile
+					eventManager.AddPTPConfig(ptpConfigFileName, ptp4lConfig)
 				}
+
 				// loop through to find if any interface changed
 				if eventManager.Ptp4lConfigInterfaces[ptpConfigFileName] != nil &&
 					HasEqualInterface(newInterfaces, eventManager.Ptp4lConfigInterfaces[ptpConfigFileName].Interfaces) {
 					log.Infof("skipped update,interface not changed in ptl4lconfig")
+					// add to eventManager
+					eventManager.AddPTPConfig(ptpConfigFileName, ptp4lConfig)
 					continue
 				}
 
@@ -288,8 +307,7 @@ func processPtp4lConfigFileUpdates() {
 					}
 					return false
 				}
-				// update ptp4lConfig
-				ptp4lConfig := eventManager.GetPTPConfig(ptpConfigFileName)
+
 				if ptp4lConfig != nil {
 					for _, ptpInterface := range ptp4lConfig.Interfaces {
 						if !isExists(ptpInterface.Name) {
@@ -306,13 +324,13 @@ func processPtp4lConfigFileUpdates() {
 					if p, e := ptp4lConfig.ByInterface(*ptpInterface); e == nil && p.PortID == index+1 { // maintain role
 						role = p.Role
 					} // else new config order is not same
-					ptpInterface := &ptp4lconf.PTPInterface{
+					ptpIFace := &ptp4lconf.PTPInterface{
 						Name:     *ptpInterface,
 						PortID:   index + 1,
 						PortName: fmt.Sprintf("%s%d", "port ", index+1),
 						Role:     role,
 					}
-					ptpInterfaces = append(ptpInterfaces, ptpInterface)
+					ptpInterfaces = append(ptpInterfaces, ptpIFace)
 				}
 				// updated ptp4lConfig is ready
 				ptp4lConfig = &ptp4lconf.PTP4lConfig{
@@ -339,10 +357,26 @@ func processPtp4lConfigFileUpdates() {
 							strings.Replace(cName, ptp4lProcessName, ts2PhcProcessName, 1), ts2PhcProcessName)
 					}
 				}
-			case true: // ptp4l.X.conf is deleted
+				for key, np := range eventManager.PtpConfigMapUpdates.EventThreshold {
+					ptpMetrics.Threshold.With(prometheus.Labels{
+						"threshold": "MinOffsetThreshold", "node": eventManager.NodeName(), "profile": key}).Set(float64(np.MinOffsetThreshold))
+					ptpMetrics.Threshold.With(prometheus.Labels{
+						"threshold": "MaxOffsetThreshold", "node": eventManager.NodeName(), "profile": key}).Set(float64(np.MaxOffsetThreshold))
+					ptpMetrics.Threshold.With(prometheus.Labels{
+						"threshold": "HoldOverTimeout", "node": eventManager.NodeName(), "profile": key}).Set(float64(np.HoldOverTimeout))
+				}
+			case true: // ptp4l.X.conf is deleted ; how to prevent updates happening at same time
 				// delete metrics, ptp4l config is removed
+				// get config fileName
+				fileModified = true
+				eventManager.PtpConfigMapUpdates.FileWatcherUpdateInProgress(true)
+				log.Infof("delete ptp config %s at %s", *ptpConfigEvent.Name, time.Now())
 				ptpConfigFileName := ptpTypes.ConfigName(*ptpConfigEvent.Name)
+				ptp4lConfig := eventManager.GetPTPConfig(ptpConfigFileName)
+				log.Infof("deleting config %s with profile %s\n", *ptpConfigEvent.Name, ptp4lConfig.Profile)
+
 				ptpStats := eventManager.GetStats(ptpConfigFileName)
+				// to avoid new one getting created , make a copy of this stats
 				ptpStats.SetConfigAsDeleted(true)
 				// clean up
 				if ptpConfig, ok := eventManager.Ptp4lConfigInterfaces[ptpConfigFileName]; ok {
@@ -356,6 +390,7 @@ func processPtp4lConfigFileUpdates() {
 					ptpMetrics.DeleteThresholdMetrics(ptpConfig.Profile)
 					eventManager.PtpConfigMapUpdates.DeletePTPThreshold(ptpConfig.Profile)
 				}
+
 				//  offset related metrics are reported only for clock realtime and master
 				// if ptp4l config is deleted ,  remove any metrics reported by it config
 				// for dual nic, keep the CLOCK_REALTIME,if master interface not in same config
@@ -399,6 +434,14 @@ func processPtp4lConfigFileUpdates() {
 		case <-config.CloseCh:
 			fileWatcher.Close()
 			return
+		default:
+			// decision maker before ptpConfig map updates can be processes
+			if fileModified {
+				eventManager.PtpConfigMapUpdates.FileWatcherUpdateInProgress(false)
+				eventManager.PtpConfigMapUpdates.SetAppliedNodeProfileJSON([]byte{}) // reset ptpconfig dataset and update again
+				eventManager.PtpConfigMapUpdates.PushPtpConfigMapChanges(eventManager.NodeName())
+				fileModified = false
+			}
 		}
 	}
 }

--- a/plugins/ptp_operator/stats/stats.go
+++ b/plugins/ptp_operator/stats/stats.go
@@ -131,6 +131,13 @@ func (s *Stats) reset() { //nolint:unused
 	s.sumSqr = 0
 	s.aliasName = ""
 	s.role = types.UNKNOWN
+	s.frequencyAdjustment = 0
+	s.delay = 0
+	s.clackClass = 0
+	s.configDeleted = false
+	s.processName = ""
+	s.lastOffset = 0
+	s.offsetSource = ""
 }
 
 // NewStats ... create new stats
@@ -308,6 +315,13 @@ func (ps PTPStats) New() PTPStats {
 func (ps PTPStats) SetConfigAsDeleted(state bool) {
 	for _, p := range ps {
 		p.configDeleted = state
+	}
+}
+
+// Reset ...all values to empty
+func (ps PTPStats) Reset() {
+	for _, p := range ps {
+		p.reset()
 	}
 }
 


### PR DESCRIPTION
This is a backport of https://github.com/redhat-cne/cloud-event-proxy/pull/294 and https://github.com/redhat-cne/cloud-event-proxy/pull/296 except HA related changes.