### PR TITLE
OCPBUGS-44208: Fix Holdover Event Triggering for T-GM and Minimize Redundant Clock Class Events:

### DIFF
--- a/plugins/ptp_operator/metrics/manager_test.go
+++ b/plugins/ptp_operator/metrics/manager_test.go
@@ -1,3 +1,6 @@
+//go:build unittests
+// +build unittests
+
 package metrics_test
 
 import (
@@ -65,7 +68,7 @@ func TestPTPEventManager_GenPTPEvent(t *testing.T) {
 			eventResourceName: "resource3",
 			ptpOffset:         500,
 			lastClockState:    ptp.HOLDOVER,
-			clockState:        ptp.FREERUN,
+			clockState:        ptp.FREERUN, // stays in HOLDOVER until times out
 			eventType:         ptp.PtpStateChange,
 			mock:              true,
 			wantLastSyncState: ptp.HOLDOVER,
@@ -81,6 +84,30 @@ func TestPTPEventManager_GenPTPEvent(t *testing.T) {
 			eventType:         ptp.PtpStateChange,
 			mock:              true,
 			wantLastSyncState: ptp.LOCKED,
+		},
+		{
+			name:              "holdover to locked state",
+			ptpProfileName:    "T-GM",
+			oStats:            stats.NewStats("T-GM"),
+			eventResourceName: "resource3",
+			ptpOffset:         50,
+			lastClockState:    ptp.LOCKED,
+			clockState:        ptp.HOLDOVER,
+			eventType:         ptp.PtpStateChange,
+			mock:              true,
+			wantLastSyncState: ptp.HOLDOVER,
+		},
+		{
+			name:              "holdover to locked state",
+			ptpProfileName:    "T-GM",
+			oStats:            stats.NewStats("T-GM"),
+			eventResourceName: "resource3",
+			ptpOffset:         50,
+			lastClockState:    ptp.HOLDOVER,
+			clockState:        ptp.HOLDOVER,
+			eventType:         ptp.PtpStateChange,
+			mock:              true,
+			wantLastSyncState: ptp.HOLDOVER,
 		},
 	}
 

--- a/plugins/ptp_operator/metrics/ptp4lParse.go
+++ b/plugins/ptp_operator/metrics/ptp4lParse.go
@@ -43,11 +43,13 @@ func (p *PTPEventManager) ParsePTP4l(processName, configName, profileName, outpu
 				alias, _ = ptp4lCfg.GetUnknownAlias()
 			}
 			masterResource := fmt.Sprintf("%s/%s", alias, MasterClockType)
-			ptpStats[master].SetClockClass(int64(clockClass))
+
 			ClockClassMetrics.With(prometheus.Labels{
 				"process": processName, "node": ptpNodeName}).Set(clockClass)
-
-			p.PublishClockClassEvent(clockClass, masterResource, ptp.PtpClockClassChange)
+			if ptpStats[master].ClockClass() != int64(clockClass) {
+				ptpStats[master].SetClockClass(int64(clockClass))
+				p.PublishClockClassEvent(clockClass, masterResource, ptp.PtpClockClassChange)
+			}
 		}
 	} else if strings.Contains(output, " port ") {
 		portID, role, syncState := extractPTP4lEventState(output)


### PR DESCRIPTION
This PR addresses two issues:

1.  Fix Holdover Event Triggering for T-GM :
        Issue: When the T-GM (Telecom Grandmaster) entered holdover mode, the associated events were not generated, although metrics were successfully created.
        Resolution: This PR ensures that event generation is correctly triggered for the holdover state, aligning events with the metrics generated.

2. Eliminate Duplicate Clock Class Events:
        Issue: Multiple events were being generated for the same clock class value, causing redundancy.
        Resolution: Duplicate events for the same clock class value have been removed, streamlining event reporting and reducing noise.