### PR TITLE
[release-4.18] OCPBUGS-57036: Update Sync State Logic for Downstream Slave When All HA Interfaces Are Down

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,15 +117,20 @@ undeploy-consumer-v2:kustomize
 # For GitHub Actions CI
 gha:
 	mkdir -p $(GOPATH)/src/github.com/redhat-cne/cloud-event-proxy
-	rm -rf $(GOPATH)/src/github.com/redhat-cne/cloud-event-proxy/*
-	cp -r cmd examples pkg plugins test $(GOPATH)/src/github.com/redhat-cne/cloud-event-proxy
-	cp -r vendor/* $(GOPATH)/src
+	@if [ "$$(realpath $(GOPATH)/src/github.com/redhat-cne/cloud-event-proxy)" != "$$(realpath .)" ]; then \
+		echo "✅ Safe to delete: cleaning GOPATH workspace..."; \
+		rm -rf $(GOPATH)/src/github.com/redhat-cne/cloud-event-proxy/*; \
+		cp -r cmd examples pkg plugins test $(GOPATH)/src/github.com/redhat-cne/cloud-event-proxy; \
+		cp -r vendor/* $(GOPATH)/src; \
+		rm -rf /tmp/sub-store && mkdir -p /tmp/sub-store; \
+	else \
+		echo "⚠️ Skipping delete: GOPATH is pointing to current working directory!"; \
+	fi
+
 	GO111MODULE=off go build -a -o plugins/ptp_operator_plugin.so -buildmode=plugin plugins/ptp_operator/ptp_operator_plugin.go
 	GO111MODULE=off go build -a -o plugins/mock_plugin.so -buildmode=plugin plugins/mock/mock_plugin.go
 	GO111MODULE=off go build -a -o plugins/http_plugin.so -buildmode=plugin plugins/http/http_plugin.go
-	rm -rf /tmp/sub-store && mkdir -p /tmp/sub-store
 	GO111MODULE=off STORE_PATH=/tmp/sub-store go test ./... --tags=unittests -coverprofile=cover.out
-
 
 docker-build:
 	# make sure build the right target when developer using a Mac

--- a/plugins/ptp_operator/metrics/logparser.go
+++ b/plugins/ptp_operator/metrics/logparser.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -16,6 +17,7 @@ import (
 
 var (
 	ptpProcessStatusIdentifier = "PTP_PROCESS_STATUS"
+	numericOnly                = regexp.MustCompile(`^\d+$`)
 )
 
 func extractSummaryMetrics(processName, output string) (iface string, ptpOffset, maxPtpOffset, frequencyAdjustment, delay float64) {
@@ -254,10 +256,13 @@ func extractNmeaMetrics(processName, output string) (interfaceName string, statu
 //	     "MASTER to PASSIVE"
 func extractPTP4lEventState(output string) (portID int, role types.PtpPortRole, clockState ptp.SyncState) {
 	// This makes the out to equal
-	// phc2sys[187248.740]:[ens5f0] CLOCK_REALTIME phc offset        12 s2 freq   +6879 delay    49
-	// phc2sys[187248.740]:[ens5f1] CLOCK_REALTIME phc offset        12 s2 freq   +6879 delay    49
+
 	// ptp4l[5199193.712]: [ptp4l.0.config] port 1: SLAVE to UNCALIBRATED on SYNCHRONIZATION_FAULT
-	replacer := strings.NewReplacer("[", " ", "]", " ", ":", " ")
+	// ptp4l[28914813.104]: [ptp4l.1.config] port 1 (ens2f0): SLAVE to UNCALIBRATED on RS_SLAVE
+	clockState = ptp.FREERUN
+	role = types.UNKNOWN
+
+	var replacer = strings.NewReplacer("[", " ", "]", " ", ":", " ")
 	output = replacer.Replace(output)
 
 	index := strings.Index(output, " port ")
@@ -271,18 +276,11 @@ func extractPTP4lEventState(output string) (portID int, role types.PtpPortRole, 
 		return
 	}
 
-	portIndex := fields[1]
-	role = types.UNKNOWN
-
-	var e error
-	portID, e = strconv.Atoi(portIndex)
-	if e != nil {
-		log.Errorf("error parsing port id %s for output %s", e, output)
-		portID = 0
+	portID, err := handlePort(fields[1])
+	if err != nil {
 		return
 	}
 
-	clockState = ptp.FREERUN
 	if strings.Contains(output, "UNCALIBRATED to SLAVE") ||
 		strings.Contains(output, "LISTENING to SLAVE") {
 		role = types.SLAVE
@@ -297,7 +295,8 @@ func extractPTP4lEventState(output string) (portID int, role types.PtpPortRole, 
 	} else if strings.Contains(output, "FAULT_DETECTED") ||
 		strings.Contains(output, "SYNCHRONIZATION_FAULT") ||
 		strings.Contains(output, "SLAVE to UNCALIBRATED") ||
-		strings.Contains(output, "MASTER to UNCALIBRATED on RS_SLAVE") {
+		strings.Contains(output, "MASTER to UNCALIBRATED on RS_SLAVE") ||
+		strings.Contains(output, "LISTENING to UNCALIBRATED on RS_SLAVE") {
 		role = types.FAULTY
 		clockState = ptp.HOLDOVER
 	} else if strings.Contains(output, "SLAVE to MASTER") ||
@@ -307,6 +306,10 @@ func extractPTP4lEventState(output string) (portID int, role types.PtpPortRole, 
 	} else if strings.Contains(output, "SLAVE to LISTENING") {
 		role = types.LISTENING
 		clockState = ptp.HOLDOVER
+	} else if strings.Contains(output, "FAULTY to LISTENING") ||
+		strings.Contains(output, "UNCALIBRATED to LISTENING") ||
+		strings.Contains(output, "INITIALIZING to LISTENING") {
+		role = types.LISTENING
 	}
 	return
 }
@@ -728,4 +731,23 @@ func GetSyncStateID(state string) float64 {
 	default:
 		return 0
 	}
+}
+
+func handlePort(portIndex string) (portID int, err error) {
+	if !numericOnly.MatchString(portIndex) {
+		// Skip any non-numeric portIndex like "b49691.fffe.a3f27c-1"
+		return
+	}
+
+	portID, err = strconv.Atoi(portIndex)
+	if err != nil {
+		log.Printf("Failed to convert portIndex to int: %v", err)
+		return
+	}
+	// Use portID as needed
+	return portID, err
+}
+
+func TestFuncExtractPTP4lEventState(output string) (portID int, role types.PtpPortRole, clockState ptp.SyncState) {
+	return extractPTP4lEventState(output)
 }

--- a/plugins/ptp_operator/metrics/logparser_test.go
+++ b/plugins/ptp_operator/metrics/logparser_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/event"
 	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/ptp4lconf"
 
+	"encoding/json"
+
 	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/metrics"
 	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/stats"
 	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/types"
@@ -295,6 +297,7 @@ func Test_ParseGmLogs(t *testing.T) {
 	ptpStats := ptpEventManager.GetStats(types.ConfigName(configName))
 	replacer := strings.NewReplacer("[", " ", "]", " ", ":", " ")
 	for _, tt := range tc {
+		tt := tt
 		output := replacer.Replace(tt.output)
 		fields := strings.Fields(output)
 		ptpStats[types.IFace(tt.interfaceName)] = &stats.Stats{}
@@ -323,7 +326,6 @@ func TestExtractPTP4lEventState(t *testing.T) {
 	tests := []struct {
 		name          string
 		logLine       string
-		isFollower    bool
 		expectedPort  int
 		expectedRole  types.PtpPortRole
 		expectedState ptp.SyncState
@@ -332,7 +334,6 @@ func TestExtractPTP4lEventState(t *testing.T) {
 		{
 			name:          "b49691.fffe.a3f27c-1 changed state",
 			logLine:       "phc2sys[152918.606]: [phc2sys.2.config:6] port b49691.fffe.a3f27c-1 changed state",
-			isFollower:    false,
 			expectedPort:  0,
 			expectedRole:  types.UNKNOWN,
 			expectedState: ptp.FREERUN,
@@ -341,7 +342,6 @@ func TestExtractPTP4lEventState(t *testing.T) {
 		{
 			name:          "INITIALIZING to LISTENING",
 			logLine:       "ptp4l.0.config  port 2 (ens1f1)  INITIALIZING to LISTENING on INIT_COMPLETE",
-			isFollower:    false,
 			expectedPort:  2,
 			expectedRole:  types.LISTENING,
 			expectedState: ptp.FREERUN,
@@ -349,7 +349,6 @@ func TestExtractPTP4lEventState(t *testing.T) {
 		{
 			name:          "LISTENING to UNCALIBRATED ",
 			logLine:       "ptp4l.1.config  port 1 (ens2f0)  LISTENING to UNCALIBRATED on RS_SLAVE",
-			isFollower:    false,
 			expectedPort:  1,
 			expectedRole:  types.FAULTY,
 			expectedState: ptp.HOLDOVER,
@@ -357,7 +356,6 @@ func TestExtractPTP4lEventState(t *testing.T) {
 		{
 			name:          "FAULTY on FAULT_DETECTED",
 			logLine:       "ptp4l[72444.514]: [ptp4l.0.config:5] port 1 (ens1f0): SLAVE to FAULTY on FAULT_DETECTED (FT_UNSPECIFIED)",
-			isFollower:    false,
 			expectedPort:  1,
 			expectedRole:  types.FAULTY,
 			expectedState: ptp.HOLDOVER,
@@ -365,7 +363,6 @@ func TestExtractPTP4lEventState(t *testing.T) {
 		{
 			name:          "LISTENING to UNCALIBRATED",
 			logLine:       "ptp4l[72530.751]: [ptp4l.0.config:5] port 1 (ens1f0): LISTENING to UNCALIBRATED on RS_SLAVE",
-			isFollower:    false,
 			expectedPort:  1,
 			expectedRole:  types.FAULTY,
 			expectedState: ptp.HOLDOVER,
@@ -373,7 +370,6 @@ func TestExtractPTP4lEventState(t *testing.T) {
 		{
 			name:          "UNCALIBRATED to SLAVE ",
 			logLine:       "ptp4l[72530.885]: [ptp4l.0.config:5] port 1 (ens1f0): UNCALIBRATED to SLAVE on MASTER_CLOCK_SELECTED",
-			isFollower:    false,
 			expectedPort:  1,
 			expectedRole:  types.SLAVE,
 			expectedState: ptp.FREERUN,
@@ -381,7 +377,6 @@ func TestExtractPTP4lEventState(t *testing.T) {
 		{
 			name:          "SLAVE to UNCALIBRATED",
 			logLine:       "ptp4l[5199193.712]: [ptp4l.0.config] port 1: SLAVE to UNCALIBRATED on SYNCHRONIZATION_FAULT",
-			isFollower:    false,
 			expectedPort:  1,
 			expectedRole:  types.FAULTY,
 			expectedState: ptp.HOLDOVER,
@@ -389,7 +384,6 @@ func TestExtractPTP4lEventState(t *testing.T) {
 		{
 			name:          "LISTENING to SLAVE",
 			logLine:       "ptp4l[5199200.100]: [ptp4l.0.config] port 1: LISTENING to SLAVE",
-			isFollower:    false,
 			expectedPort:  1,
 			expectedRole:  types.SLAVE,
 			expectedState: ptp.FREERUN,
@@ -397,7 +391,6 @@ func TestExtractPTP4lEventState(t *testing.T) {
 		{
 			name:          "SLAVE to PASSIVE",
 			logLine:       "ptp4l[5199210.200]: [ptp4l.0.config] port 1: SLAVE to PASSIVE",
-			isFollower:    false,
 			expectedPort:  1,
 			expectedRole:  types.PASSIVE,
 			expectedState: ptp.FREERUN,
@@ -405,7 +398,6 @@ func TestExtractPTP4lEventState(t *testing.T) {
 		{
 			name:          "SLAVE to MASTER",
 			logLine:       "ptp4l[5199220.300]: [ptp4l.0.config] port 1: SLAVE to MASTER",
-			isFollower:    false,
 			expectedPort:  1,
 			expectedRole:  types.MASTER,
 			expectedState: ptp.HOLDOVER,
@@ -413,7 +405,6 @@ func TestExtractPTP4lEventState(t *testing.T) {
 		{
 			name:          "INITIALIZING to LISTENING (follower only)",
 			logLine:       "ptp4l[5199230.400]: [ptp4l.0.config] port 1: INITIALIZING to LISTENING",
-			isFollower:    true,
 			expectedPort:  1,
 			expectedRole:  types.LISTENING,
 			expectedState: ptp.FREERUN,
@@ -421,18 +412,224 @@ func TestExtractPTP4lEventState(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			portID, role, clockState := metrics.TestFuncExtractPTP4lEventState(tc.logLine)
+		tc := tc
+		for _, followers := range []int{0, 1, 2} {
+			t.Run(tc.name, func(t *testing.T) {
+				portID, role, clockState := metrics.TestFuncExtractPTP4lEventState(tc.logLine)
 
-			if portID != tc.expectedPort {
-				assert.Equal(t, tc.expectedPort, portID, fmt.Sprintf("portID = %d; want %d", portID, tc.expectedPort))
-			}
-			if role != tc.expectedRole {
-				assert.Equal(t, tc.expectedRole, role, fmt.Sprintf("role = %v; want %v", role, tc.expectedRole))
-			}
-			if clockState != tc.expectedState {
-				assert.Equal(t, tc.expectedPort, clockState, fmt.Sprintf("state = %v; want %v", clockState, tc.expectedState))
-			}
-		})
+				if portID != tc.expectedPort {
+					assert.Equal(t, tc.expectedPort, portID, fmt.Sprintf("with followers(%d) portID = %d; want %d", followers, portID, tc.expectedPort))
+				}
+				if role != tc.expectedRole {
+					assert.Equal(t, tc.expectedRole, role, fmt.Sprintf("with followers(%d) role = %v; want %v", followers, role, tc.expectedRole))
+				}
+				if clockState != tc.expectedState {
+					assert.Equal(t, tc.expectedPort, clockState, fmt.Sprintf("with followers(%d) state = %v; want %v", followers, clockState, tc.expectedState))
+				}
+			})
+		}
 	}
+}
+
+func TestParsePTP4l(t *testing.T) {
+	tests := []struct {
+		name                string
+		processName         string
+		configName          string
+		profileName         string
+		output              string
+		fields              []string
+		expectedStateChange bool
+		expectedMasterState ptp.SyncState // expected state when exiting
+		expectedOSState     ptp.SyncState
+		ptpInterface        ptp4lconf.PTPInterface
+		ptp4lCfg            *ptp4lconf.PTP4lConfig
+		lastSyncState       ptp.SyncState // what ws the last sync state before entering new state
+		expectedError       bool
+	}{
+		{
+			name:        "valid CLOCK_CLASS_CHANGE event",
+			processName: "ptp4l",
+			configName:  "ptp4l.0.config",
+			profileName: "test-profile",
+			output:      "ptp4l 1646672953 ptp4l.0.config CLOCK_CLASS_CHANGE 165.000000",
+			fields:      []string{"ptp4l", "1646672953", "ptp4l.0.config", "CLOCK_CLASS_CHANGE", "165.000000"},
+			ptpInterface: ptp4lconf.PTPInterface{
+				Name: "ens2f0",
+			},
+			ptp4lCfg: &ptp4lconf.PTP4lConfig{
+				Interfaces: []*ptp4lconf.PTPInterface{
+					{
+						Name:     "ens2f0",
+						PortID:   1,
+						PortName: "port 1",
+						Role:     types.SLAVE, //master
+					},
+					{
+						Name:     "ens2f1",
+						PortID:   2,
+						PortName: "port 2",
+						Role:     types.MASTER, // master
+					},
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name:        "SLAVE changing to FAULT",
+			processName: "ptp4l",
+			configName:  "ptp4l.0.config",
+			profileName: "test-profile",
+			output:      "ptp4l[72444.514]: [ptp4l.0.config:5] port 1 (ens2f0): SLAVE to FAULTY on FAULT_DETECTED (FT_UNSPECIFIED)",
+			fields:      []string{"ptp4l", "1646672953", "ptp4l.0.config", "port", "1", "(ens2f0)", "SLAVE to FAULTY on FAULT_DETECTED (FT_UNSPECIFIED)"},
+			ptpInterface: ptp4lconf.PTPInterface{
+				Name: "ens2f0",
+			},
+			ptp4lCfg: &ptp4lconf.PTP4lConfig{
+				Interfaces: []*ptp4lconf.PTPInterface{
+					{
+						Name:     "ens2f0",
+						PortID:   1,
+						PortName: "port 1",
+						Role:     types.SLAVE,
+					},
+					{
+						Name:     "ens2f1",
+						PortID:   2,
+						PortName: "port 2",
+						Role:     types.MASTER, // master
+					},
+				},
+			},
+			expectedMasterState: ptp.HOLDOVER,
+			expectedStateChange: true,
+			lastSyncState:       ptp.LOCKED,
+			expectedError:       false,
+		},
+		{
+			name:        "FAULTY Changing to SLAVE",
+			processName: "ptp4l",
+			configName:  "ptp4l.0.config",
+			profileName: "test-profile",
+			output:      "ptp4l[72444.514]: [ptp4l.0.config:5] port 1 (ens2f0): FAULTY to SLAVE",
+			fields:      []string{"ptp4l", "1646672953", "ptp4l.0.config", "port", "1", "(ens2f0)", "FAULTY to SLAVE"},
+			ptpInterface: ptp4lconf.PTPInterface{
+				Name: "ens2f0",
+			},
+			ptp4lCfg: &ptp4lconf.PTP4lConfig{
+				Interfaces: []*ptp4lconf.PTPInterface{
+					{
+						Name:     "ens2f0",
+						PortID:   1,
+						PortName: "port 1",
+						Role:     types.FAULTY,
+					},
+					{
+						Name:     "ens2f1",
+						PortID:   2,
+						PortName: "port 2",
+						Role:     types.MASTER, // master
+					},
+				},
+			},
+			expectedMasterState: ptp.HOLDOVER, //stays in holdover in 4.18 , when backporting we need to check this to make it FREERUN
+			lastSyncState:       ptp.HOLDOVER,
+			expectedStateChange: true,
+			expectedError:       false,
+		},
+		{
+			name:        "LISTENING Changing to SLAVE",
+			processName: "ptp4l",
+			configName:  "ptp4l.0.config",
+			profileName: "test-profile",
+			output:      "ptp4l[72444.514]: [ptp4l.0.config:5] port 1 (ens2f1): LISTENING to SLAVE",
+			fields:      []string{"ptp4l", "1646672953", "ptp4l.0.config", "port", "2", "(ens2f1)", "LISTENING to SLAVE"},
+			ptpInterface: ptp4lconf.PTPInterface{
+				Name: "ens2f0",
+			},
+			ptp4lCfg: &ptp4lconf.PTP4lConfig{
+				Interfaces: []*ptp4lconf.PTPInterface{
+					{
+						Name:     "ens2f0",
+						PortID:   1,
+						PortName: "port 1",
+						Role:     types.FAULTY,
+					},
+					{
+						Name:     "ens2f1",
+						PortID:   2,
+						PortName: "port 2",
+						Role:     types.LISTENING, // master
+					},
+				},
+			},
+			expectedMasterState: ptp.FREERUN, // Here if the last state was freerun then satys in free run until it gets a locked
+			lastSyncState:       ptp.FREERUN,
+			expectedStateChange: true,
+			expectedError:       false,
+		},
+		{
+			name:        "SLAVE Changing to LISTENING",
+			processName: "ptp4l",
+			configName:  "ptp4l.0.config",
+			profileName: "test-profile",
+			output:      "ptp4l[72444.514]: [ptp4l.0.config:5] port 1 (ens2f0): SLAVE to LISTENING",
+			fields:      []string{"ptp4l", "1646672953", "ptp4l.0.config", "port", "2", "(ens2f0)", "SLAVE to LISTENING"},
+			ptpInterface: ptp4lconf.PTPInterface{
+				Name: "ens2f0",
+			},
+			ptp4lCfg: &ptp4lconf.PTP4lConfig{
+				Interfaces: []*ptp4lconf.PTPInterface{
+					{
+						Name:     "ens2f0",
+						PortID:   1,
+						PortName: "port 1",
+						Role:     types.SLAVE,
+					},
+					{
+						Name:     "ens2f1",
+						PortID:   2,
+						PortName: "port 2",
+						Role:     types.LISTENING, // master
+					},
+				},
+			},
+			expectedMasterState: ptp.HOLDOVER, //stays in holdover in 4.18 , when backporting we need to check this to make it FREERUN
+			lastSyncState:       ptp.LOCKED,
+			expectedStateChange: true,
+			expectedError:       false,
+		},
+	}
+	ptpEventManager := metrics.NewPTPEventManager("", initPubSubTypes(), "tetsnode", nil)
+	ptpEventManager.MockTest(true)
+	for _, followers := range []int{1, 2} {
+		followers := followers // 👈 capture the value of `followers` too
+		for _, tt := range tests {
+			tt := tt // Important: capture tt for each iteration
+			tt.ptp4lCfg = deepCopyPTP4lCfg(tt.ptp4lCfg)
+			t.Run(tt.name, func(t *testing.T) {
+				if followers == 2 {
+					tt.ptp4lCfg.Interfaces[1].UpdateRole(types.LISTENING)
+				}
+
+				metrics.SetMasterOffsetSource(tt.processName)
+				ptpEventManager.Stats[types.ConfigName(tt.configName)] = make(stats.PTPStats)
+				ptpStats := ptpEventManager.GetStats(types.ConfigName(tt.configName))
+				ptpStats.CheckSource(metrics.ClockRealTime, configName, tt.processName)
+				ptpStats.CheckSource(metrics.MasterClockType, configName, tt.processName)
+				ptpStats[metrics.MasterClockType].SetLastSyncState(tt.lastSyncState)
+				ptpEventManager.ParsePTP4l(tt.processName, tt.configName, tt.profileName, tt.output, tt.fields, tt.ptpInterface, tt.ptp4lCfg, ptpStats)
+				if tt.expectedStateChange {
+					assert.Equal(t, tt.expectedMasterState, ptpStats[metrics.MasterClockType].LastSyncState(), fmt.Sprintf("%s-followers(%d) state = %v; want %v", tt.name, followers, ptpStats[metrics.MasterClockType].LastSyncState(), tt.expectedMasterState))
+				}
+			})
+		}
+	}
+}
+
+func deepCopyPTP4lCfg(src *ptp4lconf.PTP4lConfig) *ptp4lconf.PTP4lConfig {
+	var copied ptp4lconf.PTP4lConfig
+	raw, _ := json.Marshal(src)
+	_ = json.Unmarshal(raw, &copied)
+	return &copied
 }

--- a/plugins/ptp_operator/metrics/logparser_test.go
+++ b/plugins/ptp_operator/metrics/logparser_test.go
@@ -1,6 +1,7 @@
 package metrics_test
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 	"testing"
@@ -315,5 +316,123 @@ func Test_ParseGmLogs(t *testing.T) {
 		lastState, errState := ptpStats[masterType].GetStateState(tt.processName, pointer.String(tt.interfaceName))
 		assert.Equal(t, errState, nil)
 		assert.Equal(t, tt.expectedState, lastState)
+	}
+}
+
+func TestExtractPTP4lEventState(t *testing.T) {
+	tests := []struct {
+		name          string
+		logLine       string
+		isFollower    bool
+		expectedPort  int
+		expectedRole  types.PtpPortRole
+		expectedState ptp.SyncState
+	}{
+
+		{
+			name:          "b49691.fffe.a3f27c-1 changed state",
+			logLine:       "phc2sys[152918.606]: [phc2sys.2.config:6] port b49691.fffe.a3f27c-1 changed state",
+			isFollower:    false,
+			expectedPort:  0,
+			expectedRole:  types.UNKNOWN,
+			expectedState: ptp.FREERUN,
+		},
+
+		{
+			name:          "INITIALIZING to LISTENING",
+			logLine:       "ptp4l.0.config  port 2 (ens1f1)  INITIALIZING to LISTENING on INIT_COMPLETE",
+			isFollower:    false,
+			expectedPort:  2,
+			expectedRole:  types.LISTENING,
+			expectedState: ptp.FREERUN,
+		},
+		{
+			name:          "LISTENING to UNCALIBRATED ",
+			logLine:       "ptp4l.1.config  port 1 (ens2f0)  LISTENING to UNCALIBRATED on RS_SLAVE",
+			isFollower:    false,
+			expectedPort:  1,
+			expectedRole:  types.FAULTY,
+			expectedState: ptp.HOLDOVER,
+		},
+		{
+			name:          "FAULTY on FAULT_DETECTED",
+			logLine:       "ptp4l[72444.514]: [ptp4l.0.config:5] port 1 (ens1f0): SLAVE to FAULTY on FAULT_DETECTED (FT_UNSPECIFIED)",
+			isFollower:    false,
+			expectedPort:  1,
+			expectedRole:  types.FAULTY,
+			expectedState: ptp.HOLDOVER,
+		},
+		{
+			name:          "LISTENING to UNCALIBRATED",
+			logLine:       "ptp4l[72530.751]: [ptp4l.0.config:5] port 1 (ens1f0): LISTENING to UNCALIBRATED on RS_SLAVE",
+			isFollower:    false,
+			expectedPort:  1,
+			expectedRole:  types.FAULTY,
+			expectedState: ptp.HOLDOVER,
+		},
+		{
+			name:          "UNCALIBRATED to SLAVE ",
+			logLine:       "ptp4l[72530.885]: [ptp4l.0.config:5] port 1 (ens1f0): UNCALIBRATED to SLAVE on MASTER_CLOCK_SELECTED",
+			isFollower:    false,
+			expectedPort:  1,
+			expectedRole:  types.SLAVE,
+			expectedState: ptp.FREERUN,
+		},
+		{
+			name:          "SLAVE to UNCALIBRATED",
+			logLine:       "ptp4l[5199193.712]: [ptp4l.0.config] port 1: SLAVE to UNCALIBRATED on SYNCHRONIZATION_FAULT",
+			isFollower:    false,
+			expectedPort:  1,
+			expectedRole:  types.FAULTY,
+			expectedState: ptp.HOLDOVER,
+		},
+		{
+			name:          "LISTENING to SLAVE",
+			logLine:       "ptp4l[5199200.100]: [ptp4l.0.config] port 1: LISTENING to SLAVE",
+			isFollower:    false,
+			expectedPort:  1,
+			expectedRole:  types.SLAVE,
+			expectedState: ptp.FREERUN,
+		},
+		{
+			name:          "SLAVE to PASSIVE",
+			logLine:       "ptp4l[5199210.200]: [ptp4l.0.config] port 1: SLAVE to PASSIVE",
+			isFollower:    false,
+			expectedPort:  1,
+			expectedRole:  types.PASSIVE,
+			expectedState: ptp.FREERUN,
+		},
+		{
+			name:          "SLAVE to MASTER",
+			logLine:       "ptp4l[5199220.300]: [ptp4l.0.config] port 1: SLAVE to MASTER",
+			isFollower:    false,
+			expectedPort:  1,
+			expectedRole:  types.MASTER,
+			expectedState: ptp.HOLDOVER,
+		},
+		{
+			name:          "INITIALIZING to LISTENING (follower only)",
+			logLine:       "ptp4l[5199230.400]: [ptp4l.0.config] port 1: INITIALIZING to LISTENING",
+			isFollower:    true,
+			expectedPort:  1,
+			expectedRole:  types.LISTENING,
+			expectedState: ptp.FREERUN,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			portID, role, clockState := metrics.TestFuncExtractPTP4lEventState(tc.logLine)
+
+			if portID != tc.expectedPort {
+				assert.Equal(t, tc.expectedPort, portID, fmt.Sprintf("portID = %d; want %d", portID, tc.expectedPort))
+			}
+			if role != tc.expectedRole {
+				assert.Equal(t, tc.expectedRole, role, fmt.Sprintf("role = %v; want %v", role, tc.expectedRole))
+			}
+			if clockState != tc.expectedState {
+				assert.Equal(t, tc.expectedPort, clockState, fmt.Sprintf("state = %v; want %v", clockState, tc.expectedState))
+			}
+		})
 	}
 }

--- a/plugins/ptp_operator/metrics/metrics.go
+++ b/plugins/ptp_operator/metrics/metrics.go
@@ -377,3 +377,8 @@ func getAlias(iface string) string {
 	r := []rune(iface)
 	return string(r[:len(r)-1]) + "x"
 }
+
+// SetMasterOffsetSource .. setting for testing purposes
+func SetMasterOffsetSource(processName string) {
+	masterOffsetSource = processName
+}

--- a/plugins/ptp_operator/metrics/metrics.go
+++ b/plugins/ptp_operator/metrics/metrics.go
@@ -86,6 +86,7 @@ func (p *PTPEventManager) ExtractMetrics(msg string) {
 			log.Errorf("failed to extract %s", msg)
 		}
 	}()
+
 	replacer := strings.NewReplacer("[", " ", "]", " ", ":", " ")
 	output := replacer.Replace(msg)
 	fields := strings.Fields(output)

--- a/plugins/ptp_operator/metrics/ptp4lParse.go
+++ b/plugins/ptp_operator/metrics/ptp4lParse.go
@@ -51,11 +51,12 @@ func (p *PTPEventManager) ParsePTP4l(processName, configName, profileName, outpu
 				p.PublishClockClassEvent(clockClass, masterResource, ptp.PtpClockClassChange)
 			}
 		}
-	} else if strings.Contains(output, " port ") {
+	} else if strings.Contains(output, " port ") && processName == ptp4lProcessName { // ignore anything reported by other process
 		portID, role, syncState := extractPTP4lEventState(output)
 		if portID == 0 || role == types.UNKNOWN {
 			return
 		}
+
 		if ptpInterface, err = ptp4lCfg.ByPortID(portID); err != nil {
 			log.Error(err)
 			log.Errorf("possible error due to file watcher not updated")
@@ -93,7 +94,7 @@ func (p *PTPEventManager) ParsePTP4l(processName, configName, profileName, outpu
 					ptpStats[master].SetRole(role)
 				}
 			}
-			log.Infof("update interface %s with portid %d from role %s to role %s", ptpIFace, portID, lastRole, role)
+			log.Infof("update interface %s with portid %d from role %s to role %s  out %s", ptpIFace, portID, lastRole, role, output)
 			ptp4lCfg.Interfaces[portID-1].UpdateRole(role)
 
 			// update role metrics
@@ -120,16 +121,11 @@ func (p *PTPEventManager) ParsePTP4l(processName, configName, profileName, outpu
 				p.PublishEvent(syncState, ptpStats[master].LastOffset(), masterResource, ptp.PtpStateChange)
 				ptpStats[master].SetLastSyncState(syncState)
 				UpdateSyncStateMetrics(ptpStats[master].ProcessName(), alias, syncState)
-				// Put CLOCK_REALTIME in FREERUN state
-				var ptpOpts *ptpConfig.PtpProcessOpts
-				var ok bool
-				if ptpOpts, ok = p.PtpConfigMapUpdates.PtpProcessOpts[profileName]; ok && ptpOpts != nil && ptpOpts.Phc2SysEnabled() {
-					p.PublishEvent(ptp.FREERUN, ptpStats[ClockRealTime].LastOffset(), ClockRealTime, ptp.OsClockSyncStateChange)
-					ptpStats[ClockRealTime].SetLastSyncState(ptp.FREERUN)
-					UpdateSyncStateMetrics(phc2sysProcessName, ClockRealTime, ptp.FREERUN)
+				if ptpOpts, ok := p.PtpConfigMapUpdates.PtpProcessOpts[profileName]; ok && ptpOpts != nil {
+					p.maybePublishOSClockSyncStateChangeEvent(ptpOpts, configName, profileName)
+					threshold := p.PtpThreshold(profileName, true)
+					go handleHoldOverState(p, ptpOpts, configName, profileName, threshold.HoldOverTimeout, ptpStats[MasterClockType].Alias(), threshold.Close)
 				}
-				threshold := p.PtpThreshold(profileName, true)
-				go handleHoldOverState(p, ptpOpts, configName, profileName, threshold.HoldOverTimeout, MasterClockType, threshold.Close)
 			}
 		}
 	}
@@ -140,7 +136,7 @@ func handleHoldOverState(ptpManager *PTPEventManager,
 	ptpProfileName string, holdoverTimeout int64,
 	ptpIFace string, c chan struct{}) {
 	defer func() {
-		log.Infof("exiting holdover for interface %s", ptpIFace)
+		log.Infof("exiting holdover for profile %s with interface %s", ptpProfileName, ptpIFace)
 		if r := recover(); r != nil {
 			fmt.Println("Recovered in f", r)
 		}
@@ -150,7 +146,7 @@ func handleHoldOverState(ptpManager *PTPEventManager,
 		log.Infof("call received to close holderover timeout")
 		return
 	case <-time.After(time.Duration(holdoverTimeout) * time.Second):
-		log.Infof("time expired for interface %s", ptpIFace)
+		log.Infof("holdover time expired for interface %s", ptpIFace)
 		ptpStats := ptpManager.GetStats(types.ConfigName(configName))
 		if mStats, found := ptpStats[master]; found {
 			if mStats.LastSyncState() == ptp.HOLDOVER { // if it was still in holdover while timing out then switch to FREERUN
@@ -161,16 +157,69 @@ func handleHoldOverState(ptpManager *PTPEventManager,
 				ptpStats[MasterClockType].SetLastSyncState(ptp.FREERUN)
 				UpdateSyncStateMetrics(mStats.ProcessName(), mStats.Alias(), ptp.FREERUN)
 				// don't check of os clock sync state if phc2 not enabled
-				if cStats, ok := ptpStats[ClockRealTime]; ok && ptpOpts != nil && ptpOpts.Phc2SysEnabled() {
-					ptpManager.GenPTPEvent(ptpProfileName, cStats, ClockRealTime, FreeRunOffsetValue, ptp.FREERUN, ptp.OsClockSyncStateChange)
-					UpdateSyncStateMetrics(phc2sysProcessName, ClockRealTime, ptp.FREERUN)
-				} else {
-					log.Infof("phc2sys is not enabled for profile %s, skiping os clock syn state ", ptpProfileName)
-				}
-				// s.reset()
+				ptpManager.maybePublishOSClockSyncStateChangeEvent(ptpOpts, configName, ptpProfileName)
 			}
 		} else {
 			log.Errorf("failed to switch from holdover, could not find ptpStats for interface %s", ptpIFace)
 		}
+	}
+}
+
+func (p *PTPEventManager) maybePublishOSClockSyncStateChangeEvent(
+	ptpOpts *ptpConfig.PtpProcessOpts, configName, ptpProfileName string) {
+	if ptpOpts == nil {
+		log.Error("No profile found in configuration; OS clock sync state change event not published.")
+		return
+	}
+
+	// Already in a synced state, check if we need to emit FREERUN event
+	publish := false
+	haProfile, haProfiles := p.ListHAProfilesWith(ptpProfileName)
+
+	if ptpOpts.Phc2SysEnabled() {
+		publish = true
+	} else if len(haProfiles) > 0 { // Check if we are in a HA profile
+		haConfigName := p.GetPTPConfigByProfile(haProfile)
+
+		// Proceed only if we were able to retrieve the system clock config
+		if len(haConfigName) > 0 {
+			configName = haConfigName // change to phc2sys config name
+			for _, hProfile := range haProfiles {
+				if hProfile == ptpProfileName {
+					continue // Skip current (already known to be faulty)
+				}
+				checkConfig := p.GetPTPConfigByProfile(hProfile)
+				if len(checkConfig) == 0 {
+					continue
+				}
+
+				if haStats, exists := p.GetStats(types.ConfigName(checkConfig))[master]; exists && haStats.Role() == types.SLAVE {
+					log.Infof("HA profile %s is still in SLAVE state, not setting CLOCK_REALTIME to FREERUN", hProfile)
+					return
+				}
+			}
+			// If all other HA profiles are non-SLAVE or missing, we can publish
+			publish = true
+			// set to the one that is in the HA profile
+			ptpProfileName = haProfile
+		} else {
+			return // No HA profile found, nothing to publish
+		}
+	}
+
+	ptpStats := p.GetStats(types.ConfigName(configName))
+	cStats, ok := ptpStats[ClockRealTime]
+	if !ok {
+		// ClockRealTime stats not available, nothing to publish
+		return
+	}
+	if cStats.LastSyncState() == ptp.FREERUN {
+		// Already in FREERUN, no need to publish again
+		return
+	}
+
+	if publish {
+		p.GenPTPEvent(ptpProfileName, cStats, ClockRealTime, FreeRunOffsetValue, ptp.FREERUN, ptp.OsClockSyncStateChange)
+		UpdateSyncStateMetrics(phc2sysProcessName, ClockRealTime, ptp.FREERUN)
 	}
 }

--- a/plugins/ptp_operator/ptp_operator_plugin.go
+++ b/plugins/ptp_operator/ptp_operator_plugin.go
@@ -136,7 +136,7 @@ func Start(wg *sync.WaitGroup, configuration *common.SCConfiguration, _ func(e i
 					// delete all metrics related to process
 					ptpMetrics.DeleteProcessStatusMetricsForConfig(nodeName, "", "")
 					// delete all metrics related to ptp ha if haProfile is deleted
-					if haProfiles := eventManager.HAProfiles(); len(haProfiles) > 0 {
+					if _, haProfiles := eventManager.HAProfiles(); len(haProfiles) > 0 {
 						for _, p := range haProfiles {
 							ptpMetrics.DeletePTPHAMetrics(strings.TrimSpace(p))
 						}

--- a/plugins/ptp_operator/ptp_operator_plugin.go
+++ b/plugins/ptp_operator/ptp_operator_plugin.go
@@ -457,6 +457,7 @@ func processPtp4lConfigFileUpdates() {
 					Profile:    *ptpConfigEvent.Profile,
 					Interfaces: ptpInterfaces,
 				}
+
 				// add to eventManager
 				eventManager.AddPTPConfig(ptpConfigFileName, ptp4lConfig)
 				// clean up process metrics


### PR DESCRIPTION

This manual cherry pick of https://github.com/redhat-cne/cloud-event-proxy/pull/470
and DEPENDS on https://github.com/redhat-cne/cloud-event-proxy/pull/529
`need to rebase this PR with 4.18 branch after https://github.com/redhat-cne/cloud-event-proxy/pull/529 is merged` 

In OC configuration with single port or dual follower port , taking down both interfaces leads to unexpected behavior:The interface role transitions from SLAVE to LISTENING, but the system does not correctly reflect this loss of sync.

When any port transitions from SLAVE to FAULTY, it will go through the HOLDOVER state. This should resolve the issue, so no special handling is needed — all transitions will consistently pass through HOLDOVER.
For example:
If port 1 becomes FAULTY and port 2 transitions to SLAVE, HOLDOVER should be released.
If both ports transition to FAULTY, the system will move to FREERUN via the HOLDOVER state.