### PR TITLE
[release-4.14] OCPBUGS-35889:  GNSS EVENT state is not following O-Ran spec defined values

### DIFF
--- a/plugins/ptp_operator/config/config_test.go
+++ b/plugins/ptp_operator/config/config_test.go
@@ -112,7 +112,7 @@ func Test_Config(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			ptpUpdate := ptpConfig.NewLinuxPTPConfUpdate()
-			go ptpUpdate.WatchConfigMapUpdate(tc.nodeName, closeCh)
+			go ptpUpdate.WatchConfigMapUpdate(tc.nodeName, closeCh, true)
 			<-ptpUpdate.UpdateCh
 			ptpUpdate.UpdatePTPThreshold()
 			assert.Equal(t, tc.len, len(ptpUpdate.NodeProfiles))

--- a/plugins/ptp_operator/metrics/logparser_test.go
+++ b/plugins/ptp_operator/metrics/logparser_test.go
@@ -92,6 +92,12 @@ func Test_ParseGNSSLogs(t *testing.T) {
 		lastState, errState := ptpStats[types.IFace(tt.interfaceName)].GetStateState(tt.processName, pointer.String(tt.interfaceName))
 		assert.Equal(t, errState, nil)
 		assert.Equal(t, tt.expectedState, lastState)
+		for _, ptpStats := range ptpEventManager.Stats { // configname->PTPStats
+			for _, s := range ptpStats {
+				_, _, sync, _ := s.GetDependsOnValueState("gnss", nil, "gnss_status")
+				assert.Equal(t, tt.expectedState, sync)
+			}
+		}
 	}
 }
 

--- a/plugins/ptp_operator/metrics/metrics.go
+++ b/plugins/ptp_operator/metrics/metrics.go
@@ -14,8 +14,9 @@ import (
 )
 
 var (
-	ptpConfigFileRegEx    = regexp.MustCompile(`ptp4l.[0-9]*.config`)
-	ts2phcConfigFileRegEx = regexp.MustCompile(`ts2phc.[0-9]*.config`)
+	ptpConfigFileRegEx     = regexp.MustCompile(`ptp4l.[0-9]*.config`)
+	ts2phcConfigFileRegEx  = regexp.MustCompile(`ts2phc.[0-9]*.config`)
+	phc2SysConfigFileRegEx = regexp.MustCompile(`phc2sys.[0-9]*.config`)
 	// NodeName from the env
 	ptpNodeName        = ""
 	masterOffsetSource = ""
@@ -70,6 +71,11 @@ const (
 	UNAVAILABLE float64 = 0
 	// AVAILABLE Nmea and Pps status
 	AVAILABLE float64 = 1
+
+	gnssStatus      = "gnss_status"
+	frequencyStatus = "frequency_status"
+	phaseStatus     = "phase_status"
+	ppsStatus       = "pps_status"
 )
 
 // ExtractMetrics ... extract metrics from ptp logs.
@@ -88,7 +94,7 @@ func (p *PTPEventManager) ExtractMetrics(msg string) {
 	// make sure configName is found in logs
 	index := FindInLogForCfgFileIndex(output)
 	if index == -1 {
-		log.Errorf("config name is not found in log outpt")
+		log.Errorf("config name is not found in log output %s", output)
 		return
 	}
 
@@ -99,21 +105,18 @@ func (p *PTPEventManager) ExtractMetrics(msg string) {
 
 	processName := fields[processNameIndex]
 	configName := fields[configNameIndex]
-	// if  is has ts2phc then it will replace it with ptp4l
+	// if log is having ts2phc then it will replace it with ptp4l
 	configName = strings.Replace(configName, ts2phcProcessName, ptp4lProcessName, 1)
 	ptp4lCfg := p.GetPTPConfig(types.ConfigName(configName))
+
 	// ptp stats goes by config either ptp4l ot pch2sys
 	// master (slave) interface can be configured in ptp4l but  offset provided by ts2phc
 
 	ptpStats := p.GetStats(types.ConfigName(configName))
 	profileName := ptp4lCfg.Profile
 
-	if len(ptp4lCfg.Interfaces) == 0 { //TODO: Use PMC to update port and roles
-		log.Errorf("file watcher have not picked the files yet or ptp4l doesn't have config")
-		return
-	}
-	if profileName == "" {
-		log.Errorf("ptp4l config does not have profile name, aborting. ")
+	if !p.validLogToProcess(profileName, processName, len(ptp4lCfg.Interfaces)) {
+		log.Infof("skipped parsing %s", output)
 		return
 	}
 
@@ -251,7 +254,9 @@ func (p *PTPEventManager) ExtractMetrics(msg string) {
 					// right now we are not managing os clock state based on GM state
 					p.GenPTPEvent(profileName, ptpStats[ClockRealTime], interfaceName, int64(ptpOffset), syncState, ptp.OsClockSyncStateChange)
 				}
+
 				ptpStats[ClockRealTime].SetAlias(ptpStats[master].Alias())
+
 				// continue to update metrics regardless and stick to last sync state
 				UpdateSyncStateMetrics(processName, interfaceName, ptpStats[ClockRealTime].LastSyncState())
 				UpdatePTPMetrics(offsetSource, processName, interfaceName, ptpOffset, float64(ptpStats[ClockRealTime].MaxAbs()), frequencyAdjustment, delay)
@@ -319,6 +324,19 @@ func (p *PTPEventManager) processDownEvent(profileName, processName string, ptpS
 			p.GenPTPEvent(profileName, s, ClockRealTime, FreeRunOffsetValue, ptp.FREERUN, ptp.OsClockSyncStateChange)
 		}
 	}
+}
+
+func (p *PTPEventManager) validLogToProcess(profileName, processName string, iFaceSize int) bool {
+	if profileName == "" {
+		log.Info("ptp4l config does not have profile name, skipping. ")
+		return false
+	}
+	// phc2sys config for HA will not have any interface defined
+	if iFaceSize == 0 { //TODO: Use PMC to update port and roles
+		log.Errorf("file watcher have not picked the files yet or ptp4l doesn't have config for %s by process %s", profileName, processName)
+		return false
+	}
+	return true
 }
 
 func getAlias(iface string) string {

--- a/plugins/ptp_operator/stats/stats.go
+++ b/plugins/ptp_operator/stats/stats.go
@@ -131,6 +131,13 @@ func (s *Stats) reset() { //nolint:unused
 	s.sumSqr = 0
 	s.aliasName = ""
 	s.role = types.UNKNOWN
+	s.frequencyAdjustment = 0
+	s.delay = 0
+	s.clackClass = 0
+	s.configDeleted = false
+	s.processName = ""
+	s.lastOffset = 0
+	s.offsetSource = ""
 }
 
 // NewStats ... create new stats
@@ -238,6 +245,30 @@ func (s *Stats) GetStateState(processName string, iface *string) (ptp.SyncState,
 	return ptp.FREERUN, fmt.Errorf("sync state not found %s", processName)
 }
 
+// GetDependsOnValueState ... get value offset and state
+func (s *Stats) GetDependsOnValueState(processName string, iface *string, key string) (int64, float64, ptp.SyncState, error) {
+	if s.ptpDependentEventState != nil && s.ptpDependentEventState.DependsOn != nil {
+		if d, ok := s.ptpDependentEventState.DependsOn[processName]; ok {
+			if iface == nil && len(d) > 0 {
+				if v, ok2 := d[0].Value[key]; ok2 {
+					return v, *d[0].Offset, d[0].State, nil
+				}
+			}
+
+			if iface != nil {
+				for _, state := range d {
+					if *state.IFace == *iface {
+						if v, ok2 := state.Value[key]; ok2 {
+							return v, *state.Offset, state.State, nil
+						}
+					}
+				}
+			}
+		}
+	}
+	return 0, 99999999999, ptp.FREERUN, fmt.Errorf("value not found %s", processName)
+}
+
 // HasProcessEnabled ... check if process is enabled
 func (s *Stats) HasProcessEnabled(processName string) bool {
 	if s.ptpDependentEventState != nil && s.ptpDependentEventState.DependsOn != nil {
@@ -308,6 +339,13 @@ func (ps PTPStats) New() PTPStats {
 func (ps PTPStats) SetConfigAsDeleted(state bool) {
 	for _, p := range ps {
 		p.configDeleted = state
+	}
+}
+
+// Reset ...all values to empty
+func (ps PTPStats) Reset() {
+	for _, p := range ps {
+		p.reset()
 	}
 }
 


### PR DESCRIPTION
update GNSS sync state to send enum value as per O-Ran
The value of GPS sync State will be

SYNCHRONIZED --> gpsFix >=3
ACQUIRING_SYNC --> gpsFix=1-2 or OFFSET is not in range or GPSFIX is in sync
ANTENNA_DISCONNECTED --> gpsfix ==0
FREERUN --> This is when event not found or error
Example of cold boot 'Status | Offset | gpsfix | `

 | 2024-05-30T21:17:24Z | ANTENNA-DISCONNECTED | 2.0000146e+07 | 0 | event.sync.gnss-status.gnss-state-change    | /cluster/node/cnfdg3.ptp.eng.rdu2.dc.redhat.com/ens4fx/master/gpsFix
 
 | 2024-05-30T21:17:30Z | SYNCHRONIZED | 24 | 3 | event.sync.gnss-status.gnss-state-change       | /cluster/node/cnfdg3.ptp.eng.rdu2.dc.redhat.com/ens4fx/master/gpsFix  


{
  "id": "4fceb3e1-ea86-4024-beb8-2c39dc6ac641",
  "type": "event.sync.gnss-status.gnss-state-change",
  "source": "/cluster/node/cnfdg3.ptp.eng.rdu2.dc.redhat.com/sync/gnss-status/gnss-sync-status",
  "dataContentType": "application/json",
  "time": "2024-05-30T18:20:17.874375571Z",
  "data": {
    "version": "v1",
    "values": [
      {
        "resource": "cluster/node/node.com/ens4fx/master",
        "dataType": "notification",
        "valueType": "enumeration",
        "value": "SYNCHRONIZED"
      },
      {
        "resource": "/cluster/node/node.com/ens4fx/master",
        "dataType": "metric",
        "valueType": "decimal64.3",
        "value": "3"
      },
      {
        "resource": "/cluster/node/node.com/ens4fx/master/gpsFix",
        "dataType": "metric",
        "valueType": "decimal64.3",
        "value": "5"
      }
    ]
  }
}
