### PR TITLE
Enabled gosec and fixed security issue

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -33,7 +33,6 @@ linters-settings:
         # Whether to be strict about shadowing; can be noisy.
         # Default: false
         strict: true
-
   gocyclo:
     # minimal code complexity to report, 30 by default (but we recommend 10-20)
     min-complexity: 50
@@ -48,7 +47,14 @@ linters-settings:
       - const
       - var
       - func
-
+  revive:
+    rules:
+      - name: dot-imports
+        arguments:
+          - allowedPackages:
+              - "github.com/onsi/ginkgo"
+              - "github.com/onsi/ginkgo/v2"
+              - "github.com/onsi/gomega"
 linters:
   disable-all: true
   enable: # NOTE: please keep this list alphabetically sorted

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ build-examples:
 	go build -o ./build/cloud-event-consumer ./examples/consumer/main.go
 
 lint:
-	golangci-lint run
+	golangci-lint --enable gosec run
 
 build-plugins:
 	go build -a -o plugins/ptp_operator_plugin.so -buildmode=plugin plugins/ptp_operator/ptp_operator_plugin.go

--- a/pkg/storage/kubernetes/client.go
+++ b/pkg/storage/kubernetes/client.go
@@ -124,21 +124,20 @@ func (sClient *Client) UpdateConfigMap(ctx context.Context, data []subscriber.Su
 		existingData = make(map[string]string)
 	}
 
-	for _, d := range data {
-		if d.Action == channel.DELETE {
-			delete(existingData, d.ClientID.String())
+	for i := 0; i < len(data); i++ {
+		if data[i].Action == channel.DELETE {
+			delete(existingData, data[i].ClientID.String())
 		} else {
 			// Marshal back to json (as original)
 			var out []byte
 			var e error
-			if out, e = json.MarshalIndent(&d, "", " "); e != nil {
+			if out, e = json.MarshalIndent(&data[i], "", " "); e != nil {
 				log.Errorf("error marshalling subscriber %s", e.Error())
 				continue
 			}
 			log.Infof("persisting following contents %s ", string(out))
-
 			log.Infof("updating new subscriber in configmap")
-			existingData[d.ClientID.String()] = string(out)
+			existingData[data[i].ClientID.String()] = string(out)
 		}
 	}
 
@@ -166,7 +165,7 @@ func (sClient *Client) InitConfigMap(apiVersion, storePath, nodeName, namespace 
 				if subscriberErr == nil {
 					filePath := fmt.Sprintf("%s/%s", storePath, fmt.Sprintf("%s.json", clientID))
 					log.Infof("persisting following contents %s to a file %s\n", string(newSubscriberBytes), filePath)
-					if subscriberErr = os.WriteFile(filePath, newSubscriberBytes, 0666); subscriberErr != nil {
+					if subscriberErr = os.WriteFile(filePath, newSubscriberBytes, 0600); subscriberErr != nil {
 						log.Errorf("error writing subscription to a file %s", subscriberErr.Error())
 					}
 				} else {

--- a/plugins/ptp_operator/config/config.go
+++ b/plugins/ptp_operator/config/config.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"sync"
 	"time"
 
@@ -415,6 +416,11 @@ func (l *LinuxPTPConfigMapUpdate) updatePtpConfig(nodeName string) (updated bool
 			return
 		}
 		log.Errorf("error finding node profile %v: %v", nodeName, err)
+		return
+	}
+	nodeProfile = filepath.Clean(nodeProfile)
+	if !strings.HasPrefix(nodeProfile, l.profilePath) {
+		log.Errorf("reading nodeProfile %s from unknon path ", nodeProfile)
 		return
 	}
 	nodeProfilesJSON, err := os.ReadFile(nodeProfile)

--- a/plugins/ptp_operator/config/config_test.go
+++ b/plugins/ptp_operator/config/config_test.go
@@ -125,8 +125,8 @@ func Test_Config(t *testing.T) {
 	}
 
 	closeCh := make(chan struct{})
-	os.Setenv("PTP_PROFILE_PATH", "../_testprofile")
-	os.Setenv("CONFIG_UPDATE_INTERVAL", "1")
+	_ = os.Setenv("PTP_PROFILE_PATH", "../_testprofile")
+	_ = os.Setenv("CONFIG_UPDATE_INTERVAL", "1")
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			ptpUpdate := ptpConfig.NewLinuxPTPConfUpdate()

--- a/plugins/ptp_operator/ptp4lconf/ptp4lConfig.go
+++ b/plugins/ptp_operator/ptp4lconf/ptp4lConfig.go
@@ -37,6 +37,7 @@ var (
 
 const (
 	ptp4lGlobalSection = "global"
+	ptpConfigDir       = "/var/run/"
 )
 
 // PtpConfigUpdate ...  updated ptp config values
@@ -243,6 +244,11 @@ func readAllConfig(dir string) []*PtpConfigUpdate {
 }
 func readConfig(path string) (*PtpConfigUpdate, error) {
 	fName := filename(path)
+	path = filepath.Clean(path)
+	if !strings.HasPrefix(path, ptpConfigDir) {
+		log.Errorf("reading ptpconfig %s from unknon path ", path)
+		return nil, fmt.Errorf("reading ptpconfig %s from unknon path ", path)
+	}
 	b, err := os.ReadFile(path)
 	if err != nil {
 		log.Errorf("error reading ptpconfig %s error %s", path, err)


### PR DESCRIPTION
Enabled gosec and fixed three sec issues

1. Linter: gosec, Rule: G306 - Poor file permissions used 
[Key file permissions are not correct, should be 600 or 660]
3. G304: Potential file inclusion via variable
4. Use of net/http serve function that has no support for setting timeouts (gosec) err := http.ListenAndServe(address, mux)