### PR TITLE
OCPBUGS-53247: CLOCK_REALTIME state reports 1 (locked) when both active and inactive interfaces are down in BC/OC HA environment

### DIFF
--- a/plugins/ptp_operator/metrics/metrics.go
+++ b/plugins/ptp_operator/metrics/metrics.go
@@ -86,6 +86,7 @@ func (p *PTPEventManager) ExtractMetrics(msg string) {
 			log.Errorf("failed to extract %s", msg)
 		}
 	}()
+
 	replacer := strings.NewReplacer("[", " ", "]", " ", ":", " ")
 	output := replacer.Replace(msg)
 	fields := strings.Fields(output)

--- a/plugins/ptp_operator/ptp_operator_plugin.go
+++ b/plugins/ptp_operator/ptp_operator_plugin.go
@@ -136,7 +136,7 @@ func Start(wg *sync.WaitGroup, configuration *common.SCConfiguration, _ func(e i
 					// delete all metrics related to process
 					ptpMetrics.DeleteProcessStatusMetricsForConfig(nodeName, "", "")
 					// delete all metrics related to ptp ha if haProfile is deleted
-					if haProfiles := eventManager.HAProfiles(); len(haProfiles) > 0 {
+					if _, haProfiles := eventManager.HAProfiles(); len(haProfiles) > 0 {
 						for _, p := range haProfiles {
 							ptpMetrics.DeletePTPHAMetrics(strings.TrimSpace(p))
 						}


### PR DESCRIPTION

Observed Behavior:
    CLOCK_REALTIME continued to report as LOCKED even when both active and inactive slave interfaces were down.
   
Fix: 
Added logic to evaluate HA profile state consistency
CLOCK_REALTIME is now transitioned to FREERUN only if all HA profiles are in FAULTY state
Ensures LOCKED is not reported falsely when no valid upstream source is active