### PR TITLE
Reduce clock class event noise by checking previous clock class state 

### DIFF
--- a/plugins/ptp_operator/metrics/ptp4lParse.go
+++ b/plugins/ptp_operator/metrics/ptp4lParse.go
@@ -43,13 +43,15 @@ func (p *PTPEventManager) ParsePTP4l(processName, configName, profileName, outpu
 				alias, _ = ptp4lCfg.GetUnknownAlias()
 			}
 			masterResource := fmt.Sprintf("%s/%s", alias, MasterClockType)
-			ptpStats[master].SetClockClass(int64(clockClass))
+
 			ClockClassMetrics.With(prometheus.Labels{
 				"process": processName, "node": ptpNodeName}).Set(clockClass)
-
-			p.PublishClockClassEvent(clockClass, masterResource, ptp.PtpClockClassChange)
+			if ptpStats[master].ClockClass() != int64(clockClass) {
+				ptpStats[master].SetClockClass(int64(clockClass))
+				p.PublishClockClassEvent(clockClass, masterResource, ptp.PtpClockClassChange)
+			}
 		}
-	} else if strings.Contains(output, " port ") {
+	} else if strings.Contains(output, " port ") && processName == ptp4lProcessName { // ignore anything reported by other process
 		portID, role, syncState := extractPTP4lEventState(output)
 		if portID == 0 || role == types.UNKNOWN {
 			return


### PR DESCRIPTION
Optimize ClockClass Event Publishing and Filter Non-ptp4l Port Events
This PR reduces clock class frequency that was introduced in this PR https://github.com/openshift/linuxptp-daemon/pull/427  Under linuxptp daemon repo 


This PR introduces two key improvements to the PTP metrics and event publishing logic:

    Avoid Redundant ClockClass Updates and Events
    The SetClockClass() and PublishClockClassEvent() calls are now gated by a check to ensure that the ClockClass value has actually changed. This prevents unnecessary updates and repeated event publishing when the clock class remains the same.

    Filter Out Non-ptp4l Port Events
    Modified the port event handling logic to process "port" logs only from the ptp4l process, ignoring outputs from other processes like phc2sys. This reduces noise and ensures more accurate PTP state tracking.