### PR TITLE
[release-4.15] OCPBUGS-35888: GNSS EVENT state is not following O-Ran spec defined values

### DIFF
--- a/plugins/ptp_operator/metrics/logparser_test.go
+++ b/plugins/ptp_operator/metrics/logparser_test.go
@@ -92,6 +92,12 @@ func Test_ParseGNSSLogs(t *testing.T) {
 		lastState, errState := ptpStats[types.IFace(tt.interfaceName)].GetStateState(tt.processName, pointer.String(tt.interfaceName))
 		assert.Equal(t, errState, nil)
 		assert.Equal(t, tt.expectedState, lastState)
+		for _, ptpStats := range ptpEventManager.Stats { // configname->PTPStats
+			for _, s := range ptpStats {
+				_, _, sync, _ := s.GetDependsOnValueState("gnss", nil, "gnss_status")
+				assert.Equal(t, tt.expectedState, sync)
+			}
+		}
 	}
 }
 

--- a/plugins/ptp_operator/stats/stats.go
+++ b/plugins/ptp_operator/stats/stats.go
@@ -245,6 +245,30 @@ func (s *Stats) GetStateState(processName string, iface *string) (ptp.SyncState,
 	return ptp.FREERUN, fmt.Errorf("sync state not found %s", processName)
 }
 
+// GetDependsOnValueState ... get value offset and state
+func (s *Stats) GetDependsOnValueState(processName string, iface *string, key string) (int64, float64, ptp.SyncState, error) {
+	if s.ptpDependentEventState != nil && s.ptpDependentEventState.DependsOn != nil {
+		if d, ok := s.ptpDependentEventState.DependsOn[processName]; ok {
+			if iface == nil && len(d) > 0 {
+				if v, ok2 := d[0].Value[key]; ok2 {
+					return v, *d[0].Offset, d[0].State, nil
+				}
+			}
+
+			if iface != nil {
+				for _, state := range d {
+					if *state.IFace == *iface {
+						if v, ok2 := state.Value[key]; ok2 {
+							return v, *state.Offset, state.State, nil
+						}
+					}
+				}
+			}
+		}
+	}
+	return 0, 99999999999, ptp.FREERUN, fmt.Errorf("value not found %s", processName)
+}
+
 // HasProcessEnabled ... check if process is enabled
 func (s *Stats) HasProcessEnabled(processName string) bool {
 	if s.ptpDependentEventState != nil && s.ptpDependentEventState.DependsOn != nil {


### PR DESCRIPTION
update GNSS sync state to send enum value as per O-Ran
The value of GPS sync State will be

SYNCHRONIZED --> gpsFix >=3
ACQUIRING_SYNC --> gpsFix=1-2 or OFFSET is not in range or GPSFIX is in sync
ANTENNA_DISCONNECTED --> gpsfix ==0
FREERUN --> This is when event not found or error
Example of cold boot 'Status | Offset | gpsfix | `

 | 2024-05-30T21:17:24Z | ANTENNA-DISCONNECTED | 2.0000146e+07 | 0 | event.sync.gnss-status.gnss-state-change    | /cluster/node/cnfdg3.ptp.eng.rdu2.dc.redhat.com/ens4fx/master/gpsFix
 
 | 2024-05-30T21:17:30Z | SYNCHRONIZED | 24 | 3 | event.sync.gnss-status.gnss-state-change       | /cluster/node/cnfdg3.ptp.eng.rdu2.dc.redhat.com/ens4fx/master/gpsFix  


{
  "id": "4fceb3e1-ea86-4024-beb8-2c39dc6ac641",
  "type": "event.sync.gnss-status.gnss-state-change",
  "source": "/cluster/node/cnfdg3.ptp.eng.rdu2.dc.redhat.com/sync/gnss-status/gnss-sync-status",
  "dataContentType": "application/json",
  "time": "2024-05-30T18:20:17.874375571Z",
  "data": {
    "version": "v1",
    "values": [
      {
        "resource": "cluster/node/node.com/ens4fx/master",
        "dataType": "notification",
        "valueType": "enumeration",
        "value": "SYNCHRONIZED"
      },
      {
        "resource": "/cluster/node/node.com/ens4fx/master",
        "dataType": "metric",
        "valueType": "decimal64.3",
        "value": "3"
      },
      {
        "resource": "/cluster/node/node.com/ens4fx/master/gpsFix",
        "dataType": "metric",
        "valueType": "decimal64.3",
        "value": "5"
      }
    ]
  }
}