### PR TITLE
OCPBUGS-41636: Maintain HOLDOVER for BC/OC when faulty interface returns until Clock is locked

### DIFF
--- a/plugins/ptp_operator/metrics/manager_test.go
+++ b/plugins/ptp_operator/metrics/manager_test.go
@@ -1,0 +1,107 @@
+package metrics_test
+
+import (
+	"testing"
+
+	ptpConfig "github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/config"
+	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/metrics"
+	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/stats"
+	"github.com/redhat-cne/sdk-go/pkg/event/ptp"
+)
+
+func TestPTPEventManager_GenPTPEvent(t *testing.T) {
+	tests := []struct {
+		name              string
+		ptpProfileName    string
+		oStats            *stats.Stats
+		eventResourceName string
+		ptpOffset         int64
+		clockState        ptp.SyncState
+		lastClockState    ptp.SyncState
+		eventType         ptp.EventType
+		mock              bool
+		wantLastSyncState ptp.SyncState
+	}{
+		{
+			name:              "locked state within threshold",
+			ptpProfileName:    "profile1",
+			oStats:            stats.NewStats("profile1"),
+			lastClockState:    ptp.LOCKED,
+			eventResourceName: "resource1",
+			ptpOffset:         100,
+			clockState:        ptp.LOCKED,
+			eventType:         ptp.PtpStateChange,
+			mock:              true,
+			wantLastSyncState: ptp.LOCKED,
+		},
+		{
+			name:              "freerun state outside threshold",
+			ptpProfileName:    "profile2",
+			oStats:            stats.NewStats("profile2"),
+			eventResourceName: "resource2",
+			ptpOffset:         1000,
+			clockState:        ptp.FREERUN,
+			lastClockState:    ptp.LOCKED,
+			eventType:         ptp.PtpStateChange,
+			mock:              true,
+			wantLastSyncState: ptp.FREERUN,
+		},
+		{
+			name:              "freerun to Locked state",
+			ptpProfileName:    "profile1",
+			oStats:            stats.NewStats("profile1"),
+			lastClockState:    ptp.FREERUN,
+			eventResourceName: "resource1",
+			ptpOffset:         100,
+			clockState:        ptp.LOCKED,
+			eventType:         ptp.PtpStateChange,
+			mock:              true,
+			wantLastSyncState: ptp.LOCKED,
+		},
+		{
+			name:              "holdover to holdover state",
+			ptpProfileName:    "profile3",
+			oStats:            stats.NewStats("profile3"),
+			eventResourceName: "resource3",
+			ptpOffset:         500,
+			lastClockState:    ptp.HOLDOVER,
+			clockState:        ptp.FREERUN,
+			eventType:         ptp.PtpStateChange,
+			mock:              true,
+			wantLastSyncState: ptp.HOLDOVER,
+		},
+		{
+			name:              "holdover to locked state",
+			ptpProfileName:    "profile3",
+			oStats:            stats.NewStats("profile3"),
+			eventResourceName: "resource3",
+			ptpOffset:         50,
+			lastClockState:    ptp.HOLDOVER,
+			clockState:        ptp.LOCKED,
+			eventType:         ptp.PtpStateChange,
+			mock:              true,
+			wantLastSyncState: ptp.LOCKED,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.oStats.SetLastSyncState(tt.lastClockState)
+			p := &metrics.PTPEventManager{
+				PtpConfigMapUpdates: &ptpConfig.LinuxPTPConfigMapUpdate{
+					EventThreshold: map[string]*ptpConfig.PtpClockThreshold{
+						tt.ptpProfileName: {
+							MaxOffsetThreshold: 500,
+							MinOffsetThreshold: 10,
+						},
+					},
+				},
+			}
+			p.MockTest(tt.mock)
+			p.GenPTPEvent(tt.ptpProfileName, tt.oStats, tt.eventResourceName, tt.ptpOffset, tt.clockState, tt.eventType)
+			if got := tt.oStats.LastSyncState(); got != tt.wantLastSyncState {
+				t.Errorf("GenPTPEvent() = %v, want %v", got, tt.wantLastSyncState)
+			}
+		})
+	}
+}

--- a/plugins/ptp_operator/metrics/metrics_test.go
+++ b/plugins/ptp_operator/metrics/metrics_test.go
@@ -280,6 +280,7 @@ var testCases = []TestCase{
 		expectedNmeaStatus:             SKIP,
 		expectedPpsStatus:              SKIP,
 		expectedClockClassMetrics:      SKIP,
+		expectedEvent:                  ptp.PtpStateChange,
 	},
 	{
 		log:                            "gnss[1000000500]:[ts2phc.0.config] ens2f1 gnss_status 3 offset 5 s2",
@@ -341,6 +342,7 @@ var testCases = []TestCase{
 		expectedNmeaStatus:             SKIP,
 		expectedPpsStatus:              SKIP,
 		expectedClockClassMetrics:      SKIP,
+		expectedEvent:                  ptp.OsClockSyncStateChange,
 	},
 	{
 		log:                            "phc2sys[1000000710]: [ptp4l.0.config] CLOCK_REALTIME phc offset       -62 s0 freq  -78368 delay   1100",


### PR DESCRIPTION
This PR introduces a change to the Boundary Clock (BC) and Ordinary Clock (OC) behavior, ensuring that the system remains in the HOLDOVER state when a previously faulty interface becomes operational again. The holdover state will persist until the PTP synchronization state is detected as LOCKED or until the holdover duration times out.

Key Changes:

 Added logic to maintain the HOLDOVER state after a faulty interface recovers, preventing premature exit from holdover.

    HOLDOVER will remain active until either:

-          The PTP sync state transitions to LOCKED.

-         The holdover timer reaches its limit and times out.

    Ensured this behavior applies to both BC and OC configurations.

Purpose:

This change helps to maintain clock stability by ensuring that the system does not exit the holdover state prematurely, potentially leading to timing inaccuracies during the recovery process. The clock will only transition out of holdover once it has re-locked  or holdover timeout ( in this case state to freerun ) , ensuring precise time synchronization.
This PR will help when Holdover is correctly implemented  for Boundary Clock and Ordinary Clock 