### PR TITLE
enable multi-arch consumer image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,76 @@
+name: Build and Push Consumer Image
+on:
+  push:
+    branches: [ main, release-4.18 ]
+env:
+  VERSION: ${{ github.ref_name == 'main' && 'latest' || github.ref_name == 'release-4.18' && 'release-4.18' }}
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+          - platform: linux/arm64
+            arch: arm64
+    steps:
+      - name: Debug
+        run: |
+          echo "VERSION: ${{ env.VERSION }}"
+          echo "GITHUB_REF_NAME: ${{ github.ref_name }}"
+          echo "GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}"
+          echo "GITHUB_REPOSITORY: ${{ github.repository }}"
+          echo "GITHUB_SHA: ${{ github.sha }}"
+          echo "GITHUB_RUN_ID: ${{ github.run_id }}"
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to Quay.io
+        if: ${{ github.repository_owner == 'redhat-cne' }}
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_ROBOT_USERNAME }}
+          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+      - name: Build and Push
+        if: ${{ github.repository_owner == 'redhat-cne' }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: examples/consumer.Dockerfile
+          platforms: ${{ matrix.platform }}
+          push: true
+          # Disable attestations
+          provenance: false
+          tags: |
+            quay.io/redhat-cne/cloud-event-consumer:${{ env.VERSION }}-${{ matrix.arch }}
+
+  create-manifest:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Debug
+        run: |
+          echo "VERSION: ${{ env.VERSION }}"
+          echo "GITHUB_REF_NAME: ${{ github.ref_name }}"
+          echo "GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}"
+          echo "GITHUB_REPOSITORY: ${{ github.repository }}"
+          echo "GITHUB_SHA: ${{ github.sha }}"
+          echo "GITHUB_RUN_ID: ${{ github.run_id }}"
+      - name: Log in to Quay.io
+        if: ${{ github.repository_owner == 'redhat-cne' }}
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_ROBOT_USERNAME }}
+          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+      - name: Create Multi-Arch Manifest List
+        if: ${{ github.repository_owner == 'redhat-cne' }}
+        run: |
+          docker manifest create \
+            quay.io/redhat-cne/cloud-event-consumer:${{ env.VERSION }} \
+            quay.io/redhat-cne/cloud-event-consumer:${{ env.VERSION }}-amd64 \
+            quay.io/redhat-cne/cloud-event-consumer:${{ env.VERSION }}-arm64
+          docker manifest push quay.io/redhat-cne/cloud-event-consumer:${{ env.VERSION }}


### PR DESCRIPTION
Replace quay.io Build Trigger with Github workflow.
Trigger the build and push of consumer image when a PR is merged to `main` or `release-4.18` branches.

For PR merged to main branch, this workflow will create the following images:

- quay.io/redhat-cne/cloud-event-consumer:latest (multi-arch)
- quay.io/redhat-cne/cloud-event-consumer:latest-arm64
- quay.io/redhat-cne/cloud-event-consumer:latest-amd64

For PR merged to release-4.18 branch, this workflow will create the following images:

- quay.io/redhat-cne/cloud-event-consumer:release-4.18 (multi-arch)
- quay.io/redhat-cne/cloud-event-consumer:release-4.18-arm64
- quay.io/redhat-cne/cloud-event-consumer:release-4.18-amd64

