### PR TITLE
OCPBUGS-45680: add error handling in configmap and consumer app subscription

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ build-only:
 	go build -ldflags "${LINKER_RELEASE_FLAGS}" -o ./build/cloud-event-proxy cmd/main.go
 
 build-examples:
-	go build -o ./build/cloud-event-consumer ./examples/consumer/main.go
+	go build -ldflags "${LINKER_RELEASE_FLAGS}" -o ./build/cloud-event-consumer ./examples/consumer/main.go
 
 lint:
 	golangci-lint --enable gosec run

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -57,6 +57,11 @@ import (
 	subscriberApi "github.com/redhat-cne/sdk-go/v1/subscriber"
 )
 
+const (
+	configMapRetryInterval = 3 * time.Second
+	configMapRetryCount    = 5
+)
+
 var (
 	// defaults
 	storePath               string
@@ -134,8 +139,8 @@ func main() {
 	}
 	if namespace != "" && nodeName != "" && scConfig.TransportHost.Type == common.HTTP {
 		// if consumer doesn't pass namespace then this will default to empty dir
-		if e := client.InitConfigMap(scConfig.APIVersion, scConfig.StorePath, nodeName, namespace); e != nil {
-			log.Errorf("failed to initlialize configmap, subcription will be stored in empty dir %s", e.Error())
+		if e := client.InitConfigMap(scConfig.APIVersion, scConfig.StorePath, nodeName, namespace, configMapRetryInterval, configMapRetryCount); e != nil {
+			log.Errorf("failed to initialize configmap, subscription will be stored in empty dir %s", e.Error())
 		} else {
 			scConfig.StorageType = storageClient.ConfigMap
 		}

--- a/examples/consumer/main.go
+++ b/examples/consumer/main.go
@@ -72,9 +72,12 @@ var (
 	// map to track if subscriptions were created successfully for each publisher service
 	subscribed = make(map[string]bool)
 	subs       []*pubsub.PubSub
+	// Git commit of current build set at build time
+	GitCommit = "Undefined"
 )
 
 func main() {
+	fmt.Printf("Git commit: %s\n", GitCommit)
 	common.InitLogger()
 	flag.StringVar(&localAPIAddr, "local-api-addr", "localhost:8989", "The address the local api binds to .")
 	flag.StringVar(&apiPath, "api-path", "/api/ocloudNotifications/v2/", "The rest api path.")

--- a/examples/consumer/main.go
+++ b/examples/consumer/main.go
@@ -173,6 +173,34 @@ func deleteAllSubscriptions() {
 	}
 }
 
+// listSubscriptions lists all subscriptions
+// and returns true if there are any subscriptions
+func listSubscriptions() bool {
+	url := &types.URI{URL: url.URL{Scheme: "http",
+		Host: apiAddr,
+		Path: fmt.Sprintf("%s%s", apiPath, "subscriptions")}}
+	rc := restclient.New()
+
+	var subs = []pubsub.PubSub{}
+	var subB []byte
+	status, subB, err := rc.Get(url)
+	if status != http.StatusOK {
+		log.Errorf("failed to list subscriptions, status %d", status)
+		if err != nil {
+			log.Errorf("%s", err.Error())
+		}
+		return false
+	}
+	if err = json.Unmarshal(subB, &subs); err != nil {
+		log.Errorf("failed to unmarshal subscriptions, %v", err)
+		return false
+	}
+	if len(subs) > 0 {
+		return true
+	}
+	return false
+}
+
 func subscribeToEvents() {
 RETRY:
 	for p, subOK := range subscribed {
@@ -181,7 +209,14 @@ RETRY:
 			if !healthOK {
 				deleteAllSubscriptions()
 				log.Info("delete all subscriptions due to publisher health failure")
-				return
+				goto RETRY
+			}
+			if !listSubscriptions() {
+				// re-subscribe in case of non-recoverable error at server side, for example
+				// lost of persist data in configmap
+				log.Infof("subscription not found for %s, resubscribe", p)
+				subscribed[p] = false
+				goto RETRY
 			}
 			continue
 		}
@@ -248,11 +283,14 @@ func getCurrentState(resource string) {
 		Host: apiAddr,
 		Path: fmt.Sprintf("%s%s", apiPath, fmt.Sprintf("%s/CurrentState", resource[1:]))}}
 	rc := restclient.New()
-	status, cloudEvent := rc.Get(url)
+	status, cloudEvent, err := rc.Get(url)
 	if status != http.StatusOK {
-		log.Errorf("CurrentState:error %d from url %s, %s", status, url.String(), cloudEvent)
+		log.Errorf("CurrentState: error %d from url %s", status, url.String())
+		if err != nil {
+			log.Errorf("%s", err.Error())
+		}
 	} else {
-		log.Debugf("Got CurrentState: %s ", cloudEvent)
+		log.Debugf("Got CurrentState: %s ", string(cloudEvent))
 	}
 }
 

--- a/pkg/restclient/client.go
+++ b/pkg/restclient/client.go
@@ -71,8 +71,7 @@ func (r *Rest) PostCloudEvent(url *types.URI, e ce.Event) (int, error) {
 
 // Post with data
 func (r *Rest) Post(url *types.URI, data []byte) (int, error) {
-	ctx := context.Background()
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	request, err := http.NewRequestWithContext(ctx, "POST", url.String(), bytes.NewBuffer(data))
 	if err != nil {
@@ -102,18 +101,17 @@ func (r *Rest) Post(url *types.URI, data []byte) (int, error) {
 
 // PostWithReturn post with data and return data
 func (r *Rest) PostWithReturn(url *types.URI, data []byte) (int, []byte) {
-	ctx := context.Background()
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	request, err := http.NewRequestWithContext(ctx, "POST", url.String(), bytes.NewBuffer(data))
 	if err != nil {
-		log.Errorf("error creating post request %v", err)
+		log.Errorf("error creating post with return: %v", err)
 		return http.StatusBadRequest, nil
 	}
 	request.Header.Set("content-type", "application/json")
 	res, err := r.client.Do(request)
 	if err != nil {
-		log.Errorf("error in post response %v to %s ", err, url)
+		log.Errorf("error in post response to %s: %v", url, err)
 		return http.StatusBadRequest, nil
 	}
 	if res.Body != nil {
@@ -129,18 +127,17 @@ func (r *Rest) PostWithReturn(url *types.URI, data []byte) (int, []byte) {
 
 // Put  http request
 func (r *Rest) Put(url *types.URI) int {
-	ctx := context.Background()
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	request, err := http.NewRequestWithContext(ctx, "PUT", url.String(), nil)
 	if err != nil {
-		log.Errorf("error creating post request %v", err)
+		log.Errorf("error creating put request: %v", err)
 		return http.StatusBadRequest
 	}
 	request.Header.Set("content-type", "application/json")
 	res, err := r.client.Do(request)
 	if err != nil {
-		log.Errorf("error in post response %v to %s ", err, url)
+		log.Errorf("error in put response to %s: %v", url, err)
 		return http.StatusBadRequest
 	}
 	defer res.Body.Close()
@@ -149,18 +146,17 @@ func (r *Rest) Put(url *types.URI) int {
 
 // Delete  http request
 func (r *Rest) Delete(url *types.URI) int {
-	ctx := context.Background()
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	request, err := http.NewRequestWithContext(ctx, "DELETE", url.String(), nil)
 	if err != nil {
-		log.Errorf("error creating post request %v", err)
+		log.Errorf("error creating delete request: %v", err)
 		return http.StatusBadRequest
 	}
 	request.Header.Set("content-type", "application/json")
 	res, err := r.client.Do(request)
 	if err != nil {
-		log.Errorf("error in post response %v to %s ", err, url)
+		log.Errorf("error in delete response to %s: %v", url, err)
 		return http.StatusBadRequest
 	}
 	defer res.Body.Close()
@@ -168,24 +164,22 @@ func (r *Rest) Delete(url *types.URI) int {
 }
 
 // Get  http request
-func (r *Rest) Get(url *types.URI) (int, string) {
-	ctx := context.Background()
-	ctx, cancel := context.WithCancel(ctx)
+func (r *Rest) Get(url *types.URI) (int, []byte, error) {
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	request, err := http.NewRequestWithContext(ctx, "GET", url.String(), nil)
 	if err != nil {
-		log.Errorf("error creating post request %v", err)
-		return http.StatusBadRequest, fmt.Sprintf("error creating post request %v", err)
+		return http.StatusBadRequest, nil, fmt.Errorf("error creating get request: %v", err)
 	}
 	request.Header.Set("content-type", "application/json")
 	res, err := r.client.Do(request)
 	if err != nil {
-		log.Errorf("error in post response %v to %s ", err, url)
-		return http.StatusBadRequest, fmt.Sprintf("error in post response %v to %s ", err, url)
+		return http.StatusBadRequest, nil, fmt.Errorf("error in get response to %s: %v", url, err)
 	}
 	defer res.Body.Close()
-	if body, readErr := io.ReadAll(res.Body); readErr == nil {
-		return res.StatusCode, string(body)
+	var body []byte
+	if body, err = io.ReadAll(res.Body); err != nil {
+		return res.StatusCode, body, nil
 	}
-	return http.StatusBadRequest, fmt.Sprintf("error in post response %v to %s ", err, url)
+	return http.StatusBadRequest, nil, fmt.Errorf("error reading body in get response to %s: %v", url, err)
 }

--- a/pkg/storage/kubernetes/client.go
+++ b/pkg/storage/kubernetes/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/golang/glog"
 	"github.com/redhat-cne/sdk-go/pkg/channel"
@@ -70,8 +71,10 @@ func (sClient *Client) CreateConfigMap(ctx context.Context, apiVersion, nodeName
 	if err == nil {
 		// clean up configMap if apiVersion changed
 		if apiVersion != "" && !validateConfigMap(apiVersion, cm) {
+			log.Warnf("ConfigMap %s is not compatible with the current version %s. Cleaning up.", cm.Name, apiVersion)
 			return sClient.cleanupConfigMap(ctx, cm, namespace)
 		}
+		log.Infof("ConfigMap %s already exists", cm.Name)
 		return cm, nil
 	}
 
@@ -91,7 +94,7 @@ func (sClient *Client) CreateConfigMap(ctx context.Context, apiVersion, nodeName
 		log.Errorf("Error creating configmap %s", err.Error())
 		return
 	}
-
+	log.Infof("ConfigMap %s created successfully", cm.Name)
 	return
 }
 
@@ -135,8 +138,7 @@ func (sClient *Client) UpdateConfigMap(ctx context.Context, data []subscriber.Su
 				log.Errorf("error marshalling subscriber %s", e.Error())
 				continue
 			}
-			log.Infof("persisting following contents %s ", string(out))
-			log.Infof("updating new subscriber in configmap")
+			log.Infof("updating new subscriber in configmap with following contents %s ", string(out))
 			existingData[data[i].ClientID.String()] = string(out)
 		}
 	}
@@ -152,34 +154,43 @@ func (sClient *Client) UpdateConfigMap(ctx context.Context, data []subscriber.Su
 }
 
 // InitConfigMap ... using configmap
-func (sClient *Client) InitConfigMap(apiVersion, storePath, nodeName, namespace string) error {
+func (sClient *Client) InitConfigMap(apiVersion, storePath, nodeName, namespace string, delay time.Duration, retry int) error {
 	var err error
 	var cm *corev1.ConfigMap
-	if cm, err = sClient.CreateConfigMap(context.Background(), apiVersion, nodeName, namespace); err == nil {
-		for clientID, subscriberData := range cm.Data {
-			var newSubscriberBytes []byte
-			var subscriberErr error
-			subscriber := subscriber.Subscriber{}
-			if err = json.Unmarshal([]byte(subscriberData), &subscriber); err == nil {
-				newSubscriberBytes, subscriberErr = json.MarshalIndent(&subscriber, "", " ")
-				if subscriberErr == nil {
-					filePath := fmt.Sprintf("%s/%s", storePath, fmt.Sprintf("%s.json", clientID))
-					log.Infof("persisting following contents %s to a file %s\n", string(newSubscriberBytes), filePath)
-					if subscriberErr = os.WriteFile(filePath, newSubscriberBytes, 0600); subscriberErr != nil {
-						log.Errorf("error writing subscription to a file %s", subscriberErr.Error())
-					}
-				} else {
-					log.Errorf("error write to a file %s", subscriberErr.Error())
-					continue
+
+	for i := 0; i <= retry; i++ {
+		cm, err = sClient.CreateConfigMap(context.Background(), apiVersion, nodeName, namespace)
+		if err == nil {
+			break
+		}
+		log.Warnf("error creating configmap %s, retrying %d", err.Error(), i)
+		time.Sleep(delay)
+	}
+	if err != nil {
+		log.Errorf("failed creating config map %s", err.Error())
+		return err
+	}
+
+	for clientID, subscriberData := range cm.Data {
+		var newSubscriberBytes []byte
+		var subscriberErr error
+		subscriber := subscriber.Subscriber{}
+		if err = json.Unmarshal([]byte(subscriberData), &subscriber); err == nil {
+			newSubscriberBytes, subscriberErr = json.MarshalIndent(&subscriber, "", " ")
+			if subscriberErr == nil {
+				filePath := fmt.Sprintf("%s/%s", storePath, fmt.Sprintf("%s.json", clientID))
+				log.Infof("persisting following contents from configmap to file %s: %s\n", filePath, string(newSubscriberBytes))
+				if subscriberErr = os.WriteFile(filePath, newSubscriberBytes, 0600); subscriberErr != nil {
+					log.Errorf("error writing subscription to a file %s", subscriberErr.Error())
 				}
 			} else {
-				log.Errorf("error unmarshalling data from configmap")
-				return err
+				log.Errorf("error marshalling subscriber data: %s", subscriberErr.Error())
+				continue
 			}
+		} else {
+			log.Errorf("error unmarshalling data from configmap")
+			return err
 		}
-	} else {
-		log.Errorf("error creating config map %s", err.Error())
-		return err
 	}
 	return nil
 }
@@ -202,6 +213,7 @@ func validateSubscriberVersion(apiVersion string, sub subscriber.Subscriber) boo
 
 	for _, v := range sub.SubStore.Store {
 		if !isVersionsCompatible(v.GetVersion(), apiVersion) {
+			log.Errorf("subscriber version %s is not compatible with the current version %s", v.GetVersion(), apiVersion)
 			return false
 		}
 	}
@@ -217,9 +229,16 @@ func validateConfigMap(apiVersion string, cm *corev1.ConfigMap) bool {
 		subscriber := subscriber.Subscriber{}
 		if err := json.Unmarshal([]byte(subscriberData), &subscriber); err == nil {
 			_, subscriberErr = json.MarshalIndent(&subscriber, "", " ")
-			if subscriberErr != nil || !validateSubscriberVersion(apiVersion, subscriber) {
+			if subscriberErr != nil {
+				log.Errorf("error marshalling subscriber data from configmap: %s", subscriberErr.Error())
 				return false
 			}
+			if !validateSubscriberVersion(apiVersion, subscriber) {
+				return false
+			}
+		} else {
+			log.Errorf("validateConfigMap: error unmarshalling data from configmap: %s", err.Error())
+			return false
 		}
 	}
 	return true

--- a/pkg/storage/kubernetes/client_test.go
+++ b/pkg/storage/kubernetes/client_test.go
@@ -3,6 +3,7 @@ package kubernetes_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
@@ -14,8 +15,9 @@ import (
 )
 
 const (
-	nodeName  = "test_node_name"
-	storePath = "."
+	nodeName               = "test_node_name"
+	storePath              = "."
+	configMapRetryInterval = 3 * time.Second
 )
 
 var (
@@ -40,7 +42,7 @@ func Subscriptions() *v1.ConfigMap {
 
 func TestClient_InitConfigMap(t *testing.T) {
 	setupClient()
-	err := clients.InitConfigMap("1.0", ".", nodeName, metav1.NamespaceSystem)
+	err := clients.InitConfigMap("1.0", ".", nodeName, metav1.NamespaceSystem, configMapRetryInterval, 0)
 	assert.Nil(t, err)
 	cm, e := clients.GetConfigMap(context.Background(), nodeName, metav1.NamespaceSystem)
 	assert.Nil(t, e)
@@ -49,7 +51,7 @@ func TestClient_InitConfigMap(t *testing.T) {
 
 func TestClient_GetConfigMap(t *testing.T) {
 	setupClient()
-	err := clients.InitConfigMap("1.0", ".", nodeName, metav1.NamespaceSystem)
+	err := clients.InitConfigMap("1.0", ".", nodeName, metav1.NamespaceSystem, configMapRetryInterval, 0)
 	assert.Nil(t, err)
 	cm, e := clients.GetConfigMap(context.Background(), nodeName, metav1.NamespaceSystem)
 	assert.Nil(t, e)
@@ -59,7 +61,7 @@ func TestClient_GetConfigMap(t *testing.T) {
 
 func Test_LoadingSubscriptionFromFileToCache(t *testing.T) {
 	setupClient()
-	err := clients.InitConfigMap("1.0", ".", nodeName, metav1.NamespaceSystem)
+	err := clients.InitConfigMap("1.0", ".", nodeName, metav1.NamespaceSystem, configMapRetryInterval, 0)
 	assert.Nil(t, err)
 	cm, e := clients.GetConfigMap(context.Background(), nodeName, metav1.NamespaceSystem)
 	assert.Nil(t, e)


### PR DESCRIPTION
consumer changes:
- re-subscribe in case of non-recoverable error at server side, for example lost of persist data in configmap
- add git commit ID in consumer image

sidecar changes:
- add retry in configMap creation
- add trace and error handling to configMap creation and updating