### PR TITLE
Enable synce metrics and events 

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -36,7 +36,7 @@ linters-settings:
 
   gocyclo:
     # minimal code complexity to report, 30 by default (but we recommend 10-20)
-    min-complexity: 45
+    min-complexity: 50
   goconst:
     min-len: 3
     min-occurrences: 4

--- a/plugins/ptp_operator/config/config.go
+++ b/plugins/ptp_operator/config/config.go
@@ -82,11 +82,18 @@ type PtpProcessOpts struct {
 	Phc2Opts *string `json:"Phc2Opts,omitempty"`
 	// TS2PhcOpts
 	TS2PhcOpts *string `json:"TS2PhcOpts,omitempty"`
+	// SyncE4lOpts
+	SyncE4lOpts *string `json:"SyncE4lOpts,omitempty"`
 }
 
 // Ptp4lEnabled check if ptp4l is enabled
 func (ptpOpts *PtpProcessOpts) Ptp4lEnabled() bool {
 	return ptpOpts.Ptp4lOpts != nil && *ptpOpts.Ptp4lOpts != ""
+}
+
+// SyncE4lEnabled check if ptp4l is enabled
+func (ptpOpts *PtpProcessOpts) SyncE4lEnabled() bool {
+	return ptpOpts.SyncE4lOpts != nil && *ptpOpts.SyncE4lOpts != ""
 }
 
 // Phc2SysEnabled check if phc2sys is enabled

--- a/plugins/ptp_operator/event/event.go
+++ b/plugins/ptp_operator/event/event.go
@@ -54,10 +54,10 @@ type PTPEventState struct {
 
 // ClockState ...
 type ClockState struct {
-	State       ptp.SyncState
-	Offset      *float64
-	IFace       *string
-	Process     string //dpll //gnss
+	State       ptp.SyncState // gives over all state as LOCKED OR not
+	Offset      *float64      // for syne no offset for now until frequency offset is provided
+	IFace       *string       // could be iface gnss , sync1
+	Process     string        //dpll //gnss
 	ClockSource ClockSourceType
 	Value       map[string]int64
 	Metric      map[string]*PMetric
@@ -161,7 +161,7 @@ func (p *PTPEventState) UpdateCurrentEventState(c ClockState, metrics map[string
 			if m, hasMetric := metrics[k]; hasMetric {
 				metrics[k] = m
 				if h, hasHelpTxt := help[k]; hasHelpTxt {
-					clockState.HelpText[k] = h // expecets to have help text for value
+					clockState.HelpText[k] = h // expects to have help text for value
 				}
 			} else {
 				metrics[k] = &PMetric{

--- a/plugins/ptp_operator/metrics/logData.go
+++ b/plugins/ptp_operator/metrics/logData.go
@@ -1,0 +1,79 @@
+package metrics
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// SyncELogData ... collect synce log data
+type SyncELogData struct {
+	Process           string
+	Timestamp         int64
+	Config            string
+	Interface         string
+	Device            string
+	EECState          string
+	ClockQuality      string
+	ExtQL             byte
+	QL                byte
+	NetworkOption     int
+	State             string
+	ExtendedQlEnabled bool
+}
+
+// Parse ... synce logs
+func (s *SyncELogData) Parse(out []string) error {
+	// 0        1             2             3        4     5       6             7             8      9  10
+	// synce4l 1722456110 synce4l.0.config ens7f0 device synce1 eec_state EEC_HOLDOVER network_option 2 s1
+	// 0        1             2             3           4         5     6     7      8      9        10       11 12 13   14
+	// synce4l 1722458091 synce4l.0.config ens7f0 clock_quality PRTC device synce1 ext_ql 0x20 network_option 2 ql 0x1 s2
+
+	if len(out) < 10 {
+		return fmt.Errorf("invalid log format: not enough fields")
+	}
+	timestamp, err := strconv.ParseInt(out[1], 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid timestamp: %v", err)
+	}
+	s.Process = out[0]
+	s.Timestamp = timestamp
+	s.Config = out[2]
+	s.Interface = out[3]
+	s.NetworkOption = 0
+	s.State = out[len(out)-1]
+	s.ExtendedQlEnabled = false
+
+	for i := 4; i < len(out)-2; i += 2 {
+		switch out[i] {
+		case "eec_state":
+			s.EECState = out[i+1]
+		case "clock_quality":
+			s.ClockQuality = out[i+1]
+		case "ext_ql":
+			hexString := strings.TrimPrefix(out[i+1], "0x")
+			extQLValue, err2 := strconv.ParseUint(hexString, 16, 8) // Parse as 8-bit unsigned int
+			if err2 == nil {
+				s.ExtQL = byte(extQLValue)
+			}
+			s.ExtendedQlEnabled = true
+		case "ql":
+			hexString := strings.TrimPrefix(out[i+1], "0x")
+			qLValue, err2 := strconv.ParseUint(hexString, 16, 8) // Parse as 8-bit unsigned int
+			if err2 == nil {
+				s.QL = byte(qLValue)
+			}
+		case "device":
+			s.Device = out[i+1]
+		case "network_option":
+			networkOption, er := strconv.Atoi(out[i+1])
+			if er != nil {
+				log.Errorf("invalid network option: %v", err)
+			}
+			s.NetworkOption = networkOption
+		}
+	}
+	return nil
+}

--- a/plugins/ptp_operator/metrics/logData_test.go
+++ b/plugins/ptp_operator/metrics/logData_test.go
@@ -1,0 +1,78 @@
+package metrics_test
+
+import (
+	"testing"
+
+	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/metrics"
+)
+
+func TestSyncELogData_Parse(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []string
+		want    *metrics.SyncELogData
+		wantErr bool
+	}{
+		{
+			name:  "valid log with eec_state",
+			input: []string{"synce4l", "1722456110", "synce4l.0.config", "ens7f0", "device", "synce1", "eec_state", "EEC_HOLDOVER", "network_option", "2", "s1"},
+			want: &metrics.SyncELogData{
+				Process:       "synce4l",
+				Timestamp:     1722456110,
+				Config:        "synce4l.0.config",
+				Interface:     "ens7f0",
+				Device:        "synce1",
+				EECState:      "EEC_HOLDOVER",
+				ClockQuality:  "",
+				NetworkOption: 2,
+				State:         "s1",
+			},
+			wantErr: false,
+		},
+		{
+			name:  "valid log with clock_quality and ext_ql",
+			input: []string{"synce4l", "1722458091", "synce4l.0.config", "ens7f0", "clock_quality", "PRTC", "device", "synce1", "ext_ql", "0x20", "network_option", "2", "ql", "0x1", "s2"},
+			want: &metrics.SyncELogData{
+				Process:           "synce4l",
+				Timestamp:         1722458091,
+				Config:            "synce4l.0.config",
+				Interface:         "ens7f0",
+				Device:            "synce1",
+				EECState:          "",
+				ClockQuality:      "PRTC",
+				ExtQL:             0x20,
+				QL:                0x1,
+				NetworkOption:     2,
+				State:             "s2",
+				ExtendedQlEnabled: true,
+			},
+			wantErr: false,
+		},
+		{
+			name:    "invalid log with not enough fields",
+			input:   []string{"synce4l", "1722456110", "synce4l.0.config", "ens7f0"},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "invalid log with incorrect timestamp",
+			input:   []string{"synce4l", "invalid_timestamp", "synce4l.0.config", "ens7f0", "device", "synce1", "eec_state", "EEC_HOLDOVER", "network_option", "2", "s1"},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &metrics.SyncELogData{}
+			err := s.Parse(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SyncELogData.Parse() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && *s != *tt.want {
+				t.Errorf("SyncELogData.Parse() = %+v, want %+v", s, tt.want)
+			}
+		})
+	}
+}

--- a/plugins/ptp_operator/metrics/registry.go
+++ b/plugins/ptp_operator/metrics/registry.go
@@ -1,7 +1,10 @@
 package metrics
 
 import (
+	"strconv"
 	"sync"
+
+	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/stats"
 
 	log "github.com/sirupsen/logrus"
 
@@ -118,6 +121,25 @@ var (
 			Name:      "ha_profile_status",
 			Help:      "0 = INACTIVE 1 = ACTIVE",
 		}, []string{"process", "node", "profile"})
+
+	// SynceClockQL  metrics to show current synce Clock Qulity
+	SynceClockQL = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: ptpNamespace,
+			Subsystem: ptpSubsystem,
+			Name:      "synce_clock_quality",
+			Help:      "network_option1: ePRTC = 32 PRTC = 34 PRC =257  SSU-A = 259 SSU-B = 263 EEC1 = 266 network_option2: ePRTC = 34 PRTC = 33 PRS =256 STU = 255 ST2 = 262 TNC = 259 ST3E =268 EEC2 =265 PROV =269",
+		}, []string{"process", "node", "profile", "network_option", "iface", "device"})
+
+	// SynceQLInfo metrics to show current QL values
+	SynceQLInfo = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: ptpNamespace,
+			Subsystem: ptpSubsystem,
+			Name:      "synce_ssm_ql",
+			Help: "network_option1: ePRTC: {0, 0x2, 0x21}, PRTC:  {1, 0x2, 0x20}, PRC:   {2, 0x2, 0xFF}, SSUA:  {3, 0x4, 0xFF}, SSUB:  {4, 0x8, 0xFF}, EEC1:  {5, 0xB, 0xFF},\n " +
+				"   network_option2 ePRTC: {0, 0x1, 0x21}, PRTC:  {1, 0x1, 0x20}, PRS:   {2, 0x1, 0xFF}, STU:   {3, 0x0, 0xFF}, ST2:   {4, 0x7, 0xFF}, TNC:   {5, 0x4, 0xFF}, ST3E:  {6, 0xD, 0xFF}, EEC2:  {7, 0xA, 0xFF}, PROV:  {8, 0xE, 0xFF}",
+		}, []string{"process", "node", "profile", "network_option", "iface", "device", "ql_type"})
 )
 
 var registerMetrics sync.Once
@@ -137,6 +159,8 @@ func RegisterMetrics(nodeName string) {
 		prometheus.MustRegister(ProcessStatus)
 		prometheus.MustRegister(ProcessReStartCount)
 		prometheus.MustRegister(PTPHAMetrics)
+		prometheus.MustRegister(SynceQLInfo)
+		prometheus.MustRegister(SynceClockQL)
 
 		// Including these stats kills performance when Prometheus polls with multiple targets
 		prometheus.Unregister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
@@ -272,5 +296,34 @@ func DeleteProcessStatusMetricsForConfig(node string, cfgName string, process ..
 			ProcessStatus.Delete(labels)
 			ProcessReStartCount.Delete(labels)
 		}
+	}
+}
+
+// UpdateSyncEClockQlMetrics ... update synce clock quality metrics
+func UpdateSyncEClockQlMetrics(process, cfgName string, iface string, networkOption int, device string, value float64) {
+	SynceClockQL.With(prometheus.Labels{
+		"process": process, "node": ptpNodeName, "profile": cfgName, "network_option": strconv.Itoa(networkOption), "iface": iface, "device": device}).Set(value)
+}
+
+// UpdateSyncEQLMetrics ... update QL metrics
+func UpdateSyncEQLMetrics(process, cfgName string, iface string, networkOption int, device string, qlType string, value byte) {
+	SynceQLInfo.With(prometheus.Labels{
+		"process": process, "node": ptpNodeName, "profile": cfgName, "iface": iface,
+		"network_option": strconv.Itoa(networkOption), "device": device, "ql_type": qlType}).Set(float64(value))
+}
+
+// DeleteSyncEMetrics ... delete synce metrics
+func DeleteSyncEMetrics(process, configName string, synceStats stats.SyncEStats) {
+	for iface := range synceStats.Port {
+		SynceQLInfo.Delete(prometheus.Labels{
+			"process": process, "node": ptpNodeName, "profile": configName, "iface": iface, "device": synceStats.Name, "network_option": strconv.Itoa(synceStats.NetworkOption), "ql_type": "SSM"})
+		SynceQLInfo.Delete(prometheus.Labels{
+			"process": process, "node": ptpNodeName, "profile": configName, "iface": iface, "device": synceStats.Name, "network_option": strconv.Itoa(synceStats.NetworkOption), "ql_type": "Extended SSM"})
+
+		SynceClockQL.Delete(prometheus.Labels{
+			"process": process, "node": ptpNodeName, "profile": configName, "iface": iface, "device": synceStats.Name, "network_option": strconv.Itoa(synceStats.NetworkOption)})
+
+		SyncState.Delete(prometheus.Labels{
+			"process": process, "node": ptpNodeName, "iface": iface})
 	}
 }

--- a/plugins/ptp_operator/ptp_operator_plugin_test.go
+++ b/plugins/ptp_operator/ptp_operator_plugin_test.go
@@ -133,9 +133,9 @@ func Test_StartWithHTTP(t *testing.T) {
 
 	close(scConfig.CloseCh) // close the channel
 	pubs := scConfig.PubSubAPI.GetPublishers()
-	assert.Equal(t, 5, len(pubs))
+	assert.Equal(t, 7, len(pubs))
 	subs := scConfig.PubSubAPI.GetSubscriptions()
-	assert.Equal(t, 5, len(subs))
+	assert.Equal(t, 7, len(subs))
 }
 
 // ProcessInChannel will be  called if Transport is disabled


### PR DESCRIPTION
This PR enabled metrics and events for syncE
Metrics available 
` openshift_ptp_clock_state{iface="ens7f0",node="cnfdg33.ptp.eng.rdu2.dc.redhat.com",process="synce4l"} 1
openshift_ptp_clock_state{iface="ens7f1",node="cnfdg33.ptp.eng.rdu2.dc.redhat.com",process="synce4l"} 1
openshift_ptp_process_restart_count{config="synce4l.0.config",node="cnfdg33.ptp.eng.rdu2.dc.redhat.com",process="synce4l"} 1
openshift_ptp_process_status{config="synce4l.0.config",node="cnfdg33.ptp.eng.rdu2.dc.redhat.com",process="synce4l"} 0
HELP openshift_ptp_synce_clock_quality network_option1: ePRTC = 32 PRTC = 34 PRC =257  SSU-A = 259 SSU-B = 263 EEC1 = 266 network_option2: ePRTC = 34 PRTC = 33 PRS =256 STU = 255 ST2 = 262 TNC = 259 ST3E =268 EEC2 =265 PROV =269
TYPE openshift_ptp_synce_clock_quality gauge
openshift_ptp_synce_clock_quality{device="synce1",iface="ens7f0",network_option="2",node="cnfdg33.ptp.eng.rdu2.dc.redhat.com",process="synce4l",profile="synce4l.0.config"} 1

openshift_ptp_synce_clock_quality{device="synce1",iface="ens7f1",network_option="2",node="cnfdg33.ptp.eng.rdu2.dc.redhat.com",process="synce4l",profile="synce4l.0.config"} 1
HELP openshift_ptp_synce_ssm_ql network_option1: ePRTC: {0, 0x2, 0x21}, PRTC:  {1, 0x2, 0x20}, PRC:   {2, 0x2, 0xFF}, SSUA:  {3, 0x4, 0xFF}, SSUB:  {4, 0x8, 0xFF}, EEC1:  {5, 0xB, 0xFF},\n    network_option2 ePRTC: {0, 0x1, 0x21}, PRTC:  {1, 0x1, 0x20}, PRS:   {2, 0x1, 0xFF}, STU:   {3, 0x0, 0xFF}, ST2:   {4, 0x7, 0xFF}, TNC:   {5, 0x4, 0xFF}, ST3E:  {6, 0xD, 0xFF}, EEC2:  {7, 0xA, 0xFF}, PROV:  {8, 0xE, 0xFF}
 TYPE openshift_ptp_synce_ssm_ql gauge
openshift_ptp_synce_ssm_ql{device="synce1",iface="ens7f0",network_option="2",node="cnfdg33.ptp.eng.rdu2.dc.redhat.com",process="synce4l",profile="synce4l.0.config",ql_type="ext_ql"} 32
openshift_ptp_synce_ssm_ql{device="synce1",iface="ens7f0",network_option="2",node="cnfdg33.ptp.eng.rdu2.dc.redhat.com",process="synce4l",profile="synce4l.0.config",ql_type="ql"} 1
openshift_ptp_synce_ssm_ql{device="synce1",iface="ens7f1",network_option="2",node="cnfdg33.ptp.eng.rdu2.dc.redhat.com",process="synce4l",profile="synce4l.0.config",ql_type="ext_ql"} 32
openshift_ptp_synce_ssm_ql{device="synce1",iface="ens7f1",network_option="2",node="cnfdg33.ptp.eng.rdu2.dc.redhat.com",process="synce4l",profile="synce4l.0.config",ql_type="ql"} 1
`


Events available 

`
{    "id": "16f91fdd-9f1d-43b4-8c6b-6e9c65971c80",    "type": "event.sync.synce-status.synce-clock-quality-change",    "source": "/cluster/node/cnfdg33.ptp.eng.rdu2.dc.redhat.com/sync/synce-status/clock-quality",    "dataContentType": "application/json",    "time": "2024-08-04T03:07:57.835522753Z",    "data": {      "version": "1.0",      "values": [        {          "ResourceAddress": "/cluster/node/cnfdg33.ptp.eng.rdu2.dc.redhat.com/synce1/ens7f1/PRTC",          "data_type": "metric",          "value_type": "decimal64.3",          "value": "0"        },        {          "ResourceAddress": "/cluster/node/cnfdg33.ptp.eng.rdu2.dc.redhat.com/synce1/ens7f1/PRTC",          "data_type": "metric",          "value_type": "decimal64.3",          "value": "1"        }      ]    }  }
`
`
{    "id": "16f91fdd-9f1d-43b4-8c6b-6e9c65971c80",    "type": "event.sync.synce-status.synce-clock-quality-change",    "source": "/cluster/node/cnfdg33.ptp.eng.rdu2.dc.redhat.com/sync/synce-status/clock-quality",    "dataContentType": "application/json",    "time": "2024-08-04T03:07:57.835522753Z",    "data": {      "version": "1.0",      "values": [        {          "ResourceAddress": "/cluster/node/cnfdg33.ptp.eng.rdu2.dc.redhat.com/synce1/ens7f1/PRTC",          "data_type": "metric",          "value_type": "decimal64.3",          "value": "0"        },        {          "ResourceAddress": "/cluster/node/cnfdg33.ptp.eng.rdu2.dc.redhat.com/synce1/ens7f1/PRTC",          "data_type": "metric",          "value_type": "decimal64.3",          "value": "1"        }      ]    }  }
`
