### PR TITLE
OCPBUGS-35799: OCPBUGS-38284: clean up subscriptions when lost connection to consumer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.23.0
 	github.com/prometheus/client_golang v1.14.0
-	github.com/redhat-cne/rest-api v1.0.1-0.20240809152859-44062f4d695c
-	github.com/redhat-cne/sdk-go v1.0.1-0.20240809152305-d59009827df0
+	github.com/redhat-cne/rest-api v1.0.1-0.20240826142603-ec1368b90059
+	github.com/redhat-cne/sdk-go v1.0.1-0.20240826142227-273e2055e3b6
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/net v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -419,10 +419,10 @@ github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5mo=
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/redhat-cne/rest-api v1.0.1-0.20240809152859-44062f4d695c h1:Tccyj4jcRCkJ0SSbaK1GeiBfUgLN4ritHx2P+if50aA=
-github.com/redhat-cne/rest-api v1.0.1-0.20240809152859-44062f4d695c/go.mod h1:xbtv7vXk3BqgC+uCljipbFOxNVRCazQocQNLg5a1I2U=
-github.com/redhat-cne/sdk-go v1.0.1-0.20240809152305-d59009827df0 h1:1dHxOlK41SQ4OCpMk+D0vM141zLVNplLooCTLk4F/wc=
-github.com/redhat-cne/sdk-go v1.0.1-0.20240809152305-d59009827df0/go.mod h1:q9LxxPbK1tGpDbQm/KIPujqdP0bK1hhuHrIXV3vuUrM=
+github.com/redhat-cne/rest-api v1.0.1-0.20240826142603-ec1368b90059 h1:rAFTe1wWZd4DDSorW+GyAEkC4+Cs1rztWhsftUJ4ax0=
+github.com/redhat-cne/rest-api v1.0.1-0.20240826142603-ec1368b90059/go.mod h1:E58NLd+ZilyJ5sYm7OPA9h44op1JzD7HxbM96N501ds=
+github.com/redhat-cne/sdk-go v1.0.1-0.20240826142227-273e2055e3b6 h1:zj2dxxmn8eORTRSqFUWV4WQxnwhFJ8PBN0eu/odLnFI=
+github.com/redhat-cne/sdk-go v1.0.1-0.20240826142227-273e2055e3b6/go.mod h1:q9LxxPbK1tGpDbQm/KIPujqdP0bK1hhuHrIXV3vuUrM=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/pkg/storage/kubernetes/client.go
+++ b/pkg/storage/kubernetes/client.go
@@ -113,7 +113,6 @@ func (sClient *Client) UpdateConfigMap(ctx context.Context, data []subscriber.Su
 			return err
 		}
 	}
-	log.Infof("updating configmap ")
 
 	existingData := cm.Data
 	if existingData == nil {
@@ -139,12 +138,12 @@ func (sClient *Client) UpdateConfigMap(ctx context.Context, data []subscriber.Su
 	}
 
 	cm.Data = existingData
-	cm, err = sClient.clientSet.CoreV1().ConfigMaps(namespace).Update(ctx, cm, metav1.UpdateOptions{})
+	_, err = sClient.clientSet.CoreV1().ConfigMaps(namespace).Update(ctx, cm, metav1.UpdateOptions{})
 	if err != nil {
 		log.Errorf("error updating configmap %s", err.Error())
 		return err
 	}
-	log.Infof("updated configmap with %#v", cm.Data)
+	log.Info("configmap updated")
 	return nil
 }
 

--- a/vendor/github.com/redhat-cne/sdk-go/pkg/protocol/http/http.go
+++ b/vendor/github.com/redhat-cne/sdk-go/pkg/protocol/http/http.go
@@ -587,6 +587,7 @@ func (h *Server) SendTo(wg *sync.WaitGroup, clientID uuid.UUID, clientAddress, r
 				}
 				log.Errorf("connection lost addressing %s", clientAddress)
 			} else {
+				h.subscriberAPI.ResetFailCount(clientID)
 				localmetrics.UpdateEventCreatedCount(resourceAddress, localmetrics.SUCCESS, 1)
 				h.DataOut <- &channel.DataChan{
 					Address: resourceAddress,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -184,13 +184,13 @@ github.com/prometheus/common/model
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/redhat-cne/rest-api v1.0.1-0.20240809152859-44062f4d695c
+# github.com/redhat-cne/rest-api v1.0.1-0.20240826142603-ec1368b90059
 ## explicit; go 1.22
 github.com/redhat-cne/rest-api
 github.com/redhat-cne/rest-api/pkg/localmetrics
 github.com/redhat-cne/rest-api/pkg/restclient
 github.com/redhat-cne/rest-api/v2
-# github.com/redhat-cne/sdk-go v1.0.1-0.20240809152305-d59009827df0
+# github.com/redhat-cne/sdk-go v1.0.1-0.20240826142227-273e2055e3b6
 ## explicit; go 1.22
 github.com/redhat-cne/sdk-go/pkg/channel
 github.com/redhat-cne/sdk-go/pkg/common


### PR DESCRIPTION
Fixe both v1 and v2 cleanup: reset fail count when a event is successfully delivered.

Also added API support for deleting all subscriptions:
    DELETE /api/ocloudNotifications/v2/subscriptions
    
