### PR TITLE
OCPBUGS-35587: T-GM - ts2phc process restart doesn't update PTP syncState when the process recovered

### DIFF
--- a/plugins/ptp_operator/metrics/logparser.go
+++ b/plugins/ptp_operator/metrics/logparser.go
@@ -99,13 +99,16 @@ func extractRegularMetrics(processName, output string) (interfaceName string, pt
 	// phc2sys[4268818.286]: [ptp4l.0.config] CLOCK_REALTIME phc offset       -62 s0 freq  -78368 delay   1100
 	// phc2sys[4268818.287]: [ptp4l.0.config] ens5f1 phc offset       -92 s0 freq    -890 delay   2464   ( this is down)
 	// phc2sys[4268818.287]: [ptp4l.0.config] ens5f0 phc offset       -47 s2 freq   -2047 delay   2438
-	// ts2phc[82674.465]: [ts2phc.0.cfg] nmea delay: 88403525 ns
-	// ts2phc[82674.465]: [ts2phc.0.cfg] ens2f1 extts index 0 at 1673031129.000000000 corr 0 src 1673031129.911642976 diff 0
-	// ts2phc[82674.465]: [ts2phc.0.cfg] ens2f1 master offset          0 s2 freq      -0
+	// ts2phc[82674.465]: [ts2phc.0.config] nmea delay: 88403525 ns
+	// ts2phc[82674.465]: [ts2phc.0.config] ens2f1 extts index 0 at 1673031129.000000000 corr 0 src 1673031129.911642976 diff 0
+	// ts2phc[82674.465]: [ts2phc.0.config] ens2f1 master offset          0 s2 freq      -0
+	// ts2phc[521734.693]: [ts2phc.0.config:6] /dev/ptp6 offset          0 s2 freq      -0
 
 	// 0     1            2              3       4         5    6   7     8         9   10       11
 	//                                  1       2           3   4   5     6        7    8         9
 	// ptp4l 5196819.100 ptp4l.0.config master offset   -2162130 s2 freq +22451884 path delay    374976
+	//
+	// ts2phc 522946.693    ts2phc.0.config  ens7f0 offset          0 s2 freq      -0
 	index := FindInLogForCfgFileIndex(output)
 	if index == -1 {
 		log.Errorf("config name is not found in log output %s", output)
@@ -113,17 +116,20 @@ func extractRegularMetrics(processName, output string) (interfaceName string, pt
 	}
 
 	output = strings.Replace(output, "path", "", 1)
-	replacer := strings.NewReplacer("[", " ", "]", " ", ":", " ", "phc", "", "sys", "")
+	// ts2phc 522946.693    ts2phc.0.config  ens7f0 offset          0 s2 freq      -0
+	// careful ts2phc --> here phc will be replaced so use empty string around the text
+	replacer := strings.NewReplacer("[", " ", "]", " ", ":", " ", " phc ", " ", " sys ", " ")
 	output = replacer.Replace(output)
 
 	output = output[index:]
 	fields := strings.Fields(output)
 
-	//       0         1      2          3     4   5    6          7     8
-	// ptp4l.0.config master offset   -2162130 s2 freq +22451884  delay 374976
-	// ts2phc.0.cfg  ens2f1  master    offset          0 s2 freq      -0
-	// (ts2phc.0.cfg  master  offset      0    s2 freq     -0)
-	//       0                    1      2          3     4   5    6          7     8
+	//       0           1      2          3     4   5    6          7     8
+	// ptp4l.0.config   master offset   -2162130 s2 freq +22451884  delay 374976
+	// ts2phc.0.config  ens2f1  master    offset  0  s2   freq      -0
+	//       0           1      2          3      4     5        6
+	// ts2phc.0.config  ens7f0  offset     0     s2    freq      -0
+	//       0             1              2          3     4        5    6       7
 	// ptp4l.0.config  CLOCK_REALTIME  offset       -62 s0 freq  -78368 delay   1100
 	if len(fields) < 7 {
 		return

--- a/plugins/ptp_operator/stats/stats.go
+++ b/plugins/ptp_operator/stats/stats.go
@@ -236,7 +236,7 @@ func (s *Stats) GetStateState(processName string, iface *string) (ptp.SyncState,
 				return d[0].State, nil
 			}
 			for _, state := range d {
-				if *state.IFace == *iface {
+				if iface != nil && *state.IFace == *iface {
 					return state.State, nil
 				}
 			}


### PR DESCRIPTION
ts2phc process termination only triggers FREERUN and doesn't recover back .
This PR fixes this issue by reading process down status and handle ts2phc event 