### PR TITLE
Update Github action runners

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,15 +1,15 @@
+---
 name: CI
 on: [push, pull_request]
-
 jobs:
   golangci:
     name: Linting
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: 1.23
       - name: tidy
         run: go mod tidy
       - name: golangci-lint
@@ -20,13 +20,13 @@ jobs:
           args: --timeout 3m0s
   unit-tests:
     name: Unit Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: 1.23
       - name: tidy
         run: go mod tidy
       - name: Run Test Scripts


### PR DESCRIPTION
[The Ubuntu 20.04 Actions runner image will begin deprecation](https://github.com/actions/runner-images/issues/11101).