### PR TITLE
Fix synce events for getCurrentState and regular event

### DIFF
--- a/plugins/ptp_operator/metrics/logparser_test.go
+++ b/plugins/ptp_operator/metrics/logparser_test.go
@@ -180,14 +180,14 @@ func TestParseSyncELogs(t *testing.T) {
 				ExtSource: "",
 				Port: map[string]*stats.PortState{"ens7f0": {
 					Name:               "ens7f0",
-					State:              ptp.SyncState("s2"),
+					State:              metrics.GetSyncState("s2"),
 					ClockQuality:       "PRTC",
 					QL:                 0x1,
 					ExtQL:              0x20,
 					ExtendedTvlEnabled: true,
 					LastQLState:        33,
 				}},
-				ClockState:    ptp.SyncState("s1"),
+				ClockState:    metrics.GetSyncState("s2"),
 				NetworkOption: 1,
 			},
 		},
@@ -201,14 +201,14 @@ func TestParseSyncELogs(t *testing.T) {
 				ExtSource: "",
 				Port: map[string]*stats.PortState{"ens7f0": {
 					Name:               "ens7f0",
-					State:              ptp.SyncState("s1"),
+					State:              metrics.GetSyncState("s1"),
 					ClockQuality:       "",
 					QL:                 0x1,
 					ExtQL:              0x20,
 					ExtendedTvlEnabled: true,
 					LastQLState:        33,
 				}},
-				ClockState:    ptp.SyncState("s1"),
+				ClockState:    metrics.GetSyncState("s1"),
 				NetworkOption: 1,
 			},
 		},
@@ -221,14 +221,14 @@ func TestParseSyncELogs(t *testing.T) {
 				ExtSource: "",
 				Port: map[string]*stats.PortState{"ens5f1": {
 					Name:               "ens5f1",
-					State:              ptp.SyncState("s2"),
+					State:              metrics.GetSyncState("s2"),
 					ClockQuality:       "PRTC",
 					QL:                 0x1,
 					ExtQL:              0,
 					ExtendedTvlEnabled: false,
 					LastQLState:        1,
 				}},
-				ClockState:    ptp.SyncState("s1"),
+				ClockState:    metrics.GetSyncState("s2"),
 				NetworkOption: 1,
 			},
 		},
@@ -257,6 +257,8 @@ func TestParseSyncELogs(t *testing.T) {
 					assert.Equal(t, tt.expectedStats.Port[key].ExtQL, val.ExtQL)
 					assert.Equal(t, tt.expectedStats.Port[key].QL, val.QL)
 					assert.Equal(t, tt.expectedStats.Port[key].LastQLState, val.LastQLState)
+					assert.Equal(t, tt.expectedStats.ClockState, val.State)
+					assert.Equal(t, tt.expectedStats.Port[key].State, val.State)
 				}
 			}
 		})


### PR DESCRIPTION
Synce Clock Quality event 
```
{
  "id": "13cde259-d48f-40db-aaf7-eeea07cfae14",
  "type": "event.sync.synce-status.synce-clock-quality-change",
  "source": "/cluster/node/cnfdg33.ptp.eng.rdu2.dc.redhat.com/sync/synce-status/clock-quality",
  "dataContentType": "application/json",
  "time": "2024-08-05T18:47:36.381119534Z",
  "data": {
    "version": "1.0",
    "values": [
      {
        "ResourceAddress": "/cluster/node/cnfdg33.ptp.eng.rdu2.dc.redhat.com/synce1/ens7f0/Ql",
        "data_type": "metric",
        "value_type": "decimal64.3",
        "value": "1"
      },
      {
        "ResourceAddress": "/cluster/node/cnfdg33.ptp.eng.rdu2.dc.redhat.com/synce1/ens7f0/extQl",
        "data_type": "metric",
        "value_type": "decimal64.3",
        "value": "32"
      }
    ]
  }
}
```
Synce State
```
{
  "id": "4f20e0e4-15b3-4724-b39e-2f9006d664ad",
  "type": "event.sync.synce-status.synce-state-change",
  "source": "/cluster/node/cnfdg33.ptp.eng.rdu2.dc.redhat.com/sync/synce-status/lock-state",
  "dataContentType": "application/json",
  "time": "2024-08-05T18:47:35.478384506Z",
  "data": {
    "version": "1.0",
    "values": [
      {
        "ResourceAddress": "/cluster/node/cnfdg33.ptp.eng.rdu2.dc.redhat.com/synce1/ens7f1",
        "data_type": "metric",
        "value_type": "decimal64.3",
        "value": "LOCKED"
      }
    ]
  }
}

```