### PR TITLE
CNF-17240: Change consumer image label release-4.18 to 4.18

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,9 +1,12 @@
+# We only build consumer images for main (label: latest) and release-4.18 (label: 4.18) branches.
+# 4.18 consumer is the last version to support v1 events, which is used for 4.18 and earlier releases.
+# For 4.19+ releases (v2 events only) we always use main branch for consumer.
 name: Build and Push Consumer Image
 on:
   push:
     branches: [ main, release-4.18 ]
 env:
-  VERSION: ${{ github.ref_name == 'main' && 'latest' || github.ref_name == 'release-4.18' && 'release-4.18' }}
+  VERSION: ${{ github.ref_name == 'main' && 'latest' || github.ref_name == 'release-4.18' && '4.18' }}
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -122,10 +122,7 @@ gha:
 docker-build:
 	# make sure build the right target when developer using a Mac
 	if [ "$(OS)" = "Darwin" ]; then \
-		sed -e 's|^FROM \(.*\) AS builder|FROM --platform=linux/amd64 \1 AS builder|' \
-		-e 's|^FROM \(.*\) AS bin|FROM --platform=linux/amd64 \1 AS bin|' Dockerfile > Dockerfile.tmp; \
-		docker build --no-cache -t ${IMG} -f Dockerfile.tmp .; \
-		rm Dockerfile.tmp; \
+		docker build --no-cache --platform=linux/amd64 -t ${IMG} .; \
 	else \
 		docker build --no-cache -t ${IMG} .; \
 	fi
@@ -136,10 +133,7 @@ docker-push:
 docker-build-consumer:
 	# make sure build the right target when developer using a Mac
 	if [ "$(OS)" = "Darwin" ]; then \
-		sed -e 's|^FROM \(.*\) AS builder|FROM --platform=linux/amd64 \1 AS builder|' \
-		-e 's|^FROM \(.*\) AS bin|FROM --platform=linux/amd64 \1 AS bin|' ./examples/consumer.Dockerfile > ./examples/Dockerfile.tmp; \
-		docker build -f ./examples/Dockerfile.tmp -t ${CONSUMER_IMG} .; \
-		rm ./examples/Dockerfile.tmp; \
+		docker build --platform=linux/amd64 -f ./examples/consumer.Dockerfile -t ${CONSUMER_IMG} .; \
 	else \
 		docker build -f ./examples/consumer.Dockerfile -t ${CONSUMER_IMG} .; \
 	fi


### PR DESCRIPTION
Upon agreement with QE, update consumer image label for release-4.18 from `release-4.18` to `4.18` to be consistent with other images.
Also simplified the make commands for dev testing with macOs.