### PR TITLE
Fix for case when master is lost

### DIFF
--- a/plugins/ptp_operator/metrics/manager.go
+++ b/plugins/ptp_operator/metrics/manager.go
@@ -27,7 +27,7 @@ type PTPEventManager struct {
 	lock           sync.RWMutex
 	Stats          map[types.ConfigName]stats.PTPStats
 	mock           bool
-	mockEvent      ptp.EventType
+	mockEvent      []ptp.EventType
 	// PtpConfigMapUpdates holds ptp-configmap updated details
 	PtpConfigMapUpdates *ptpConfig.LinuxPTPConfigMapUpdate
 	// Ptp4lConfigInterfaces holds interfaces and its roles, after reading from ptp4l config files
@@ -209,7 +209,7 @@ func (p *PTPEventManager) DeletePTPConfig(key types.ConfigName) {
 // PublishClockClassEvent ...publish events
 func (p *PTPEventManager) PublishClockClassEvent(clockClass float64, source string, eventType ptp.EventType) {
 	if p.mock {
-		p.mockEvent = eventType
+		p.mockEvent = append(p.mockEvent, eventType)
 		log.Infof("PublishClockClassEvent clockClass=%f, source=%s, eventType=%s", clockClass, source, eventType)
 		return
 	}
@@ -221,7 +221,7 @@ func (p *PTPEventManager) PublishClockClassEvent(clockClass float64, source stri
 // PublishClockClassEvent ...publish events
 func (p *PTPEventManager) publishGNSSEvent(state int64, offset float64, syncState ptp.SyncState, source string, eventType ptp.EventType) {
 	if p.mock {
-		p.mockEvent = eventType
+		p.mockEvent = append(p.mockEvent, eventType)
 		log.Infof("publishGNSSEvent state=%d, offset=%f, source=%s, eventType=%s", state, offset, source, eventType)
 		return
 	}
@@ -241,7 +241,7 @@ func (p *PTPEventManager) publishGNSSEvent(state int64, offset float64, syncStat
 // publishSyncEEvent ...publish events
 func (p *PTPEventManager) publishSyncEEvent(syncState ptp.SyncState, source string, ql byte, extQl byte, extendedTvlEnabled bool, eventType ptp.EventType) {
 	if p.mock {
-		p.mockEvent = eventType
+		p.mockEvent = append(p.mockEvent, eventType)
 		log.Infof("publishSyncEEvent state=%s, source=%s, eventType=%s", syncState, source, eventType)
 		return
 	}
@@ -347,7 +347,7 @@ func (p *PTPEventManager) PublishEvent(state ptp.SyncState, ptpOffset int64, sou
 		return
 	}
 	if p.mock {
-		p.mockEvent = eventType
+		p.mockEvent = append(p.mockEvent, eventType)
 		log.Infof("PublishEvent state=%s, ptpOffset=%d, source=%s, eventType=%s", state, ptpOffset, source, eventType)
 		return
 	}
@@ -497,13 +497,13 @@ func (p *PTPEventManager) NodeName() string {
 }
 
 // GetMockEvent ...
-func (p *PTPEventManager) GetMockEvent() ptp.EventType {
+func (p *PTPEventManager) GetMockEvent() []ptp.EventType {
 	return p.mockEvent
 }
 
 // ResetMockEvent ...
 func (p *PTPEventManager) ResetMockEvent() {
-	p.mockEvent = ""
+	p.mockEvent = []ptp.EventType{}
 }
 
 // PrintStats .... for debug

--- a/plugins/ptp_operator/metrics/metrics.go
+++ b/plugins/ptp_operator/metrics/metrics.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"fmt"
 	"regexp"
+	"runtime/debug"
 	"strings"
 
 	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/ptp4lconf"
@@ -83,7 +84,9 @@ func (p *PTPEventManager) ExtractMetrics(msg string) {
 	defer func() {
 		if err := recover(); err != nil {
 			log.Errorf("restored from extract metrics and events: %s", err)
+			log.Printf("Stack trace:\n%s", debug.Stack())
 			log.Errorf("failed to extract %s", msg)
+
 		}
 	}()
 

--- a/plugins/ptp_operator/metrics/ptp4lParse.go
+++ b/plugins/ptp_operator/metrics/ptp4lParse.go
@@ -99,7 +99,7 @@ func (p *PTPEventManager) ParsePTP4l(processName, configName, profileName, outpu
 					ptpStats[master].SetRole(role)
 				}
 			}
-			log.Infof("update interface %s with portid %d from role %s to role %s  out %s, syncState %s, lastSyncState %s", ptpIFace, portID, lastRole, role, output, syncState, ptpStats[master].LastSyncState())
+			log.Infof("update interface %s with portid %d from role %s to role %s  out %s, syncState %s", ptpIFace, portID, lastRole, role, output, syncState)
 			ptp4lCfg.Interfaces[portID-1].UpdateRole(role)
 
 			// update role metrics


### PR DESCRIPTION
Currently, when the master is lost, the clock reports locked state. This considers that all ports in listening state is a failure since the master cannot be received.