### PR TITLE
[release-4.14] OCPBUGS-41353: implement over all sync-status

### DIFF
--- a/examples/consumer/main.go
+++ b/examples/consumer/main.go
@@ -168,7 +168,7 @@ func createSubscription(resourceAddress string) (sub pubsub.PubSub, err error) {
 	if subB, err = json.Marshal(&sub); err == nil {
 		rc := restclient.New()
 		if status, subB = rc.PostWithReturn(subURL, subB); status != http.StatusCreated {
-			err = fmt.Errorf("error subscription creation api at %s, returned status %d", subURL, status)
+			err = fmt.Errorf("api at %s returned status %d for %s", subURL, status, resourceAddress)
 		} else {
 			err = json.Unmarshal(subB, &sub)
 		}
@@ -248,6 +248,7 @@ func initSubscribers(cType ConsumerTypeEnum) map[string]string {
 		subscribeTo[string(ptpEvent.PtpClockClassChange)] = string(ptpEvent.PtpClockClass)
 		subscribeTo[string(ptpEvent.PtpStateChange)] = string(ptpEvent.PtpLockState)
 		subscribeTo[string(ptpEvent.GnssStateChange)] = string(ptpEvent.GnssSyncStatus)
+		subscribeTo[string(ptpEvent.SyncStateChange)] = string(ptpEvent.SyncStatusState)
 	case MOCK:
 		subscribeTo[mockResourceKey] = mockResource
 	case HW:

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -274,7 +274,7 @@ func CreateSubscription(config *SCConfiguration, subscription pubsub.PubSub) (su
 }
 
 // CreateEvent create an event
-func CreateEvent(pubSubID, eventType, resourceAddress string, data ceevent.Data) (ceevent.Event, error) {
+func CreateEvent(pubSubID, eventType, source string, data ceevent.Data) (ceevent.Event, error) {
 	// create an event
 	if pubSubID == "" {
 		return ceevent.Event{}, fmt.Errorf("id is a required field")
@@ -285,7 +285,7 @@ func CreateEvent(pubSubID, eventType, resourceAddress string, data ceevent.Data)
 	event := v1event.CloudNativeEvent()
 	event.ID = pubSubID
 	event.Type = eventType
-	event.SetSource(resourceAddress)
+	event.SetSource(source)
 	event.SetTime(types.Timestamp{Time: time.Now().UTC()}.Time)
 	event.SetDataContentType(ceevent.ApplicationJSON)
 	event.SetData(data)
@@ -330,7 +330,7 @@ func GetPublishingCloudEvent(scConfig *SCConfiguration, cneEvent ceevent.Event) 
 	pub, err := scConfig.PubSubAPI.GetPublisher(cneEvent.ID)
 	if err != nil {
 		localmetrics.UpdateEventPublishedCount(cneEvent.ID, localmetrics.FAIL, 1)
-		return nil, fmt.Errorf("no publisher data for id %s found to publish event for", cneEvent.ID)
+		return nil, err
 	}
 	ceEvent, err := cneEvent.NewCloudEvent(&pub)
 	if err != nil {

--- a/plugins/ptp_operator/ptp_operator_plugin_test.go
+++ b/plugins/ptp_operator/ptp_operator_plugin_test.go
@@ -194,9 +194,9 @@ func Test_StartWithOutAMQP(t *testing.T) {
 	log.Printf("Closing the channels")
 	close(scConfig.CloseCh) // close the channel
 	pubs := scConfig.PubSubAPI.GetPublishers()
-	assert.Equal(t, 4, len(pubs))
+	assert.Equal(t, 5, len(pubs))
 	subs := scConfig.PubSubAPI.GetSubscriptions()
-	assert.Equal(t, 4, len(subs))
+	assert.Equal(t, 5, len(subs))
 
 }
 
@@ -254,9 +254,9 @@ func Test_StartWithHTTP(t *testing.T) {
 
 	close(scConfig.CloseCh) // close the channel
 	pubs := scConfig.PubSubAPI.GetPublishers()
-	assert.Equal(t, 4, len(pubs))
+	assert.Equal(t, 5, len(pubs))
 	subs := scConfig.PubSubAPI.GetSubscriptions()
-	assert.Equal(t, 4, len(subs))
+	assert.Equal(t, 5, len(subs))
 }
 
 // ProcessInChannel will be  called if Transport is disabled


### PR DESCRIPTION
Implement /sync/sync-status/sync-state.
Trigger overall sync-state event when either ptp-state-change or os-clock-sync-state-change events are triggered.