### PR TITLE
OCPBUGS-57063: fix concurrent map read in getCurrentStatOverrideFn

### DIFF
--- a/plugins/ptp_operator/metrics/manager_test.go
+++ b/plugins/ptp_operator/metrics/manager_test.go
@@ -4,15 +4,17 @@
 package metrics_test
 
 import (
-	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/types"
 	"testing"
+
+	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/types"
+
+	"sync"
 
 	ptpConfig "github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/config"
 	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/metrics"
 	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/stats"
 	"github.com/redhat-cne/sdk-go/pkg/event/ptp"
 	"github.com/stretchr/testify/assert"
-	"sync"
 )
 
 func TestPTPEventManager_GenPTPEvent(t *testing.T) {
@@ -164,9 +166,9 @@ func TestConcurrentMapAccess(t *testing.T) {
 	}
 	manager.MockTest(true)
 	// Function to simulate concurrent writes
-	writeFunc := func(wg *sync.WaitGroup, key string, value stats.PTPStats) {
+	writeFunc := func(wg *sync.WaitGroup, key types.ConfigName, value stats.PTPStats) {
 		defer wg.Done()
-		manager.GetStats(types.ConfigName(configName))
+		manager.SetStats(key, value)
 	}
 
 	// Function to simulate concurrent reads

--- a/plugins/ptp_operator/ptp_operator_plugin.go
+++ b/plugins/ptp_operator/ptp_operator_plugin.go
@@ -231,9 +231,8 @@ func getCurrentStatOverrideFn() func(e v2.Event, d *channel.DataChan) error {
 		}
 
 		var overallSyncState ptp.SyncState
-
-		for _, ptpStats := range eventManager.Stats { // configname->PTPStats
-			for ptpInterface, s := range ptpStats { // iface->stats
+		for config := range eventManager.Stats { // configname->PTPStats
+			for ptpInterface, s := range eventManager.GetStats(config) { // iface->stats
 				switch ptpInterface {
 				case ptpMetrics.MasterClockType:
 					if s.Alias() != "" {
@@ -334,7 +333,7 @@ func getCurrentStatOverrideFn() func(e v2.Event, d *channel.DataChan) error {
 				return err
 			}
 			d.Data.SetSource(string(eventSource))
-			log.Errorf("could not find any events for requested resource type %s", e.Source())
+			log.Errorf("event data not found for requested resource type %s", e.Source())
 			return nil
 		}
 		return nil


### PR DESCRIPTION
- Use concurrent map read eventManager.GetStats() in getCurrentStatOverrideFn
- fix error log when event data not found