### PR TITLE
[release-4.19] OCPBUGS-56113: Extract listening state when transitioning from faulty

### DIFF
--- a/plugins/ptp_operator/metrics/logparser.go
+++ b/plugins/ptp_operator/metrics/logparser.go
@@ -296,8 +296,7 @@ func extractPTP4lEventState(output string) (portID int, role types.PtpPortRole, 
 		strings.Contains(output, "SYNCHRONIZATION_FAULT") ||
 		strings.Contains(output, "SLAVE to UNCALIBRATED") ||
 		strings.Contains(output, "MASTER to UNCALIBRATED on RS_SLAVE") ||
-		strings.Contains(output, "LISTENING to UNCALIBRATED on RS_SLAVE") ||
-		strings.Contains(output, "FAULTY to LISTENING on INIT_COMPLETE") { // added to manage two port case so its not breaking
+		strings.Contains(output, "LISTENING to UNCALIBRATED on RS_SLAVE") {
 		role = types.FAULTY
 		clockState = ptp.HOLDOVER
 	} else if strings.Contains(output, "SLAVE to MASTER") ||


### PR DESCRIPTION
 FAULTY to LISTENING transition is reported as a FAULTY state instead of LISTENING
