### PR TITLE
OCPBUGS-55391: reduce event logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/onsi/gomega v1.23.0
 	github.com/prometheus/client_golang v1.14.0
 	github.com/redhat-cne/rest-api v1.23.1
-	github.com/redhat-cne/sdk-go v1.23.0
+	github.com/redhat-cne/sdk-go v1.23.1
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/net v0.38.0

--- a/go.sum
+++ b/go.sum
@@ -422,8 +422,8 @@ github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0ua
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/redhat-cne/rest-api v1.23.1 h1:2lRFl5/jTpfTGSo3wt7P7m//R8PsAIFqLh6d1Z2oNwg=
 github.com/redhat-cne/rest-api v1.23.1/go.mod h1:AZc7dtEePnNKQY11/aQtNcx61vvz3q9sPZcde/Mgnk8=
-github.com/redhat-cne/sdk-go v1.23.0 h1:HxJqhqlTZJ91C5FHHb0S4ERQsVDOC6kx6n8cAKRH0Ao=
-github.com/redhat-cne/sdk-go v1.23.0/go.mod h1:+edGV2lN9v2+mXgfOC3jNH8WX5r07r+HngoK6nAnuVk=
+github.com/redhat-cne/sdk-go v1.23.1 h1:+8XtKtX9sLD5UBDQGWzG1WC7MvePRPcfl0OYR7ycDfs=
+github.com/redhat-cne/sdk-go v1.23.1/go.mod h1:+edGV2lN9v2+mXgfOC3jNH8WX5r07r+HngoK6nAnuVk=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -371,7 +371,6 @@ func GetPublishingCloudEvent(scConfig *SCConfiguration, cneEvent ceevent.Event) 
 
 // APIHealthCheck ... rest api should be ready before starting to consume api
 func APIHealthCheck(uri *types.URI, delay time.Duration) (ok bool, err error) {
-	log.Printf("checking for rest service health")
 	for i := 0; i <= 5; i++ {
 		log.Infof("health check %s", uri.String())
 		response, errResp := http.Get(uri.String())

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -192,7 +192,7 @@ github.com/redhat-cne/rest-api
 github.com/redhat-cne/rest-api/pkg/localmetrics
 github.com/redhat-cne/rest-api/pkg/restclient
 github.com/redhat-cne/rest-api/v2
-# github.com/redhat-cne/sdk-go v1.23.0
+# github.com/redhat-cne/sdk-go v1.23.1
 ## explicit; go 1.23
 github.com/redhat-cne/sdk-go/pkg/channel
 github.com/redhat-cne/sdk-go/pkg/common


### PR DESCRIPTION
Reduce logs in consumer sidecar from 3 to 1 for each v1 event pull. See detail in https://issues.redhat.com/browse/OCPBUGS-55264