### PR TITLE
OCPBUGS-47515: [release-4.17] Fix GM State Transition Event Generation

### DIFF
--- a/plugins/ptp_operator/metrics/logparser.go
+++ b/plugins/ptp_operator/metrics/logparser.go
@@ -375,11 +375,28 @@ func (p *PTPEventManager) ParseGMLogs(processName, configName, output string, fi
 
 	// If GM is locked/Freerun/Holdover then ptp state change event
 	masterResource := fmt.Sprintf("%s/%s", alias, MasterClockType)
+	lastClockState := ptpStats[masterType].LastSyncState()
 
-	// When GM is enabled there is only event happening at GM level for now
-	p.GenPTPEvent(processName, ptpStats[masterType], masterResource, 0, clockState.State, ptp.PtpStateChange)
-	ptpStats[masterType].SetLastSyncState(clockState.State)
-	UpdateSyncStateMetrics(processName, alias, ptpStats[masterType].LastSyncState())
+	// When GM is enabled, there is only one event happening at the GM level for now, so it is not being sent to the state decision routine.
+	// LOCKED -->FREERUN
+	//LOCKED->HOLDOVER
+	/// HOLDOVER-->FREERUN
+	// HOLDOVER-->LOCKED
+
+	_, phaseOffset, _, err := ptpStats[types.IFace(iface)].GetDependsOnValueState(dpllProcessName, pointer.String(iface), phaseStatus)
+	if err != nil {
+		log.Errorf("error parsing phase offset %s", err.Error())
+	}
+	ptpStats[masterType].SetLastOffset(int64(phaseOffset))
+	lastOffset := ptpStats[masterType].LastOffset()
+
+	if clockState.State != lastClockState { // publish directly here
+		log.Infof("%s sync state %s, last ptp state is : %s", masterResource, clockState.State, lastClockState)
+		p.PublishEvent(clockState.State, lastOffset, masterResource, ptp.PtpStateChange)
+		ptpStats[masterType].SetLastSyncState(clockState.State)
+		UpdateSyncStateMetrics(processName, alias, ptpStats[masterType].LastSyncState())
+		UpdatePTPOffsetMetrics(processName, processName, alias, float64(lastOffset))
+	}
 }
 
 // ParseDPLLLogs ... parse logs for various events


### PR DESCRIPTION
This is a cherrypick from #379
Previously, when the Grandmaster (GM) transitioned to the HOLDOVER state, an event was generated with the HOLDOVER status. However, subsequent state transitions from HOLDOVER to FREERUN or LOCKED did not trigger any events. This bug fix ensures that events are now correctly generated for transitions from HOLDOVER to FREERUN or LOCKED states.