### PR TITLE
parse BC holdover

### DIFF
--- a/plugins/ptp_operator/metrics/metrics.go
+++ b/plugins/ptp_operator/metrics/metrics.go
@@ -30,6 +30,7 @@ const (
 	gnssProcessName    = "gnss"
 	dpllProcessName    = "dpll"
 	gmProcessName      = "GM"
+	bcProcessName      = "T-BC"
 	syncE4lProcessName = "synce4l"
 
 	unLocked     = "s0"
@@ -49,6 +50,8 @@ const (
 	DPLL = "DPLL"
 	// ClockClass number
 	ClockClass = "CLOCK_CLASS"
+	// TBC ...
+	TBC = "T-BC"
 
 	// from the logs
 	processNameIndex = 0
@@ -142,6 +145,8 @@ func (p *PTPEventManager) ExtractMetrics(msg string) {
 		p.ParseDPLLLogs(processName, configName, output, fields, ptpStats)
 	case gmProcessName:
 		p.ParseGMLogs(processName, configName, output, fields, ptpStats)
+	case bcProcessName:
+		p.ParseTBCLogs(processName, configName, output, fields, ptpStats)
 	case syncE4lProcessName:
 		p.ParseSyncELogs(processName, configName, output, fields, ptpStats)
 	default:

--- a/plugins/ptp_operator/metrics/ptp4lParse.go
+++ b/plugins/ptp_operator/metrics/ptp4lParse.go
@@ -18,6 +18,7 @@ import (
 var classChangeIdentifier = "CLOCK_CLASS_CHANGE"
 var gnssEventIdentifier = "gnss_status"
 var gmStatusIdentifier = "T-GM-STATUS"
+var bcStatusIdentifier = "T-BC"
 
 // ParsePTP4l ... parse ptp4l for various events
 func (p *PTPEventManager) ParsePTP4l(processName, configName, profileName, output string, fields []string,


### PR DESCRIPTION
Handling for TBC logs in an expected format, which should be added to
the linuxptp-daemon soon.

T-BC[1743005894]:[ptp4l.0.config] ens7f0  offset  55 T-BC-STATUS s0
