### PR TITLE
[release-4.16] OCPBUGS-47795: OCPBUGS-47793: update sdk-go and rest-api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.23.0
 	github.com/prometheus/client_golang v1.14.0
-	github.com/redhat-cne/rest-api v1.21.0
-	github.com/redhat-cne/sdk-go v1.21.1
+	github.com/redhat-cne/rest-api v1.21.1
+	github.com/redhat-cne/sdk-go v1.21.3
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/net v0.23.0

--- a/go.sum
+++ b/go.sum
@@ -419,10 +419,10 @@ github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5mo=
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/redhat-cne/rest-api v1.21.0 h1:Nh/0K2q6Aov5WvnRcevWOIOR6Jzh9YDrDXIM2Gfp80o=
-github.com/redhat-cne/rest-api v1.21.0/go.mod h1:P4+xDa4l9NjBMLeslRXqaWm+iLA/wWJaScEPcfcHcKM=
-github.com/redhat-cne/sdk-go v1.21.1 h1:ifyH8Ci3hezxTBNFSAONFxI0HqeTBMpKT8YItrrYrqk=
-github.com/redhat-cne/sdk-go v1.21.1/go.mod h1:1fq4KGbPiUgj65/rZCD217uV04Qz3mVjODUNrP02FkQ=
+github.com/redhat-cne/rest-api v1.21.1 h1:lswHPhzMqrYL6JUcn44myZU4hi/Q4qoS2p60Tbv88uM=
+github.com/redhat-cne/rest-api v1.21.1/go.mod h1:5f6Y9eq3aFXuElyiHj78Jzq/L54z+QHjsNM+so/g69A=
+github.com/redhat-cne/sdk-go v1.21.3 h1:5XmuYR0LAAMJmU+UynLpmLNQDy2869P5zmkbxOybldw=
+github.com/redhat-cne/sdk-go v1.21.3/go.mod h1:1fq4KGbPiUgj65/rZCD217uV04Qz3mVjODUNrP02FkQ=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/vendor/github.com/redhat-cne/rest-api/.gitignore
+++ b/vendor/github.com/redhat-cne/rest-api/.gitignore
@@ -18,3 +18,6 @@ pub.json
 sub.json
 
 .idea
+.cache
+.dccache
+

--- a/vendor/github.com/redhat-cne/rest-api/v2/routes.go
+++ b/vendor/github.com/redhat-cne/rest-api/v2/routes.go
@@ -68,12 +68,13 @@ func (s *Server) createSubscription(w http.ResponseWriter, r *http.Request) {
 		localmetrics.UpdateSubscriptionCount(localmetrics.FAILCREATE, 1)
 		return
 	}
-	clientIDs := s.subscriberAPI.GetClientIDByResource(sub.GetResource())
-	if len(clientIDs) != 0 {
-		respondWithStatusCode(w, http.StatusConflict,
-			fmt.Sprintf("subscription (clientID: %s) with same resource already exists, skipping creation",
-				clientIDs[0]))
-		return
+	for id, address := range s.subscriberAPI.GetClientIDAddressByResource(sub.GetResource()) {
+		if address.String() == endPointURI {
+			respondWithStatusCode(w, http.StatusConflict,
+				fmt.Sprintf("subscription (clientID: %s) with same resource already exists, skipping creation",
+					id))
+			return
+		}
 	}
 
 	id := uuid.New().String()

--- a/vendor/github.com/redhat-cne/rest-api/v2/server.go
+++ b/vendor/github.com/redhat-cne/rest-api/v2/server.go
@@ -309,7 +309,10 @@ func (s *Server) Start() {
 		io.WriteString(w, "OK") //nolint:errcheck
 	}).Methods(http.MethodGet)
 
+	// for internal test
 	api.HandleFunc("/dummy", dummy).Methods(http.MethodPost)
+	// for internal test: test multiple clients
+	api.HandleFunc("/dummy2", dummy).Methods(http.MethodPost)
 	api.HandleFunc("/log", s.logEvent).Methods(http.MethodPost)
 
 	//publishEvent create event and send it to a channel that is shared by middleware to process

--- a/vendor/github.com/redhat-cne/sdk-go/pkg/pubsub/pubsub_unmarshal.go
+++ b/vendor/github.com/redhat-cne/sdk-go/pkg/pubsub/pubsub_unmarshal.go
@@ -15,6 +15,7 @@
 package pubsub
 
 import (
+	"fmt"
 	"io"
 	"sync"
 
@@ -91,7 +92,14 @@ func readJSONFromIterator(out *PubSub, iterator *jsoniter.Iterator) error {
 	if iterator.Error != nil {
 		return iterator.Error
 	}
-
+	// Skip checking EndPointURI here since it is not used in http transport.
+	// Check EndPointURI in O-RAN REST API handler
+	//if endpointUri == "" {
+	//	return fmt.Errorf("mandatory field EndPointURI is not set")
+	//}
+	if resource == "" {
+		return fmt.Errorf("mandatory field ResourceAddress is not set")
+	}
 	out.SetID(id)
 	out.SetEndpointURI(endpointUri) //nolint:errcheck
 	out.SetURILocation(uriLocation) //nolint:errcheck

--- a/vendor/github.com/redhat-cne/sdk-go/v1/subscriber/subscriber.go
+++ b/vendor/github.com/redhat-cne/sdk-go/v1/subscriber/subscriber.go
@@ -272,20 +272,6 @@ func (p *API) GetSubscriberURLByResource(resource string) (urls []string) {
 	return urls
 }
 
-// GetClientIDByResource  get  subscriptionOne information
-func (p *API) GetClientIDByResource(resource string) (clientIDs []uuid.UUID) {
-	p.SubscriberStore.RLock()
-	defer p.SubscriberStore.RUnlock()
-	for _, subs := range p.SubscriberStore.Store {
-		for _, sub := range subs.SubStore.Store {
-			if strings.Contains(sub.GetResource(), resource) {
-				clientIDs = append(clientIDs, subs.ClientID)
-			}
-		}
-	}
-	return clientIDs
-}
-
 // GetClientIDBySubID ...
 func (p *API) GetClientIDBySubID(subID string) (clientIDs []uuid.UUID) {
 	p.SubscriberStore.RLock()
@@ -300,7 +286,7 @@ func (p *API) GetClientIDBySubID(subID string) (clientIDs []uuid.UUID) {
 	return clientIDs
 }
 
-// GetClientIDAddressByResource  get  subscriptionOne information
+// GetClientIDAddressByResource get subscriptionOne information
 func (p *API) GetClientIDAddressByResource(resource string) map[uuid.UUID]*types.URI {
 	clients := map[uuid.UUID]*types.URI{}
 	p.SubscriberStore.RLock()

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -184,13 +184,13 @@ github.com/prometheus/common/model
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/redhat-cne/rest-api v1.21.0
+# github.com/redhat-cne/rest-api v1.21.1
 ## explicit; go 1.21
 github.com/redhat-cne/rest-api
 github.com/redhat-cne/rest-api/pkg/localmetrics
 github.com/redhat-cne/rest-api/pkg/restclient
 github.com/redhat-cne/rest-api/v2
-# github.com/redhat-cne/sdk-go v1.21.1
+# github.com/redhat-cne/sdk-go v1.21.3
 ## explicit; go 1.21
 github.com/redhat-cne/sdk-go/pkg/channel
 github.com/redhat-cne/sdk-go/pkg/common


### PR DESCRIPTION
Update sdk-go and rest-api modules to fix the following issues:
[OCPBUGS-47795](https://issues.redhat.com/browse/OCPBUGS-47795)
Unable to subscribe two or more consumers to the same PTP event
[OCPBUGS-47793](https://issues.redhat.com/browse/OCPBUGS-47793)
Bad HTTP response (409) sent when the subscription request is not correct