### PR TITLE
OCPBUGS-42840: cleanup configmap when event apiVersion change

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -139,7 +139,7 @@ func main() {
 	}
 	if namespace != "" && nodeName != "" && scConfig.TransportHost.Type == common.HTTP {
 		// if consumer doesn't pass namespace then this will default to empty dir
-		if e := client.InitConfigMap(scConfig.StorePath, nodeName, namespace); e != nil {
+		if e := client.InitConfigMap(scConfig.APIVersion, scConfig.StorePath, nodeName, namespace); e != nil {
 			log.Errorf("failed to initlialize configmap, subcription will be stored in empty dir %s", e.Error())
 		} else {
 			scConfig.StorageType = storageClient.ConfigMap

--- a/pkg/storage/kubernetes/client_test.go
+++ b/pkg/storage/kubernetes/client_test.go
@@ -40,7 +40,7 @@ func Subscriptions() *v1.ConfigMap {
 
 func TestClient_InitConfigMap(t *testing.T) {
 	setupClient()
-	err := clients.InitConfigMap(".", nodeName, metav1.NamespaceSystem)
+	err := clients.InitConfigMap("1.0", ".", nodeName, metav1.NamespaceSystem)
 	assert.Nil(t, err)
 	cm, e := clients.GetConfigMap(context.Background(), nodeName, metav1.NamespaceSystem)
 	assert.Nil(t, e)
@@ -49,7 +49,7 @@ func TestClient_InitConfigMap(t *testing.T) {
 
 func TestClient_GetConfigMap(t *testing.T) {
 	setupClient()
-	err := clients.InitConfigMap(".", nodeName, metav1.NamespaceSystem)
+	err := clients.InitConfigMap("1.0", ".", nodeName, metav1.NamespaceSystem)
 	assert.Nil(t, err)
 	cm, e := clients.GetConfigMap(context.Background(), nodeName, metav1.NamespaceSystem)
 	assert.Nil(t, e)
@@ -59,7 +59,7 @@ func TestClient_GetConfigMap(t *testing.T) {
 
 func Test_LoadingSubscriptionFromFileToCache(t *testing.T) {
 	setupClient()
-	err := clients.InitConfigMap(".", nodeName, metav1.NamespaceSystem)
+	err := clients.InitConfigMap("1.0", ".", nodeName, metav1.NamespaceSystem)
 	assert.Nil(t, err)
 	cm, e := clients.GetConfigMap(context.Background(), nodeName, metav1.NamespaceSystem)
 	assert.Nil(t, e)


### PR DESCRIPTION
Tests done:

1. deploy ptp-operator, update ptpoperatorconfig to enable v1 event
2. deploy v1 consumer => verify configmap and events
3. update update ptpoperatorconfig to enable v2 event => verify configmap cleaned up
4. undeploy v1 consumer and deploy v2 consumer => verify configmap and events
5. reboot linuxptp-daemon pod => verify configmap and events
6. reboot consumer => verify configmap and events
7. reboot linuxptp-daemon pod again => verify configmap and events
8. update ptpoperatorconfig to enable v1 event => verify configmap cleaned up
9. undeploy v2 consumer and deploy v1 consumer => verify configmap and events
10. reboot linuxptp-daemon pod => verify configmap and events
