### PR TITLE
OCPBUGS-54543: Data race in Server.status access causes instability in cloud-event-proxy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhat-cne/cloud-event-proxy
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
@@ -12,7 +12,7 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.23.0
 	github.com/prometheus/client_golang v1.14.0
-	github.com/redhat-cne/rest-api v1.23.0
+	github.com/redhat-cne/rest-api v1.23.1
 	github.com/redhat-cne/sdk-go v1.23.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -420,8 +420,8 @@ github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5mo=
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/redhat-cne/rest-api v1.23.0 h1:e7LMPBvA2XVh/vMeg4wAA1xQXqDJ0t50VI7tWHt5x0c=
-github.com/redhat-cne/rest-api v1.23.0/go.mod h1:AZc7dtEePnNKQY11/aQtNcx61vvz3q9sPZcde/Mgnk8=
+github.com/redhat-cne/rest-api v1.23.1 h1:2lRFl5/jTpfTGSo3wt7P7m//R8PsAIFqLh6d1Z2oNwg=
+github.com/redhat-cne/rest-api v1.23.1/go.mod h1:AZc7dtEePnNKQY11/aQtNcx61vvz3q9sPZcde/Mgnk8=
 github.com/redhat-cne/sdk-go v1.23.0 h1:HxJqhqlTZJ91C5FHHb0S4ERQsVDOC6kx6n8cAKRH0Ao=
 github.com/redhat-cne/sdk-go v1.23.0/go.mod h1:+edGV2lN9v2+mXgfOC3jNH8WX5r07r+HngoK6nAnuVk=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -186,7 +186,7 @@ github.com/prometheus/common/model
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/redhat-cne/rest-api v1.23.0
+# github.com/redhat-cne/rest-api v1.23.1
 ## explicit; go 1.23
 github.com/redhat-cne/rest-api
 github.com/redhat-cne/rest-api/pkg/localmetrics


### PR DESCRIPTION
Update go.mod to use rest-api v1.23.1, which includes a fix for a race condition when reading the server status.

api fix: [redhat-cne/rest-api#90](https://github.com/redhat-cne/rest-api/pull/90)