### PR TITLE
 OCPBUGS-56053: Suppress Error Logging for DPLL Phase Offset Calculation

### DIFF
--- a/examples/consumer/main.go
+++ b/examples/consumer/main.go
@@ -395,7 +395,6 @@ func pullEvents() {
 		}
 	}
 	for _, s := range subs {
-		getCurrentState(s.Resource)
 		if err := getCurrentState(s.Resource); err != nil {
 			log.Error(err)
 		}

--- a/plugins/ptp_operator/metrics/logparser.go
+++ b/plugins/ptp_operator/metrics/logparser.go
@@ -391,11 +391,9 @@ func (p *PTPEventManager) ParseGMLogs(processName, configName, output string, fi
 	//LOCKED->HOLDOVER
 	/// HOLDOVER-->FREERUN
 	// HOLDOVER-->LOCKED
-
-	_, phaseOffset, _, err := ptpStats[types.IFace(iface)].GetDependsOnValueState(dpllProcessName, pointer.String(iface), phaseStatus)
-	if err != nil {
-		log.Errorf("error parsing phase offset %s", err.Error())
-	}
+	//nolint:dogsled // Ignoring lint warning for blank identifiers in GetDependsOnValueState
+	_, phaseOffset, _, _ := ptpStats[types.IFace(iface)].GetDependsOnValueState(dpllProcessName, pointer.String(iface), phaseStatus)
+	// do not process error , if dpll phase is not available then it will print large offset forT-GM offset
 	ptpStats[masterType].SetLastOffset(int64(phaseOffset))
 	lastOffset := ptpStats[masterType].LastOffset()
 


### PR DESCRIPTION
This pull request addresses an issue where unnecessary error messages were being logged when retrieving the DPLL (Digital Phase-Locked Loop) phase offset in PTP statistics. 
The error log was misleading because it did not account for the time required for the DPLL to acquire phase details. This caused noise flooding , especially during the initial setup or reconfiguration.

Problem:
The existing implementation logged an error whenever the DPLL phase offset could not be immediately retrieved.

Solution:
 Removed the error logging for the phase offset retrieval in the GetDependsOnValueState function.
 noise: error parsing phase offset value not found dpll