### PR TITLE
[release-4.18] OCPBUGS-55121: add error handling in configmap and consumer app subscription

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ build-only:
 	go build -ldflags "${LINKER_RELEASE_FLAGS}" -o ./build/cloud-event-proxy cmd/main.go
 
 build-examples:
-	go build -o ./build/cloud-event-consumer ./examples/consumer/main.go
+	go build -ldflags "${LINKER_RELEASE_FLAGS}" -o ./build/cloud-event-consumer ./examples/consumer/main.go
 
 lint:
 	golangci-lint --enable gosec run

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,9 @@ KUSTOMIZE ?= $(LOCALBIN)/kustomize
 KUSTOMIZE_VERSION ?= v4.5.7
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 
+GIT_COMMIT=$(shell git rev-list -1 HEAD)
+LINKER_RELEASE_FLAGS=-X main.GitCommit=$(GIT_COMMIT)
+
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary. If wrong version is installed, it will be removed before downloading.
 $(KUSTOMIZE): $(LOCALBIN)
@@ -61,7 +64,7 @@ build:build-plugins test
 	go build -o ./build/cloud-event-proxy cmd/main.go
 
 build-only:
-	go build -o ./build/cloud-event-proxy cmd/main.go
+	go build -ldflags "${LINKER_RELEASE_FLAGS}" -o ./build/cloud-event-proxy cmd/main.go
 
 build-examples:
 	go build -o ./build/cloud-event-consumer ./examples/consumer/main.go

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -77,9 +77,13 @@ var (
 	nodeName           string
 	namespace          string
 	isV1Api            bool
+
+	// Git commit of current build set at build time
+	GitCommit = "Undefined"
 )
 
 func main() {
+	fmt.Printf("Git commit: %s\n", GitCommit)
 	// init
 	common.InitLogger()
 	flag.StringVar(&metricsAddr, "metrics-addr", ":9091", "The address the metric endpoint binds to.")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -59,6 +59,11 @@ import (
 	subscriberApi "github.com/redhat-cne/sdk-go/v1/subscriber"
 )
 
+const (
+	configMapRetryInterval = 3 * time.Second
+	configMapRetryCount    = 5
+)
+
 var (
 	// defaults
 	storePath               string
@@ -143,8 +148,8 @@ func main() {
 	}
 	if namespace != "" && nodeName != "" && scConfig.TransportHost.Type == common.HTTP {
 		// if consumer doesn't pass namespace then this will default to empty dir
-		if e := client.InitConfigMap(scConfig.APIVersion, scConfig.StorePath, nodeName, namespace); e != nil {
-			log.Errorf("failed to initlialize configmap, subcription will be stored in empty dir %s", e.Error())
+		if e := client.InitConfigMap(scConfig.APIVersion, scConfig.StorePath, nodeName, namespace, configMapRetryInterval, configMapRetryCount); e != nil {
+			log.Errorf("failed to initialize configmap, subscription will be stored in empty dir %s", e.Error())
 		} else {
 			scConfig.StorageType = storageClient.ConfigMap
 		}

--- a/examples/consumer/main.go
+++ b/examples/consumer/main.go
@@ -72,9 +72,12 @@ var (
 	subscribed = make(map[string]bool)
 	subs       []*pubsub.PubSub
 	isV1Api    bool
+	// Git commit of current build set at build time
+	GitCommit = "Undefined"
 )
 
 func main() {
+	fmt.Printf("Git commit: %s\n", GitCommit)
 	common.InitLogger()
 	flag.StringVar(&localAPIAddr, "local-api-addr", "localhost:8989", "The address the local api binds to .")
 	flag.StringVar(&apiPath, "api-path", "/api/ocloudNotifications/v1/", "The rest api path.")

--- a/examples/manifests/consumer.yaml
+++ b/examples/manifests/consumer.yaml
@@ -23,6 +23,7 @@ spec:
       containers:
         - name: cloud-event-consumer
           image: cloud-event-consumer
+          imagePullPolicy: Always
           args:
             - "--local-api-addr=127.0.0.1:9089"
             - "--api-path=/api/ocloudNotifications/v1/"
@@ -39,6 +40,7 @@ spec:
               value: "true"
         - name: cloud-event-sidecar
           image: cloud-event-sidecar
+          imagePullPolicy: Always
           args:
             - "--metrics-addr=127.0.0.1:9091"
             - "--store-path=/store"

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -371,7 +371,6 @@ func GetPublishingCloudEvent(scConfig *SCConfiguration, cneEvent ceevent.Event) 
 
 // APIHealthCheck ... rest api should be ready before starting to consume api
 func APIHealthCheck(uri *types.URI, delay time.Duration) (ok bool, err error) {
-	log.Printf("checking for rest service health")
 	for i := 0; i <= 5; i++ {
 		log.Infof("health check %s", uri.String())
 		response, errResp := http.Get(uri.String())
@@ -401,7 +400,7 @@ func HTTPTransportHealthCheck(uri *types.URI, delay time.Duration) (ok bool, err
 		log.Infof("health check %s ", uri.String())
 		response, errResp := http.Get(uri.String())
 		if errResp != nil {
-			log.Warnf("try %d, return health check of the http transportfor error  %v", i, errResp)
+			log.Warnf("try %d, return health check of the http transport error  %v", i, errResp)
 			time.Sleep(delay)
 			err = errResp
 			continue

--- a/pkg/restclient/client.go
+++ b/pkg/restclient/client.go
@@ -71,8 +71,7 @@ func (r *Rest) PostCloudEvent(url *types.URI, e ce.Event) (int, error) {
 
 // Post with data
 func (r *Rest) Post(url *types.URI, data []byte) (int, error) {
-	ctx := context.Background()
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	request, err := http.NewRequestWithContext(ctx, "POST", url.String(), bytes.NewBuffer(data))
 	if err != nil {
@@ -102,18 +101,17 @@ func (r *Rest) Post(url *types.URI, data []byte) (int, error) {
 
 // PostWithReturn post with data and return data
 func (r *Rest) PostWithReturn(url *types.URI, data []byte) (int, []byte) {
-	ctx := context.Background()
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	request, err := http.NewRequestWithContext(ctx, "POST", url.String(), bytes.NewBuffer(data))
 	if err != nil {
-		log.Errorf("error creating post request %v", err)
+		log.Errorf("error creating post with return: %v", err)
 		return http.StatusBadRequest, nil
 	}
 	request.Header.Set("content-type", "application/json")
 	res, err := r.client.Do(request)
 	if err != nil {
-		log.Errorf("error in post response %v to %s ", err, url)
+		log.Errorf("error in post response to %s: %v", url, err)
 		return http.StatusBadRequest, nil
 	}
 	if res.Body != nil {
@@ -129,18 +127,17 @@ func (r *Rest) PostWithReturn(url *types.URI, data []byte) (int, []byte) {
 
 // Put  http request
 func (r *Rest) Put(url *types.URI) int {
-	ctx := context.Background()
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	request, err := http.NewRequestWithContext(ctx, "PUT", url.String(), nil)
 	if err != nil {
-		log.Errorf("error creating post request %v", err)
+		log.Errorf("error creating put request: %v", err)
 		return http.StatusBadRequest
 	}
 	request.Header.Set("content-type", "application/json")
 	res, err := r.client.Do(request)
 	if err != nil {
-		log.Errorf("error in post response %v to %s ", err, url)
+		log.Errorf("error in put response to %s: %v", url, err)
 		return http.StatusBadRequest
 	}
 	defer res.Body.Close()
@@ -149,18 +146,17 @@ func (r *Rest) Put(url *types.URI) int {
 
 // Delete  http request
 func (r *Rest) Delete(url *types.URI) int {
-	ctx := context.Background()
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	request, err := http.NewRequestWithContext(ctx, "DELETE", url.String(), nil)
 	if err != nil {
-		log.Errorf("error creating post request %v", err)
+		log.Errorf("error creating delete request: %v", err)
 		return http.StatusBadRequest
 	}
 	request.Header.Set("content-type", "application/json")
 	res, err := r.client.Do(request)
 	if err != nil {
-		log.Errorf("error in post response %v to %s ", err, url)
+		log.Errorf("error in delete response to %s: %v", url, err)
 		return http.StatusBadRequest
 	}
 	defer res.Body.Close()
@@ -168,24 +164,22 @@ func (r *Rest) Delete(url *types.URI) int {
 }
 
 // Get  http request
-func (r *Rest) Get(url *types.URI) (int, string) {
-	ctx := context.Background()
-	ctx, cancel := context.WithCancel(ctx)
+func (r *Rest) Get(url *types.URI) (int, []byte, error) {
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	request, err := http.NewRequestWithContext(ctx, "GET", url.String(), nil)
 	if err != nil {
-		log.Errorf("error creating post request %v", err)
-		return http.StatusBadRequest, fmt.Sprintf("error creating post request %v", err)
+		return http.StatusBadRequest, nil, fmt.Errorf("error creating get request: %v", err)
 	}
 	request.Header.Set("content-type", "application/json")
 	res, err := r.client.Do(request)
 	if err != nil {
-		log.Errorf("error in post response %v to %s ", err, url)
-		return http.StatusBadRequest, fmt.Sprintf("error in post response %v to %s ", err, url)
+		return http.StatusBadRequest, nil, fmt.Errorf("error in get response to %s: %v", url, err)
 	}
 	defer res.Body.Close()
-	if body, readErr := io.ReadAll(res.Body); readErr == nil {
-		return res.StatusCode, string(body)
+	var body []byte
+	if body, err = io.ReadAll(res.Body); err == nil {
+		return res.StatusCode, body, nil
 	}
-	return http.StatusBadRequest, fmt.Sprintf("error in post response %v to %s ", err, url)
+	return http.StatusBadRequest, nil, fmt.Errorf("error reading body in get response to %s: %v", url, err)
 }

--- a/pkg/storage/kubernetes/client.go
+++ b/pkg/storage/kubernetes/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/golang/glog"
 	"github.com/redhat-cne/sdk-go/pkg/channel"
@@ -70,8 +71,10 @@ func (sClient *Client) CreateConfigMap(ctx context.Context, apiVersion, nodeName
 	if err == nil {
 		// clean up configMap if apiVersion changed
 		if apiVersion != "" && !validateConfigMap(apiVersion, cm) {
+			log.Warnf("ConfigMap %s is not compatible with the current version %s. Cleaning up.", cm.Name, apiVersion)
 			return sClient.cleanupConfigMap(ctx, cm, namespace)
 		}
+		log.Infof("ConfigMap %s already exists", cm.Name)
 		return cm, nil
 	}
 
@@ -91,7 +94,7 @@ func (sClient *Client) CreateConfigMap(ctx context.Context, apiVersion, nodeName
 		log.Errorf("Error creating configmap %s", err.Error())
 		return
 	}
-
+	log.Infof("ConfigMap %s created successfully", cm.Name)
 	return
 }
 
@@ -135,8 +138,7 @@ func (sClient *Client) UpdateConfigMap(ctx context.Context, data []subscriber.Su
 				log.Errorf("error marshalling subscriber %s", e.Error())
 				continue
 			}
-			log.Infof("persisting following contents %s ", string(out))
-			log.Infof("updating new subscriber in configmap")
+			log.Infof("updating new subscriber in configmap with following contents %s ", string(out))
 			existingData[data[i].ClientID.String()] = string(out)
 		}
 	}
@@ -152,34 +154,43 @@ func (sClient *Client) UpdateConfigMap(ctx context.Context, data []subscriber.Su
 }
 
 // InitConfigMap ... using configmap
-func (sClient *Client) InitConfigMap(apiVersion, storePath, nodeName, namespace string) error {
+func (sClient *Client) InitConfigMap(apiVersion, storePath, nodeName, namespace string, delay time.Duration, retry int) error {
 	var err error
 	var cm *corev1.ConfigMap
-	if cm, err = sClient.CreateConfigMap(context.Background(), apiVersion, nodeName, namespace); err == nil {
-		for clientID, subscriberData := range cm.Data {
-			var newSubscriberBytes []byte
-			var subscriberErr error
-			subscriber := subscriber.Subscriber{}
-			if err = json.Unmarshal([]byte(subscriberData), &subscriber); err == nil {
-				newSubscriberBytes, subscriberErr = json.MarshalIndent(&subscriber, "", " ")
-				if subscriberErr == nil {
-					filePath := fmt.Sprintf("%s/%s", storePath, fmt.Sprintf("%s.json", clientID))
-					log.Infof("persisting following contents %s to a file %s\n", string(newSubscriberBytes), filePath)
-					if subscriberErr = os.WriteFile(filePath, newSubscriberBytes, 0600); subscriberErr != nil {
-						log.Errorf("error writing subscription to a file %s", subscriberErr.Error())
-					}
-				} else {
-					log.Errorf("error write to a file %s", subscriberErr.Error())
-					continue
+
+	for i := 0; i <= retry; i++ {
+		cm, err = sClient.CreateConfigMap(context.Background(), apiVersion, nodeName, namespace)
+		if err == nil {
+			break
+		}
+		log.Warnf("error creating configmap %s, retrying %d", err.Error(), i)
+		time.Sleep(delay)
+	}
+	if err != nil {
+		log.Errorf("failed creating config map %s", err.Error())
+		return err
+	}
+
+	for clientID, subscriberData := range cm.Data {
+		var newSubscriberBytes []byte
+		var subscriberErr error
+		subscriber := subscriber.Subscriber{}
+		if err = json.Unmarshal([]byte(subscriberData), &subscriber); err == nil {
+			newSubscriberBytes, subscriberErr = json.MarshalIndent(&subscriber, "", " ")
+			if subscriberErr == nil {
+				filePath := fmt.Sprintf("%s/%s", storePath, fmt.Sprintf("%s.json", clientID))
+				log.Infof("persisting following contents from configmap to file %s: %s\n", filePath, string(newSubscriberBytes))
+				if subscriberErr = os.WriteFile(filePath, newSubscriberBytes, 0600); subscriberErr != nil {
+					log.Errorf("error writing subscription to a file %s", subscriberErr.Error())
 				}
 			} else {
-				log.Errorf("error unmarshalling data from configmap")
-				return err
+				log.Errorf("error marshalling subscriber data: %s", subscriberErr.Error())
+				continue
 			}
+		} else {
+			log.Errorf("error unmarshalling data from configmap")
+			return err
 		}
-	} else {
-		log.Errorf("error creating config map %s", err.Error())
-		return err
 	}
 	return nil
 }
@@ -202,6 +213,7 @@ func validateSubscriberVersion(apiVersion string, sub subscriber.Subscriber) boo
 
 	for _, v := range sub.SubStore.Store {
 		if !isVersionsCompatible(v.GetVersion(), apiVersion) {
+			log.Errorf("subscriber version %s is not compatible with the current version %s", v.GetVersion(), apiVersion)
 			return false
 		}
 	}
@@ -217,9 +229,16 @@ func validateConfigMap(apiVersion string, cm *corev1.ConfigMap) bool {
 		subscriber := subscriber.Subscriber{}
 		if err := json.Unmarshal([]byte(subscriberData), &subscriber); err == nil {
 			_, subscriberErr = json.MarshalIndent(&subscriber, "", " ")
-			if subscriberErr != nil || !validateSubscriberVersion(apiVersion, subscriber) {
+			if subscriberErr != nil {
+				log.Errorf("error marshalling subscriber data from configmap: %s", subscriberErr.Error())
 				return false
 			}
+			if !validateSubscriberVersion(apiVersion, subscriber) {
+				return false
+			}
+		} else {
+			log.Errorf("validateConfigMap: error unmarshalling data from configmap: %s", err.Error())
+			return false
 		}
 	}
 	return true

--- a/pkg/storage/kubernetes/client_test.go
+++ b/pkg/storage/kubernetes/client_test.go
@@ -3,6 +3,7 @@ package kubernetes_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
@@ -14,8 +15,10 @@ import (
 )
 
 const (
-	nodeName  = "test_node_name"
-	storePath = "."
+	nodeName               = "test_node_name"
+	storePath              = "."
+	configMapRetryInterval = 3 * time.Second
+	apiVersion             = "2.0"
 )
 
 var (
@@ -31,8 +34,62 @@ func Subscriptions() *v1.ConfigMap {
 	cm := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceSystem, Name: nodeName},
 		Data: map[string]string{
-			"03dc46b6-2493-37fa-82e2-7545714a17d6": "{\"clientID\":\"03dc46b6-2493-37fa-82e2-7545714a17d6\",\"subStore\":{\"Store\":{\"32659c8d-5a81-3522-b2e0-256675e341d1\":{\"id\":\"32659c8d-5a81-3522-b2e0-256675e341d1\",\"endpointUri\":null,\"uriLocation\":null,\"resource\":\"/cluster/node/cnfocto2.ptp.lab.eng.bos.redhat.com/sync/ptp-status/lock-state\"},\"5ddba6d8-be9b-3e74-8ba1-191d478024f8\":{\"id\":\"5ddba6d8-be9b-3e74-8ba1-191d478024f8\",\"endpointUri\":null,\"uriLocation\":null,\"resource\":\"/cluster/node/cnfocto2.ptp.lab.eng.bos.redhat.com/sync/sync-status/os-clock-sync-state\"},\"746fba50-7ce8-335f-9d8d-e12a4ab6b30b\":{\"id\":\"746fba50-7ce8-335f-9d8d-e12a4ab6b30b\",\"endpointUri\":null,\"uriLocation\":null,\"resource\":\"/cluster/node/cnfocto2.ptp.lab.eng.bos.redhat.com/sync/ptp-status/ptp-clock-class-change\"}}},\"endPointURI\":\"http://event-consumer-external3:27017\",\"status\":1,\"action\":0}",
-			"04dc46b6-2493-37fa-82e2-7545714a17d6": "{\"clientID\":\"03dc46b6-2493-37fa-82e2-7545714a17d6\",\"subStore\":{\"Store\":{\"32659c8d-5a81-3522-b2e0-256675e341d1\":{\"id\":\"32659c8d-5a81-3522-b2e0-256675e341d1\",\"endpointUri\":null,\"uriLocation\":null,\"resource\":\"/cluster/node/cnfocto2.ptp.lab.eng.bos.redhat.com/sync/ptp-status/lock-state\"},\"5ddba6d8-be9b-3e74-8ba1-191d478024f8\":{\"id\":\"5ddba6d8-be9b-3e74-8ba1-191d478024f8\",\"endpointUri\":null,\"uriLocation\":null,\"resource\":\"/cluster/node/cnfocto2.ptp.lab.eng.bos.redhat.com/sync/sync-status/os-clock-sync-state\"},\"746fba50-7ce8-335f-9d8d-e12a4ab6b30b\":{\"id\":\"746fba50-7ce8-335f-9d8d-e12a4ab6b30b\",\"endpointUri\":null,\"uriLocation\":null,\"resource\":\"/cluster/node/cnfocto2.ptp.lab.eng.bos.redhat.com/sync/ptp-status/ptp-clock-class-change\"}}},\"endPointURI\":\"http://event-consumer-external2:27017\",\"status\":1,\"action\":0}",
+			"03dc46b6-2493-37fa-82e2-7545714a17d6": `{
+				"clientID": "03dc46b6-2493-37fa-82e2-7545714a17d6",
+				"subStore": {
+					"Store": {
+						"32659c8d-5a81-3522-b2e0-256675e341d1": {
+							"SubscriptionId": "32659c8d-5a81-3522-b2e0-256675e341d1",
+							"EndpointUri": null,
+							"UriLocation": null,
+							"ResourceAddress": "/cluster/node/cnfocto2.ptp.lab.eng.bos.redhat.com/sync/ptp-status/lock-state"
+						},
+						"5ddba6d8-be9b-3e74-8ba1-191d478024f8": {
+							"SubscriptionId": "5ddba6d8-be9b-3e74-8ba1-191d478024f8",
+							"EndpointUri": null,
+							"UriLocation": null,
+							"ResourceAddress": "/cluster/node/cnfocto2.ptp.lab.eng.bos.redhat.com/sync/sync-status/os-clock-sync-state"
+						},
+						"746fba50-7ce8-335f-9d8d-e12a4ab6b30b": {
+							"SubscriptionId": "746fba50-7ce8-335f-9d8d-e12a4ab6b30b",
+							"EndpointUri": null,
+							"UriLocation": null,
+							"ResourceAddress": "/cluster/node/cnfocto2.ptp.lab.eng.bos.redhat.com/sync/ptp-status/ptp-clock-class-change"
+						}
+					}
+				},
+				"EndPointURI": "http://event-consumer-external3:27017",
+				"status": 1,
+				"action": 0
+			}`,
+			"04dc46b6-2493-37fa-82e2-7545714a17d6": `{
+				"clientID": "03dc46b6-2493-37fa-82e2-7545714a17d6",
+				"subStore": {
+					"Store": {
+						"32659c8d-5a81-3522-b2e0-256675e341d1": {
+							"SubscriptionId": "32659c8d-5a81-3522-b2e0-256675e341d1",
+							"EndpointUri": null,
+							"UriLocation": null,
+							"ResourceAddress": "/cluster/node/cnfocto2.ptp.lab.eng.bos.redhat.com/sync/ptp-status/lock-state"
+						},
+						"5ddba6d8-be9b-3e74-8ba1-191d478024f8": {
+							"SubscriptionId": "5ddba6d8-be9b-3e74-8ba1-191d478024f8",
+							"EndpointUri": null,
+							"UriLocation": null,
+							"ResourceAddress": "/cluster/node/cnfocto2.ptp.lab.eng.bos.redhat.com/sync/sync-status/os-clock-sync-state"
+						},
+						"746fba50-7ce8-335f-9d8d-e12a4ab6b30b": {
+							"SubscriptionId": "746fba50-7ce8-335f-9d8d-e12a4ab6b30b",
+							"EndpointUri": null,
+							"UriLocation": null,
+							"ResourceAddress": "/cluster/node/cnfocto2.ptp.lab.eng.bos.redhat.com/sync/ptp-status/ptp-clock-class-change"
+						}
+					}
+				},
+				"EndPointURI": "http://event-consumer-external2:27017",
+				"status": 1,
+				"action": 0
+			}`,
 		},
 	}
 	return cm
@@ -40,7 +97,7 @@ func Subscriptions() *v1.ConfigMap {
 
 func TestClient_InitConfigMap(t *testing.T) {
 	setupClient()
-	err := clients.InitConfigMap("1.0", ".", nodeName, metav1.NamespaceSystem)
+	err := clients.InitConfigMap(apiVersion, ".", nodeName, metav1.NamespaceSystem, configMapRetryInterval, 0)
 	assert.Nil(t, err)
 	cm, e := clients.GetConfigMap(context.Background(), nodeName, metav1.NamespaceSystem)
 	assert.Nil(t, e)
@@ -49,7 +106,7 @@ func TestClient_InitConfigMap(t *testing.T) {
 
 func TestClient_GetConfigMap(t *testing.T) {
 	setupClient()
-	err := clients.InitConfigMap("1.0", ".", nodeName, metav1.NamespaceSystem)
+	err := clients.InitConfigMap(apiVersion, ".", nodeName, metav1.NamespaceSystem, configMapRetryInterval, 0)
 	assert.Nil(t, err)
 	cm, e := clients.GetConfigMap(context.Background(), nodeName, metav1.NamespaceSystem)
 	assert.Nil(t, e)
@@ -59,7 +116,7 @@ func TestClient_GetConfigMap(t *testing.T) {
 
 func Test_LoadingSubscriptionFromFileToCache(t *testing.T) {
 	setupClient()
-	err := clients.InitConfigMap("1.0", ".", nodeName, metav1.NamespaceSystem)
+	err := clients.InitConfigMap(apiVersion, ".", nodeName, metav1.NamespaceSystem, configMapRetryInterval, 0)
 	assert.Nil(t, err)
 	cm, e := clients.GetConfigMap(context.Background(), nodeName, metav1.NamespaceSystem)
 	assert.Nil(t, e)


### PR DESCRIPTION
Part of changes are cherry-picks of https://github.com/redhat-cne/cloud-event-proxy/pull/444, https://github.com/redhat-cne/cloud-event-proxy/pull/469 and https://github.com/redhat-cne/cloud-event-proxy/pull/472

consumer changes:
re-subscribe in case of non-recoverable error at server side, for example lost of persist data in configmap
add git commit ID in consumer image
* New change: In v1, eventpullErrorCount is used to recover subscriptions from this scenario.

sidecar changes:
add retry in configMap creation
add trace and error handling to configMap creation and updating
