### PR TITLE
OCPBUGS-44954: PTP operator Event Notification API breaking change within 4.16 release

### DIFF
--- a/examples/consumer/main.go
+++ b/examples/consumer/main.go
@@ -109,7 +109,7 @@ func main() {
 		log.Infof("apiVersion=%s, updated apiAddr=%s, apiPath=%s", apiVersion, apiAddr, apiPath)
 	}
 
-	subscribeTo := initSubscribers(consumerType)
+	subscribeTo := initSubscribers(consumerType, isV1Api)
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go server() // spin local api
@@ -329,12 +329,15 @@ func processEventV2(data []byte) error {
 	return nil
 }
 
-func initSubscribers(cType ConsumerTypeEnum) map[string]string {
+func initSubscribers(cType ConsumerTypeEnum, v1Api bool) map[string]string {
 	subscribeTo := make(map[string]string)
 	switch cType {
 	case PTP:
 		subscribeTo[string(ptpEvent.OsClockSyncStateChange)] = string(ptpEvent.OsClockSyncState)
 		subscribeTo[string(ptpEvent.PtpClockClassChange)] = string(ptpEvent.PtpClockClass)
+		if v1Api {
+			subscribeTo[string(ptpEvent.PtpClockClassChange)] = string(ptpEvent.PtpClockClassV1)
+		}
 		subscribeTo[string(ptpEvent.PtpStateChange)] = string(ptpEvent.PtpLockState)
 		subscribeTo[string(ptpEvent.GnssStateChange)] = string(ptpEvent.GnssSyncStatus)
 		subscribeTo[string(ptpEvent.SyncStateChange)] = string(ptpEvent.SyncStatusState)

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/onsi/gomega v1.23.0
 	github.com/prometheus/client_golang v1.14.0
 	github.com/redhat-cne/rest-api v1.22.0
-	github.com/redhat-cne/sdk-go v1.22.0
+	github.com/redhat-cne/sdk-go v1.22.1
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/net v0.23.0

--- a/go.sum
+++ b/go.sum
@@ -421,8 +421,8 @@ github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0ua
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/redhat-cne/rest-api v1.22.0 h1:A0IbrLi07eYteFGimhmrOHVD6q1wk3kPKpG4oVAenrk=
 github.com/redhat-cne/rest-api v1.22.0/go.mod h1:9Bb+edIo4zJ3/QUwgTWlwP/ZBbtGExxhnAzzLkQLtEA=
-github.com/redhat-cne/sdk-go v1.22.0 h1:oAfCu9jjXLn3/aXASuccZCX1Vlz9iIV9pmuO4vy4dSk=
-github.com/redhat-cne/sdk-go v1.22.0/go.mod h1:qeir05dwTscLvqGCIoQPCUM6HUoVmhR7521nXn28utA=
+github.com/redhat-cne/sdk-go v1.22.1 h1:g5Kuyu92bwEmrjrapK12HvNxzZym+PMh6YhQ0463znw=
+github.com/redhat-cne/sdk-go v1.22.1/go.mod h1:qeir05dwTscLvqGCIoQPCUM6HUoVmhR7521nXn28utA=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/plugins/ptp_operator/ptp_operator_plugin.go
+++ b/plugins/ptp_operator/ptp_operator_plugin.go
@@ -83,7 +83,7 @@ func Start(wg *sync.WaitGroup, configuration *common.SCConfiguration, _ func(e i
 	config = configuration
 	// register metrics type
 	ptpMetrics.RegisterMetrics(nodeName)
-	publishers = InitPubSubTypes()
+	publishers = InitPubSubTypes(config)
 
 	// 1. Create event Publication
 	var err error
@@ -201,6 +201,9 @@ func getCurrentStatOverrideFn() func(e v2.Event, d *channel.DataChan) error {
 		} else if strings.Contains(e.Source(), string(ptp.PtpClockClass)) {
 			eventType = ptp.PtpClockClassChange
 			eventSource = ptp.PtpClockClass
+		} else if strings.Contains(e.Source(), string(ptp.PtpClockClassV1)) {
+			eventType = ptp.PtpClockClassChange
+			eventSource = ptp.PtpClockClassV1
 		} else if strings.Contains(e.Source(), string(ptp.GnssSyncStatus)) {
 			eventType = ptp.GnssStateChange
 			eventSource = ptp.GnssSyncStatus
@@ -633,7 +636,7 @@ func HasEqualInterface(a []*string, b []*ptp4lconf.PTPInterface) bool {
 }
 
 // InitPubSubTypes ... initialize types of publishers for ptp operator
-func InitPubSubTypes() map[ptp.EventType]*ptpTypes.EventPublisherType {
+func InitPubSubTypes(scConfig *common.SCConfiguration) map[ptp.EventType]*ptpTypes.EventPublisherType {
 	InitPubs := make(map[ptp.EventType]*ptpTypes.EventPublisherType)
 	InitPubs[ptp.SyncStateChange] = &ptpTypes.EventPublisherType{
 		EventType: ptp.SyncStateChange,
@@ -643,9 +646,16 @@ func InitPubSubTypes() map[ptp.EventType]*ptpTypes.EventPublisherType {
 		EventType: ptp.OsClockSyncStateChange,
 		Resource:  ptp.OsClockSyncState,
 	}
-	InitPubs[ptp.PtpClockClassChange] = &ptpTypes.EventPublisherType{
-		EventType: ptp.PtpClockClassChange,
-		Resource:  ptp.PtpClockClass,
+	if !common.IsV1Api(scConfig.APIVersion) {
+		InitPubs[ptp.PtpClockClassChange] = &ptpTypes.EventPublisherType{
+			EventType: ptp.PtpClockClassChange,
+			Resource:  ptp.PtpClockClass,
+		}
+	} else {
+		InitPubs[ptp.PtpClockClassChange] = &ptpTypes.EventPublisherType{
+			EventType: ptp.PtpClockClassChange,
+			Resource:  ptp.PtpClockClassV1,
+		}
 	}
 	InitPubs[ptp.PtpStateChange] = &ptpTypes.EventPublisherType{
 		EventType: ptp.PtpStateChange,

--- a/plugins/ptp_operator/ptp_operator_plugin_test.go
+++ b/plugins/ptp_operator/ptp_operator_plugin_test.go
@@ -71,7 +71,7 @@ func TestMain(m *testing.M) {
 
 	c = make(chan os.Signal)
 	common.StartPubSubService(scConfig)
-	pubsubTypes = InitPubSubTypes()
+	pubsubTypes = InitPubSubTypes(scConfig)
 	cleanUP()
 	os.Exit(m.Run())
 }

--- a/vendor/github.com/redhat-cne/sdk-go/pkg/event/ptp/resource.go
+++ b/vendor/github.com/redhat-cne/sdk-go/pkg/event/ptp/resource.go
@@ -30,6 +30,10 @@ const (
 	// PtpClockClass notification is generated when the clock-class changes.
 	PtpClockClass EventResource = "/sync/ptp-status/clock-class"
 
+	// Support V1
+	// PtpClockClassV1 notification is generated when the clock-class changes for v1.
+	PtpClockClassV1 EventResource = "/sync/ptp-status/ptp-clock-class-change"
+
 	// O-RAN 7.2.3.3
 	// PtpLockState notification is signalled from equipment at state change
 	PtpLockState EventResource = "/sync/ptp-status/lock-state"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -190,7 +190,7 @@ github.com/redhat-cne/rest-api
 github.com/redhat-cne/rest-api/pkg/localmetrics
 github.com/redhat-cne/rest-api/pkg/restclient
 github.com/redhat-cne/rest-api/v2
-# github.com/redhat-cne/sdk-go v1.22.0
+# github.com/redhat-cne/sdk-go v1.22.1
 ## explicit; go 1.22
 github.com/redhat-cne/sdk-go/pkg/channel
 github.com/redhat-cne/sdk-go/pkg/common


### PR DESCRIPTION
Fix Backward Compatibility for PTP Clock-Class Event Subscription 

The problem arises because the V1 version of PTP events subscribed to the resource address /sync/ptp-status/ptp-clock-class-change, which was updated to /sync/ptp-status/clock-class in V2 as per O-RAN spec.
As a result, older versions referencing /sync/ptp-status/ptp-clock-class-change failed to subscribe to clock-class events.

This PR resolves the issue by introducing a new enum type, PtpClockClassV1, which refers to the older event resource.
The solution ensures backward compatibility for V1 while adhering to the O-RAN 7.2.3.10 specification for the PtpClockClass notification.

Key Changes:
In Cloud-event-proxy ,  manages different clock type subscription names by detecting API version 
if v1Api {
+                       subscribeTo[string(ptpEvent.PtpClockClassChange)] = string(ptpEvent.PtpClockClassV1)
+               }
In redhat-cnt/sd-go: 
sdk-go updated  by  adding  **PtpClockClassV1** to support the older **/sync/ptp-status/ptp-clock-class-change** resource for V1 compatibility.
Retained the **PtpClockClass** resource for the updated **/sync/ptp-status/clock-class** to align with the O-RAN specification.
Updated Definitions:
// O-RAN 7.2.3.10
// PtpClockClass notification is generated when the clock-class changes.
PtpClockClass EventResource = "/sync/ptp-status/clock-class"

// Support V1
// PtpClockClassV1 notification is generated when the clock-class changes for V1.
PtpClockClassV1 EventResource = "/sync/ptp-status/ptp-clock-class-change"

This change ensures that both V1 and the current versions of PTP events can correctly subscribe to clock-class notifications without breaking functionality for older versions.



