### PR TITLE
[release-4.17] OCPBUGS-58310: ptp all sync-state event should be FREERUN. Instead sends event as LOCKED and resource address should be consistent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,13 +117,19 @@ undeploy-consumer-v2:kustomize
 # For GitHub Actions CI
 gha:
 	mkdir -p $(GOPATH)/src/github.com/redhat-cne/cloud-event-proxy
-	rm -rf $(GOPATH)/src/github.com/redhat-cne/cloud-event-proxy/*
-	cp -r cmd examples pkg plugins test $(GOPATH)/src/github.com/redhat-cne/cloud-event-proxy
-	cp -r vendor/* $(GOPATH)/src
+	@if [ "$$(realpath $(GOPATH)/src/github.com/redhat-cne/cloud-event-proxy)" != "$$(realpath .)" ]; then \
+		echo "✅ Safe to delete: cleaning GOPATH workspace..."; \
+		rm -rf $(GOPATH)/src/github.com/redhat-cne/cloud-event-proxy/*; \
+		cp -r cmd examples pkg plugins test $(GOPATH)/src/github.com/redhat-cne/cloud-event-proxy; \
+		cp -r vendor/* $(GOPATH)/src; \
+		rm -rf /tmp/sub-store && mkdir -p /tmp/sub-store; \
+	else \
+		echo "⚠️ Skipping delete: GOPATH is pointing to current working directory!"; \
+	fi
+
 	GO111MODULE=off go build -a -o plugins/ptp_operator_plugin.so -buildmode=plugin plugins/ptp_operator/ptp_operator_plugin.go
 	GO111MODULE=off go build -a -o plugins/mock_plugin.so -buildmode=plugin plugins/mock/mock_plugin.go
 	GO111MODULE=off go build -a -o plugins/http_plugin.so -buildmode=plugin plugins/http/http_plugin.go
-	rm -rf /tmp/sub-store && mkdir -p /tmp/sub-store
 	GO111MODULE=off STORE_PATH=/tmp/sub-store go test ./... --tags=unittests -coverprofile=cover.out
 
 docker-build: #test ## Build docker image with the manager.

--- a/plugins/ptp_operator/metrics/logparser.go
+++ b/plugins/ptp_operator/metrics/logparser.go
@@ -390,10 +390,10 @@ func (p *PTPEventManager) ParseGMLogs(processName, configName, output string, fi
 	ptpStats[masterType].SetLastOffset(int64(phaseOffset))
 	lastOffset := ptpStats[masterType].LastOffset()
 
-	if clockState.State != lastClockState { // publish directly here
+	if clockState.State != lastClockState && clockState.State != "" { // publish directly here
 		log.Infof("%s sync state %s, last ptp state is : %s", masterResource, clockState.State, lastClockState)
-		p.PublishEvent(clockState.State, lastOffset, masterResource, ptp.PtpStateChange)
 		ptpStats[masterType].SetLastSyncState(clockState.State)
+		p.PublishEvent(clockState.State, lastOffset, masterResource, ptp.PtpStateChange)
 		UpdateSyncStateMetrics(processName, alias, ptpStats[masterType].LastSyncState())
 		UpdatePTPOffsetMetrics(processName, processName, alias, float64(lastOffset))
 	}

--- a/plugins/ptp_operator/metrics/manager.go
+++ b/plugins/ptp_operator/metrics/manager.go
@@ -27,7 +27,7 @@ type PTPEventManager struct {
 	lock           sync.RWMutex
 	Stats          map[types.ConfigName]stats.PTPStats
 	mock           bool
-	mockEvent      ptp.EventType
+	mockEvent      []ptp.EventType
 	// PtpConfigMapUpdates holds ptp-configmap updated details
 	PtpConfigMapUpdates *ptpConfig.LinuxPTPConfigMapUpdate
 	// Ptp4lConfigInterfaces holds interfaces and its roles, after reading from ptp4l config files
@@ -124,6 +124,16 @@ func (p *PTPEventManager) GetPTPConfig(configName types.ConfigName) *ptp4lconf.P
 	return pc
 }
 
+// GetPTPConfigByProfile ...
+func (p *PTPEventManager) GetPTPConfigByProfile(profile string) string {
+	for _, config := range p.Ptp4lConfigInterfaces {
+		if config.Profile == profile {
+			return config.Name
+		}
+	}
+	return ""
+}
+
 // GetPTPConfigDeepCopy  ... Add PtpConfigUpdate obj
 func (p *PTPEventManager) GetPTPConfigDeepCopy(configName types.ConfigName) *ptp4lconf.PTP4lConfig {
 	if _, ok := p.Ptp4lConfigInterfaces[configName]; ok && p.Ptp4lConfigInterfaces[configName] != nil {
@@ -199,7 +209,7 @@ func (p *PTPEventManager) DeletePTPConfig(key types.ConfigName) {
 // PublishClockClassEvent ...publish events
 func (p *PTPEventManager) PublishClockClassEvent(clockClass float64, source string, eventType ptp.EventType) {
 	if p.mock {
-		p.mockEvent = eventType
+		p.mockEvent = []ptp.EventType{eventType}
 		log.Infof("PublishClockClassEvent clockClass=%f, source=%s, eventType=%s", clockClass, source, eventType)
 		return
 	}
@@ -211,7 +221,7 @@ func (p *PTPEventManager) PublishClockClassEvent(clockClass float64, source stri
 // PublishClockClassEvent ...publish events
 func (p *PTPEventManager) publishGNSSEvent(state int64, offset float64, syncState ptp.SyncState, source string, eventType ptp.EventType) {
 	if p.mock {
-		p.mockEvent = eventType
+		p.mockEvent = []ptp.EventType{eventType}
 		log.Infof("publishGNSSEvent state=%d, offset=%f, source=%s, eventType=%s", state, offset, source, eventType)
 		return
 	}
@@ -231,7 +241,7 @@ func (p *PTPEventManager) publishGNSSEvent(state int64, offset float64, syncStat
 // publishSyncEEvent ...publish events
 func (p *PTPEventManager) publishSyncEEvent(syncState ptp.SyncState, source string, ql byte, extQl byte, extendedTvlEnabled bool, eventType ptp.EventType) {
 	if p.mock {
-		p.mockEvent = eventType
+		p.mockEvent = []ptp.EventType{eventType}
 		log.Infof("publishSyncEEvent state=%s, source=%s, eventType=%s", syncState, source, eventType)
 		return
 	}
@@ -337,7 +347,10 @@ func (p *PTPEventManager) PublishEvent(state ptp.SyncState, ptpOffset int64, sou
 		return
 	}
 	if p.mock {
-		p.mockEvent = eventType
+		p.mockEvent = []ptp.EventType{eventType}
+		if eventType == ptp.PtpStateChange || eventType == ptp.OsClockSyncStateChange {
+			p.mockEvent = append(p.mockEvent, ptp.SyncStateChange)
+		}
 		log.Infof("PublishEvent state=%s, ptpOffset=%d, source=%s, eventType=%s", state, ptpOffset, source, eventType)
 		return
 	}
@@ -349,12 +362,14 @@ func (p *PTPEventManager) PublishEvent(state ptp.SyncState, ptpOffset int64, sou
 	// publish the event again as overall sync state
 	// SyncStateChange is the overall sync state including PtpStateChange and OsClockSyncStateChange
 	if eventType == ptp.PtpStateChange || eventType == ptp.OsClockSyncStateChange {
+		nodeState := p.GetNodeSyncState(state)
 		if state != p.lastOverallSyncState {
 			eventType = ptp.SyncStateChange
+			source = string(p.publisherTypes[eventType].Resource)
 			data = p.GetPTPEventsData(state, ptpOffset, source, eventType)
-			resourceAddress = path.Join(p.resourcePrefix, p.nodeName, string(p.publisherTypes[eventType].Resource))
+			resourceAddress = path.Join(p.resourcePrefix, p.nodeName, source)
 			p.publish(*data, resourceAddress, eventType)
-			p.lastOverallSyncState = state
+			p.lastOverallSyncState = nodeState
 		}
 	}
 }
@@ -401,8 +416,8 @@ func (p *PTPEventManager) GenPTPEvent(ptpProfileName string, oStats *stats.Stats
 			if isOffsetInRange(ptpOffset, threshold.MaxOffsetThreshold, threshold.MinOffsetThreshold) { // within range
 				log.Infof(" publishing event for ( profile %s) %s with last state %s and current clock state %s and offset %d for ( Max/Min Threshold %d/%d )",
 					ptpProfileName, eventResourceName, lastClockState, clockState, ptpOffset, threshold.MaxOffsetThreshold, threshold.MinOffsetThreshold)
-				p.PublishEvent(clockState, ptpOffset, eventResourceName, eventType) // change to locked
 				oStats.SetLastSyncState(clockState)
+				p.PublishEvent(clockState, ptpOffset, eventResourceName, eventType) // change to locked
 				oStats.SetLastOffset(ptpOffset)
 				oStats.AddValue(ptpOffset) // update off set when its in locked state and hold over only
 			}
@@ -413,42 +428,70 @@ func (p *PTPEventManager) GenPTPEvent(ptpProfileName string, oStats *stats.Stats
 			} else {
 				clockState = ptp.FREERUN
 				log.Infof(" publishing event for ( profile %s) %s with last state %s and current clock state %s and offset %d for ( Max/Min Threshold %d/%d )",
-					ptpProfileName, eventResourceName, oStats.LastSyncState(), clockState, ptpOffset, threshold.MaxOffsetThreshold, threshold.MinOffsetThreshold)
-				p.PublishEvent(clockState, ptpOffset, eventResourceName, eventType)
+					ptpProfileName, eventResourceName, lastClockState, clockState, ptpOffset, threshold.MaxOffsetThreshold, threshold.MinOffsetThreshold)
 				oStats.SetLastSyncState(clockState)
+				p.PublishEvent(clockState, ptpOffset, eventResourceName, eventType)
 				oStats.SetLastOffset(ptpOffset)
 			}
 		case ptp.HOLDOVER:
-			// do nothing, the timeout will switch holdover to FREE-RUN
+			//FOR OC/BC  do nothing, the timeout will switch holdover to FREE-RUN OR LOCKED  if it is not within the holdover timeout
+			// FOR T-GM its handled differently
+			// previous state was HOLDOVER, now it is in LOCKED state, cancel any HOLDOVER
+			if isOffsetInRange(ptpOffset, threshold.MaxOffsetThreshold, threshold.MinOffsetThreshold) {
+				log.Infof("interface %s is in LOCKED state, cancel any holdover states", eventResourceName)
+				threshold.SafeClose()
+				log.Infof(" publishing event for ( profile %s) %s with last state %s and current clock state %s and offset %d for ( Max/Min Threshold %d/%d )",
+					ptpProfileName, eventResourceName, lastClockState, clockState, ptpOffset, threshold.MaxOffsetThreshold, threshold.MinOffsetThreshold)
+				oStats.SetLastSyncState(clockState)
+				p.PublishEvent(clockState, ptpOffset, eventResourceName, eventType) // change to locked
+				oStats.SetLastOffset(ptpOffset)
+				oStats.AddValue(ptpOffset) // update off set when its in locked state and hold over only/ update off set when its in locked state and hold over only
+			} // else continue to stay in HOLDOVER UNTIL its really LOCKED state
+
 		default: // not yet used states
-			log.Warnf("%s sync state %s, last ptp state is unknown: %s", eventResourceName, clockState, lastClockState)
-			if !isOffsetInRange(ptpOffset, threshold.MaxOffsetThreshold, threshold.MinOffsetThreshold) {
-				clockState = ptp.FREERUN
+			clockState = ptp.FREERUN
+			if isOffsetInRange(ptpOffset, threshold.MaxOffsetThreshold, threshold.MinOffsetThreshold) {
+				clockState = ptp.LOCKED
 			}
+			log.Warnf("%s sync state %s, last ptp state is unknown, setting to  %s", eventResourceName, lastClockState, clockState)
+
 			log.Infof(" publishing event for (profile %s) %s with last state %s and current clock state %s and offset %d for ( Max/Min Threshold %d/%d )",
-				ptpProfileName, eventResourceName, oStats.LastSyncState(), clockState, ptpOffset, threshold.MaxOffsetThreshold, threshold.MinOffsetThreshold)
-			p.PublishEvent(clockState, ptpOffset, eventResourceName, eventType) // change to unknown
+				ptpProfileName, eventResourceName, lastClockState, clockState, ptpOffset, threshold.MaxOffsetThreshold, threshold.MinOffsetThreshold)
 			oStats.SetLastSyncState(clockState)
+			p.PublishEvent(clockState, ptpOffset, eventResourceName, eventType) // change to unknown
 			oStats.SetLastOffset(ptpOffset)
 		}
+	case ptp.HOLDOVER:
+		oStats.SetLastSyncState(clockState)
+		if lastClockState != ptp.HOLDOVER { //send event only once
+			log.Infof(" publishing event for (profile %s) %s with last state %s and current clock state %s and offset %d )",
+				ptpProfileName, eventResourceName, lastClockState, clockState, ptpOffset)
+			p.PublishEvent(clockState, ptpOffset, eventResourceName, eventType)
+		}
+		oStats.SetLastOffset(ptpOffset)
+		oStats.AddValue(ptpOffset)
+		return
 	case ptp.FREERUN:
-		if lastClockState != ptp.FREERUN { // within range
-			log.Infof(" publishing event for (profile %s) %s with last state %s and current clock state %s and offset %d for ( Max/Min Threshold %d/%d )",
-				ptpProfileName, eventResourceName, oStats.LastSyncState(), clockState, ptpOffset, threshold.MaxOffsetThreshold, threshold.MinOffsetThreshold)
-			p.PublishEvent(clockState, ptpOffset, eventResourceName, eventType) // change to locked
-			oStats.SetLastSyncState(clockState)
+		oStats.SetLastSyncState(clockState)
+		if lastClockState != ptp.HOLDOVER {
+			if lastClockState != ptp.FREERUN { // don't send event if last event was freerun
+				log.Infof("publishing event for (profile %s) %s with last state %s and current clock state %s and offset %d for ( Max/Min Threshold %d/%d )",
+					ptpProfileName, eventResourceName, lastClockState, clockState, ptpOffset, threshold.MaxOffsetThreshold, threshold.MinOffsetThreshold)
+				p.PublishEvent(clockState, ptpOffset, eventResourceName, eventType)
+			}
 			oStats.SetLastOffset(ptpOffset)
 			oStats.AddValue(ptpOffset)
 		}
 	default:
-		log.Warnf("%s unknown current ptp state %s", eventResourceName, clockState)
-		if !isOffsetInRange(ptpOffset, threshold.MaxOffsetThreshold, threshold.MinOffsetThreshold) {
-			clockState = ptp.FREERUN
+		clockState = ptp.FREERUN
+		if isOffsetInRange(ptpOffset, threshold.MaxOffsetThreshold, threshold.MinOffsetThreshold) {
+			clockState = ptp.LOCKED
 		}
+		log.Warnf("%s unknown current ptp state, setting to  %s", eventResourceName, clockState)
 		log.Infof(" publishing event for (profile %s) %s with last state %s and current clock state %s and offset %d for ( Max/Min Threshold %d/%d )",
-			ptpProfileName, eventResourceName, oStats.LastSyncState(), clockState, ptpOffset, threshold.MaxOffsetThreshold, threshold.MinOffsetThreshold)
-		p.PublishEvent(clockState, ptpOffset, eventResourceName, ptp.PtpStateChange) // change to unknown state
+			ptpProfileName, eventResourceName, lastClockState, clockState, ptpOffset, threshold.MaxOffsetThreshold, threshold.MinOffsetThreshold)
 		oStats.SetLastSyncState(clockState)
+		p.PublishEvent(clockState, ptpOffset, eventResourceName, ptp.PtpStateChange) // change to unknown state
 		oStats.SetLastOffset(ptpOffset)
 	}
 }
@@ -459,13 +502,13 @@ func (p *PTPEventManager) NodeName() string {
 }
 
 // GetMockEvent ...
-func (p *PTPEventManager) GetMockEvent() ptp.EventType {
+func (p *PTPEventManager) GetMockEvent() []ptp.EventType {
 	return p.mockEvent
 }
 
 // ResetMockEvent ...
 func (p *PTPEventManager) ResetMockEvent() {
-	p.mockEvent = ""
+	p.mockEvent = []ptp.EventType{}
 }
 
 // PrintStats .... for debug
@@ -491,19 +534,100 @@ func (p *PTPEventManager) IsHAProfile(name string) bool {
 }
 
 // HAProfiles ... if profile for ha found pass the settings
-func (p *PTPEventManager) HAProfiles() (profiles []string) {
+func (p *PTPEventManager) HAProfiles() (profile string, profiles []string) {
 	// Check if PtpSettings exist, if so proceed with confidence
 	if p.PtpConfigMapUpdates.PtpSettings != nil {
 		p.lock.RLock()
 		defer p.lock.RUnlock()
-		for _, ptpSettings := range p.PtpConfigMapUpdates.PtpSettings {
+		for profileName, ptpSettings := range p.PtpConfigMapUpdates.PtpSettings {
 			if ptpSettings != nil {
 				if haProfile, ok := ptpSettings["haProfiles"]; ok {
-					profiles = strings.Split(haProfile, "")
+					profile = profileName
+					rawProfiles := strings.Split(haProfile, ",")
+					for _, hp := range rawProfiles {
+						profiles = append(profiles, strings.TrimSpace(hp))
+					}
 					return
 				}
 			}
 		}
 	}
 	return
+}
+
+func (p *PTPEventManager) ListHAProfilesWith(currentProfile string) (profile string, profiles []string) {
+	// Check if PtpSettings exist, if so proceed
+	currentProfile = strings.TrimSpace(currentProfile)
+	if currentProfile == "" {
+		return "", nil
+	}
+	if p.PtpConfigMapUpdates.PtpSettings != nil {
+		profile, profiles = p.HAProfiles()
+		for _, hp := range profiles {
+			if hp == strings.TrimSpace(currentProfile) {
+				// Return all profiles in the same HA group
+				return profile, profiles
+			}
+		}
+	}
+	// No match found — return empty
+	return "", nil
+}
+
+// GetNodeSyncState evaluates the node-level sync state based on FREERUN, HOLDOVER, and LOCKED.
+// It returns the worst state among the available MasterClock and ClockRealTime stats.
+func (p *PTPEventManager) GetNodeSyncState(currentState ptp.SyncState) ptp.SyncState {
+	if currentState == "" {
+		currentState = ptp.FREERUN
+	}
+
+	var finalState ptp.SyncState = ""
+	found := false
+
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
+	for _, ptpStats := range p.Stats {
+		for iface, stat := range ptpStats {
+			if iface != MasterClockType && iface != ClockRealTime {
+				continue
+			}
+			s := stat.LastSyncState()
+			if s != ptp.FREERUN && s != ptp.HOLDOVER && s != ptp.LOCKED {
+				continue
+			}
+			finalState = OverallState(s, finalState)
+			found = true
+		}
+	}
+
+	if !found {
+		// No usable stats, use currentState as fallback
+		return currentState
+	}
+
+	// Compare with currentState and return the worst
+	return OverallState(currentState, finalState)
+}
+
+func OverallState(current, updated ptp.SyncState) ptp.SyncState {
+	if current == "" {
+		return updated
+	}
+	switch updated {
+	case ptp.FREERUN:
+		return ptp.FREERUN
+	case ptp.HOLDOVER:
+		if current == ptp.FREERUN {
+			return current
+		}
+		return updated
+	case ptp.LOCKED:
+		return current
+	case "":
+		return current
+	default:
+		log.Warnf("last sync state is unknown: %s", updated)
+	}
+	return ""
 }

--- a/plugins/ptp_operator/metrics/manager_test.go
+++ b/plugins/ptp_operator/metrics/manager_test.go
@@ -4,14 +4,17 @@
 package metrics_test
 
 import (
-	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/types"
 	"testing"
+
+	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/types"
+
+	"sync"
 
 	ptpConfig "github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/config"
 	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/metrics"
 	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/stats"
 	"github.com/redhat-cne/sdk-go/pkg/event/ptp"
-	"sync"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPTPEventManager_GenPTPEvent(t *testing.T) {
@@ -26,6 +29,7 @@ func TestPTPEventManager_GenPTPEvent(t *testing.T) {
 		eventType         ptp.EventType
 		mock              bool
 		wantLastSyncState ptp.SyncState
+		expectedEvents    []ptp.EventType
 	}{
 		{
 			name:              "locked state within threshold",
@@ -38,6 +42,7 @@ func TestPTPEventManager_GenPTPEvent(t *testing.T) {
 			eventType:         ptp.PtpStateChange,
 			mock:              true,
 			wantLastSyncState: ptp.LOCKED,
+			expectedEvents:    []ptp.EventType{ptp.PtpStateChange, ptp.SyncStateChange},
 		},
 		{
 			name:              "freerun state outside threshold",
@@ -50,6 +55,7 @@ func TestPTPEventManager_GenPTPEvent(t *testing.T) {
 			eventType:         ptp.PtpStateChange,
 			mock:              true,
 			wantLastSyncState: ptp.FREERUN,
+			expectedEvents:    []ptp.EventType{ptp.PtpStateChange, ptp.SyncStateChange},
 		},
 		{
 			name:              "freerun to Locked state",
@@ -62,9 +68,36 @@ func TestPTPEventManager_GenPTPEvent(t *testing.T) {
 			eventType:         ptp.PtpStateChange,
 			mock:              true,
 			wantLastSyncState: ptp.LOCKED,
+			expectedEvents:    []ptp.EventType{ptp.PtpStateChange, ptp.SyncStateChange},
 		},
 		{
-			name:              "locked to holdover state",
+			name:              "holdover to freerun state",
+			ptpProfileName:    "profile3",
+			oStats:            stats.NewStats("profile3"),
+			eventResourceName: "resource3",
+			ptpOffset:         500,
+			lastClockState:    ptp.HOLDOVER,
+			clockState:        ptp.FREERUN,
+			eventType:         ptp.PtpStateChange,
+			mock:              true,
+			wantLastSyncState: ptp.FREERUN,
+			expectedEvents:    []ptp.EventType{ptp.PtpStateChange, ptp.SyncStateChange},
+		},
+		{
+			name:              "holdover to locked state",
+			ptpProfileName:    "profile3",
+			oStats:            stats.NewStats("profile3"),
+			eventResourceName: "resource3",
+			ptpOffset:         50,
+			lastClockState:    ptp.HOLDOVER,
+			clockState:        ptp.LOCKED,
+			eventType:         ptp.PtpStateChange,
+			mock:              true,
+			wantLastSyncState: ptp.LOCKED,
+			expectedEvents:    []ptp.EventType{ptp.PtpStateChange, ptp.SyncStateChange},
+		},
+		{
+			name:              "holdover to locked state",
 			ptpProfileName:    "T-GM",
 			oStats:            stats.NewStats("T-GM"),
 			eventResourceName: "resource3",
@@ -74,6 +107,7 @@ func TestPTPEventManager_GenPTPEvent(t *testing.T) {
 			eventType:         ptp.PtpStateChange,
 			mock:              true,
 			wantLastSyncState: ptp.HOLDOVER,
+			expectedEvents:    []ptp.EventType{ptp.PtpStateChange, ptp.SyncStateChange},
 		},
 		{
 			name:              "holdover to holdover state",
@@ -86,6 +120,7 @@ func TestPTPEventManager_GenPTPEvent(t *testing.T) {
 			eventType:         ptp.PtpStateChange,
 			mock:              true,
 			wantLastSyncState: ptp.HOLDOVER,
+			expectedEvents:    []ptp.EventType{ptp.PtpStateChange, ptp.SyncStateChange},
 		},
 	}
 
@@ -106,7 +141,12 @@ func TestPTPEventManager_GenPTPEvent(t *testing.T) {
 			p.GenPTPEvent(tt.ptpProfileName, tt.oStats, tt.eventResourceName, tt.ptpOffset, tt.clockState, tt.eventType)
 			if got := tt.oStats.LastSyncState(); got != tt.wantLastSyncState {
 				t.Errorf("GenPTPEvent() = %v, want %v", got, tt.wantLastSyncState)
+				assert.Equal(t, len(tt.expectedEvents), len(p.GetMockEvent()))
+				for _, event := range tt.expectedEvents {
+					assert.Contains(t, p.GetMockEvent(), event)
+				}
 			}
+
 		})
 	}
 }
@@ -126,9 +166,9 @@ func TestConcurrentMapAccess(t *testing.T) {
 	}
 	manager.MockTest(true)
 	// Function to simulate concurrent writes
-	writeFunc := func(wg *sync.WaitGroup, key string, value stats.PTPStats) {
+	writeFunc := func(wg *sync.WaitGroup, key types.ConfigName, value stats.PTPStats) {
 		defer wg.Done()
-		manager.GetStats(types.ConfigName(configName))
+		manager.SetStats(key, value)
 	}
 
 	// Function to simulate concurrent reads
@@ -163,4 +203,207 @@ func TestConcurrentMapAccess(t *testing.T) {
 
 	// Wait for all goroutines to finish
 	wg.Wait()
+}
+
+func TestListHAProfilesWith(t *testing.T) {
+	// Setup
+	manager := &metrics.PTPEventManager{
+		Stats: map[types.ConfigName]stats.PTPStats{},
+		PtpConfigMapUpdates: &ptpConfig.LinuxPTPConfigMapUpdate{
+			PtpSettings: map[string]map[string]string{
+				"pProfile": {
+					"haProfiles": "profile1,profile2",
+				},
+			},
+		},
+	}
+
+	// Case 1: Found in node1
+	_, result := manager.ListHAProfilesWith("profile2")
+	assert.ElementsMatch(t, []string{"profile1", "profile2"}, result)
+
+	// Case 3: Not found
+	_, result = manager.ListHAProfilesWith("unknown")
+	assert.Equal(t, len(result), 0)
+
+	// Case 4: Empty input
+	_, result = manager.ListHAProfilesWith(" ")
+	assert.Equal(t, len(result), 0)
+
+	// Case 5: Empty settings
+	manager.PtpConfigMapUpdates = &ptpConfig.LinuxPTPConfigMapUpdate{
+		PtpSettings: map[string]map[string]string{},
+	}
+	_, result = manager.ListHAProfilesWith("profile1")
+	assert.Equal(t, len(result), 0)
+}
+
+func TestGetNodeSyncState_WithOptionalCurrentState(t *testing.T) {
+
+	tests := []struct {
+		name           string
+		statsData      map[types.ConfigName]stats.PTPStats
+		currentState   ptp.SyncState
+		expectedResult ptp.SyncState
+	}{
+		{
+			name:           "Empty stats, no current state",
+			statsData:      map[types.ConfigName]stats.PTPStats{},
+			currentState:   "",
+			expectedResult: ptp.FREERUN,
+		},
+		{
+			name: "Only LOCKED stats",
+			statsData: map[types.ConfigName]stats.PTPStats{
+				"ptp4l.0.config": {
+					metrics.MasterClockType: {},
+				},
+				"ptp4l.1.config": {
+					metrics.MasterClockType: func() *stats.Stats {
+						s := stats.NewStats("ptp4l.0.config")
+						s.SetLastSyncState(ptp.LOCKED)
+						return s
+					}(),
+				},
+				"phc2sys.1.config": {
+					metrics.ClockRealTime: func() *stats.Stats {
+						s := stats.NewStats("phc2sys.1.config")
+						s.SetLastSyncState(ptp.LOCKED)
+						return s
+					}(),
+				},
+			},
+			currentState:   ptp.LOCKED,
+			expectedResult: ptp.LOCKED,
+		},
+		{
+			name: "Mixed stats with worst state FREERUN from currentState",
+			statsData: map[types.ConfigName]stats.PTPStats{
+				"ptp4l.0.config": {
+					metrics.MasterClockType: func() *stats.Stats {
+						s := stats.NewStats("ptp4l.0.config")
+						s.SetLastSyncState(ptp.LOCKED)
+						return s
+					}(),
+				},
+				"ptp4l.1.config": {
+					metrics.MasterClockType: func() *stats.Stats {
+						s := stats.NewStats("ptp4l.1.config")
+						s.SetLastSyncState(ptp.FREERUN)
+						return s
+					}(),
+				},
+				"phc2sys.1.config": {
+					metrics.ClockRealTime: func() *stats.Stats {
+						s := stats.NewStats("phc2sys.1.config")
+						s.SetLastSyncState(ptp.LOCKED)
+						return s
+					}(),
+				},
+			},
+			currentState:   ptp.FREERUN,
+			expectedResult: ptp.FREERUN,
+		},
+		{
+			name: "Dual BC- Nic one in Locked, Nic2 PHC is Holdover and OSClock- Freerun",
+			statsData: map[types.ConfigName]stats.PTPStats{
+				"ptp4l.0.config": {
+					metrics.MasterClockType: func() *stats.Stats {
+						s := stats.NewStats("ptp4l.0.config")
+						s.SetLastSyncState(ptp.LOCKED)
+						return s
+					}(),
+				},
+				"ptp4l.1.config": {
+					metrics.MasterClockType: func() *stats.Stats {
+						s := stats.NewStats("ptp4l.1.config")
+						s.SetLastSyncState(ptp.HOLDOVER)
+						return s
+					}(),
+				},
+				"phc2sys.1.config": { // OS CLock is freerun
+					metrics.ClockRealTime: func() *stats.Stats {
+						s := stats.NewStats("phc2sys.1.config")
+						s.SetLastSyncState(ptp.FREERUN)
+						return s
+					}(),
+				},
+			},
+			currentState:   ptp.LOCKED,
+			expectedResult: ptp.FREERUN,
+		},
+		{
+			name: "OC- PHC is in Holdover, osClock is in Freerun",
+			statsData: map[types.ConfigName]stats.PTPStats{
+				"ptp4l.0.config": {
+					metrics.MasterClockType: func() *stats.Stats {
+						s := stats.NewStats("ptp4l.0.config")
+						s.SetLastSyncState(ptp.HOLDOVER)
+						return s
+					}(),
+				},
+				"phc2sys.1.config": {
+					metrics.ClockRealTime: func() *stats.Stats {
+						s := stats.NewStats("phc2sys.1.config")
+						s.SetLastSyncState(ptp.FREERUN)
+						return s
+					}(),
+				},
+			},
+			currentState:   ptp.LOCKED,
+			expectedResult: ptp.FREERUN,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &metrics.PTPEventManager{
+				PtpConfigMapUpdates: &ptpConfig.LinuxPTPConfigMapUpdate{},
+				Stats:               tt.statsData,
+			}
+			p.MockTest(true)
+
+			result := p.GetNodeSyncState(tt.currentState)
+			if result != tt.expectedResult {
+				t.Errorf("expected %s, got %s", tt.expectedResult, result)
+			}
+		})
+	}
+}
+
+func TestOverallState(t *testing.T) {
+	tests := []struct {
+		name     string
+		current  ptp.SyncState
+		updated  ptp.SyncState
+		expected ptp.SyncState
+	}{
+		// -- Basic transitions there can't be current state as empty string , if found ignore
+		{"FREERUN + FREERUN", ptp.FREERUN, ptp.FREERUN, ptp.FREERUN},
+		{"FREERUN + HOLDOVER", ptp.FREERUN, ptp.HOLDOVER, ptp.FREERUN},
+		{"FREERUN + LOCKED", ptp.FREERUN, ptp.LOCKED, ptp.FREERUN},
+
+		{"HOLDOVER + FREERUN", ptp.HOLDOVER, ptp.FREERUN, ptp.FREERUN},
+		{"HOLDOVER + HOLDOVER", ptp.HOLDOVER, ptp.HOLDOVER, ptp.HOLDOVER},
+		{"HOLDOVER + LOCKED", ptp.HOLDOVER, ptp.LOCKED, ptp.HOLDOVER},
+
+		{"LOCKED + FREERUN", ptp.LOCKED, ptp.FREERUN, ptp.FREERUN},
+		{"LOCKED + HOLDOVER", ptp.LOCKED, ptp.HOLDOVER, ptp.HOLDOVER},
+		{"LOCKED + LOCKED", ptp.LOCKED, ptp.LOCKED, ptp.LOCKED},
+
+		// -- Edge cases
+		{"Current empty, updated LOCKED", "", ptp.LOCKED, ptp.LOCKED},
+		{"Current empty, updated HOLDOVER", "", ptp.HOLDOVER, ptp.HOLDOVER},
+		{"Current empty, updated FREERUN", "", ptp.FREERUN, ptp.FREERUN},
+
+		{"Updated empty", ptp.LOCKED, "", ptp.LOCKED},
+		{"Updated unknown", ptp.HOLDOVER, "UNKNOWN_STATE", ""}, // This would also log a warning
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := metrics.OverallState(tt.current, tt.updated)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
 }

--- a/plugins/ptp_operator/metrics/metrics_test.go
+++ b/plugins/ptp_operator/metrics/metrics_test.go
@@ -92,33 +92,45 @@ func InitPubSubTypes() map[ptp.EventType]*types.EventPublisherType {
 }
 
 type TestCase struct {
-	log                            string
-	from                           string
-	process                        string
-	node                           string
-	iface                          string
-	lastSyncState                  ptp.SyncState
-	expectedPtpOffset              float64 // offset_ns
-	expectedPtpMaxOffset           float64 // max_offset_ns
-	expectedPtpFrequencyAdjustment float64 // frequency_adjustment_ns
-	expectedPtpDelay               float64 // delay_ns
-	expectedSyncState              float64 // clock_state
-	expectedNmeaStatus             float64 // nmea_status
-	expectedPpsStatus              float64 // pps_status
-	expectedClockClassMetrics      float64 // clock_class
-	expectedEvent                  ptp.EventType
-}
+	log           string
+	from          string
+	process       string
+	node          string
+	iface         string
+	lastSyncState ptp.SyncState
 
-func (tc *TestCase) init() {
-	tc.expectedPtpOffset = SKIP
-	tc.expectedPtpMaxOffset = SKIP
-	tc.expectedPtpFrequencyAdjustment = SKIP
-	tc.expectedPtpDelay = SKIP
-	tc.expectedSyncState = SKIP
-	tc.expectedNmeaStatus = SKIP
-	tc.expectedPpsStatus = SKIP
-	tc.expectedClockClassMetrics = SKIP
-	tc.expectedEvent = ""
+	// offset_ns
+	expectedPtpOffsetCheck bool
+	expectedPtpOffset      float64
+	// max_offset_ns
+	expectedPtpMaxOffsetCheck bool
+	expectedPtpMaxOffset      float64
+	// frequency_adjustment_ns
+	expectedPtpFrequencyAdjustmentCheck bool
+	expectedPtpFrequencyAdjustment      float64
+	// delay_ns
+	expectedPtpDelayCheck bool
+	expectedPtpDelay      float64
+	// clock_state
+	expectedSyncStateCheck bool
+	expectedSyncState      float64
+	// nmea_status
+	expectedNmeaStatusCheck bool
+	expectedNmeaStatus      float64
+	// pps_status
+	expectedPpsStatusCheck bool
+	expectedPpsStatus      float64
+	// clock_class
+	expectedClockClassMetricsCheck bool
+	expectedClockClassMetrics      float64
+	//role
+	expectedRoleCheck bool
+	expectedRole      types.PtpPortRole
+
+	expectedEvent        []ptp.EventType
+	logPtp4lConfigName   string
+	skipCleanupMetrics   bool
+	skipSetLastSyncState bool
 }
 
 func (tc *TestCase) String() string {
@@ -140,224 +152,183 @@ func (tc *TestCase) cleanupMetrics() {
 	metrics.SyncState.With(map[string]string{"process": tc.process, "node": tc.node, "iface": tc.iface}).Set(CLEANUP)
 	metrics.NmeaStatus.With(map[string]string{"process": tc.process, "node": tc.node, "iface": tc.iface}).Set(CLEANUP)
 	metrics.ClockClassMetrics.With(map[string]string{"process": tc.process, "node": tc.node}).Set(CLEANUP)
+	metrics.InterfaceRole.With(map[string]string{"process": tc.process, "node": tc.node, "iface": tc.iface}).Set(CLEANUP)
 	ptpEventManager.ResetMockEvent()
 }
 
-func setLastSyncState(iface string, state ptp.SyncState) {
+func setLastSyncState(iface string, state ptp.SyncState, ptp4lconfName string) {
 	if iface != metrics.ClockRealTime {
 		iface = "master"
 	}
-	s := ptpEventManager.GetStatsForInterface(types.ConfigName(logPtp4lConfig.Name), types.IFace(iface))
+	s := ptpEventManager.GetStatsForInterface(types.ConfigName(ptp4lconfName), types.IFace(iface))
 	s.SetLastSyncState(state)
 }
 
-func statsAddValue(iface string, val int64) {
+func statsAddValue(iface string, val int64, ptp4lconfName string) {
 	if iface != metrics.ClockRealTime {
 		iface = "master"
 	}
-	s := ptpEventManager.GetStatsForInterface(types.ConfigName(logPtp4lConfig.Name), types.IFace(iface))
+	s := ptpEventManager.GetStatsForInterface(types.ConfigName(ptp4lconfName), types.IFace(iface))
 	s.AddValue(val)
 }
 
 var testCases = []TestCase{
 	{
-		log:                            "dpll[1000000100]:[ts2phc.0.config] ens7f0 frequency_status 3 offset 5 phase_status 3 pps_status 1 s2",
-		from:                           "master",
-		process:                        "dpll",
-		iface:                          "ens7fx",
-		lastSyncState:                  ptp.FREERUN,
-		expectedPtpOffset:              SKIP,
-		expectedPtpMaxOffset:           SKIP,
-		expectedPtpFrequencyAdjustment: SKIP,
-		expectedPtpDelay:               SKIP,
-		expectedSyncState:              s2,
-		expectedNmeaStatus:             SKIP,
-		expectedPpsStatus:              1,
-		expectedClockClassMetrics:      SKIP,
+		log:                    "dpll[1000000100]:[ts2phc.0.config] ens7f0 frequency_status 3 offset 5 phase_status 3 pps_status 1 s2",
+		from:                   "master",
+		process:                "dpll",
+		iface:                  "ens7fx",
+		lastSyncState:          ptp.FREERUN,
+		expectedSyncStateCheck: true,
+		expectedSyncState:      float64(types.LOCKED),
+		expectedPpsStatusCheck: true,
+		expectedEvent:          []ptp.EventType{},
+		expectedPpsStatus:      1,
+		logPtp4lConfigName:     logPtp4lConfig.Name,
 	},
 	{
-		log:                            "dpll[1000000110]:[ts2phc.0.config] ens7f0 frequency_status 3 offset 5 phase_status 3 pps_status 0 s0",
-		from:                           "master",
-		process:                        "dpll",
-		iface:                          "ens7fx",
-		lastSyncState:                  ptp.LOCKED,
-		expectedPtpOffset:              SKIP,
-		expectedPtpMaxOffset:           SKIP,
-		expectedPtpFrequencyAdjustment: SKIP,
-		expectedPtpDelay:               SKIP,
-		expectedSyncState:              s0,
-		expectedNmeaStatus:             SKIP,
-		expectedPpsStatus:              0,
-		expectedEvent:                  "",
-		expectedClockClassMetrics:      SKIP,
+		log:                    "dpll[1000000110]:[ts2phc.0.config] ens7f0 frequency_status 3 offset 5 phase_status 3 pps_status 0 s0",
+		from:                   "master",
+		process:                "dpll",
+		iface:                  "ens7fx",
+		lastSyncState:          ptp.LOCKED,
+		expectedSyncStateCheck: true,
+		expectedSyncState:      float64(types.FREERUN),
+		expectedPpsStatusCheck: true,
+		expectedPpsStatus:      0,
+		expectedEvent:          []ptp.EventType{},
+		logPtp4lConfigName:     logPtp4lConfig.Name,
 	},
 	{
-		log:                            "dpll[1000000120]:[ts2phc.0.config] ens7f0 frequency_status 3 offset 7 phase_status 3 pps_status 0 s1",
-		from:                           "master",
-		process:                        "dpll",
-		iface:                          "ens7fx",
-		lastSyncState:                  ptp.FREERUN,
-		expectedPtpOffset:              SKIP,
-		expectedPtpMaxOffset:           SKIP,
-		expectedPtpFrequencyAdjustment: SKIP,
-		expectedPtpDelay:               SKIP,
-		expectedSyncState:              s1,
-		expectedNmeaStatus:             SKIP,
-		expectedPpsStatus:              0,
-		expectedClockClassMetrics:      SKIP,
+		log:                    "dpll[1000000120]:[ts2phc.0.config] ens7f0 frequency_status 3 offset 7 phase_status 3 pps_status 0 s1",
+		from:                   "master",
+		process:                "dpll",
+		iface:                  "ens7fx",
+		expectedSyncStateCheck: true,
+		expectedSyncState:      float64(types.HOLDOVER),
+		expectedPpsStatusCheck: true,
+		expectedEvent:          []ptp.EventType{},
+		expectedPpsStatus:      0,
+		logPtp4lConfigName:     logPtp4lConfig.Name,
 	},
 	{
-		log:                            "ts2phc[1000000200]:[ts2phc.0.config] ens2f0 nmea_status 0 offset 999999 s0",
-		from:                           "master",
-		process:                        "ts2phc",
-		iface:                          "ens2fx",
-		lastSyncState:                  ptp.LOCKED,
-		expectedPtpOffset:              SKIP,
-		expectedPtpMaxOffset:           SKIP,
-		expectedPtpFrequencyAdjustment: SKIP,
-		expectedPtpDelay:               SKIP,
-		expectedSyncState:              SKIP,
-		expectedNmeaStatus:             0,
-		expectedPpsStatus:              SKIP,
-		expectedClockClassMetrics:      SKIP,
-		expectedEvent:                  "",
+		log:                     "ts2phc[1000000200]:[ts2phc.0.config] ens2f0 nmea_status 0 offset 999999 s0",
+		from:                    "master",
+		process:                 "ts2phc",
+		iface:                   "ens2fx",
+		lastSyncState:           ptp.LOCKED,
+		expectedNmeaStatusCheck: true,
+		expectedNmeaStatus:      0,
+		expectedEvent:           []ptp.EventType{},
+		logPtp4lConfigName:      logPtp4lConfig.Name,
 	},
 	{
-		log:                            "ts2phc[1000000210]:[ts2phc.0.config] ens2f0 nmea_status 1 offset 0 s2",
-		from:                           "master",
-		process:                        "ts2phc",
-		iface:                          "ens2fx",
-		expectedPtpOffset:              SKIP,
-		expectedPtpMaxOffset:           SKIP,
-		expectedPtpFrequencyAdjustment: SKIP,
-		expectedPtpDelay:               SKIP,
-		expectedSyncState:              SKIP,
-		expectedNmeaStatus:             1,
-		expectedPpsStatus:              SKIP,
-		expectedClockClassMetrics:      SKIP,
-		expectedEvent:                  "",
+		log:                     "ts2phc[1000000210]:[ts2phc.0.config] ens2f0 nmea_status 1 offset 0 s2",
+		from:                    "master",
+		process:                 "ts2phc",
+		iface:                   "ens2fx",
+		expectedNmeaStatusCheck: true,
+		expectedNmeaStatus:      1,
+		expectedEvent:           []ptp.EventType{},
+		logPtp4lConfigName:      logPtp4lConfig.Name,
 	},
 	{
-		log:                            "ts2phc[1000000300]: [ts2phc.0.config] ens2f0 master offset  0 s2 freq -0",
-		from:                           "master",
-		process:                        "ts2phc",
-		iface:                          "ens2fx",
-		expectedPtpOffset:              0,
-		expectedPtpMaxOffset:           SKIP,
-		expectedPtpFrequencyAdjustment: SKIP,
-		expectedPtpDelay:               SKIP,
-		expectedSyncState:              SKIP,
-		expectedNmeaStatus:             SKIP,
-		expectedPpsStatus:              SKIP,
-		expectedClockClassMetrics:      SKIP,
-		expectedEvent:                  ptp.PtpStateChange,
+		log:                    "ts2phc[1000000300]: [ts2phc.0.config] ens2f0 master offset  0 s2 freq -0",
+		from:                   "master",
+		process:                "ts2phc",
+		iface:                  "ens2fx",
+		expectedPtpOffsetCheck: true,
+		expectedPtpOffset:      0,
+		expectedEvent:          []ptp.EventType{ptp.PtpStateChange, ptp.SyncStateChange},
+		logPtp4lConfigName:     logPtp4lConfig.Name,
 	},
 	{
-		log:                            "ts2phc[1000000310]: [ts2phc.0.config] ens7f0 master offset 999 s0 freq      -0",
-		from:                           "master",
-		process:                        "ts2phc",
-		iface:                          "ens7fx",
-		expectedPtpOffset:              999,
-		expectedPtpMaxOffset:           SKIP,
-		expectedPtpFrequencyAdjustment: SKIP,
-		expectedPtpDelay:               SKIP,
-		expectedSyncState:              s0,
-		expectedNmeaStatus:             SKIP,
-		expectedPpsStatus:              SKIP,
-		expectedClockClassMetrics:      SKIP,
-		expectedEvent:                  ptp.PtpStateChange,
+		log:                    "ts2phc[1000000310]: [ts2phc.0.config] ens7f0 master offset 999 s0 freq      -0",
+		from:                   "master",
+		process:                "ts2phc",
+		iface:                  "ens7fx",
+		expectedPtpOffsetCheck: true,
+		expectedPtpOffset:      999,
+		expectedSyncStateCheck: true,
+		expectedSyncState:      float64(types.FREERUN),
+		expectedEvent:          []ptp.EventType{ptp.PtpStateChange, ptp.SyncStateChange},
+		logPtp4lConfigName:     logPtp4lConfig.Name,
 	},
 	{
-		log:                            "GM[1000000400]:[ts2phc.0.config] ens2f0 T-GM-STATUS s0",
-		from:                           "master",
-		process:                        "GM",
-		iface:                          "ens2fx",
-		expectedPtpOffset:              SKIP,
-		expectedPtpMaxOffset:           SKIP,
-		expectedPtpFrequencyAdjustment: SKIP,
-		expectedPtpDelay:               SKIP,
-		expectedSyncState:              s0,
-		expectedNmeaStatus:             SKIP,
-		expectedPpsStatus:              SKIP,
-		expectedClockClassMetrics:      SKIP,
-		expectedEvent:                  ptp.PtpStateChange,
+		log:                    "GM[1000000400]:[ts2phc.0.config] ens2f0 T-GM-STATUS s0",
+		from:                   "master",
+		process:                "GM",
+		iface:                  "ens2fx",
+		expectedSyncStateCheck: true,
+		expectedSyncState:      float64(types.FREERUN),
+		expectedEvent:          []ptp.EventType{ptp.PtpStateChange, ptp.SyncStateChange},
+		logPtp4lConfigName:     logPtp4lConfig.Name,
 	},
 	{
-		log:                            "gnss[1000000500]:[ts2phc.0.config] ens2f1 gnss_status 3 offset 5 s2",
-		from:                           "gnss",
-		process:                        "gnss",
-		iface:                          "ens2fx",
-		lastSyncState:                  ptp.FREERUN,
-		expectedPtpOffset:              5,
-		expectedPtpMaxOffset:           SKIP,
-		expectedPtpFrequencyAdjustment: SKIP,
-		expectedPtpDelay:               SKIP,
-		expectedSyncState:              s2,
-		expectedNmeaStatus:             SKIP,
-		expectedPpsStatus:              SKIP,
-		expectedClockClassMetrics:      SKIP,
-		expectedEvent:                  ptp.GnssStateChange,
+		log:                    "gnss[1000000500]:[ts2phc.0.config] ens2f1 gnss_status 3 offset 5 s2",
+		from:                   "gnss",
+		process:                "gnss",
+		iface:                  "ens2fx",
+		lastSyncState:          ptp.FREERUN,
+		expectedPtpOffsetCheck: true,
+		expectedPtpOffset:      5,
+		expectedSyncStateCheck: true,
+		expectedSyncState:      float64(types.LOCKED),
+		expectedEvent:          []ptp.EventType{ptp.GnssStateChange},
+		logPtp4lConfigName:     logPtp4lConfig.Name,
 	},
 	{
 		log:                            "ptp4l[1000000600]:[ptp4l.0.config] CLOCK_CLASS_CHANGE 248.000000",
 		process:                        "ptp4l",
 		iface:                          "master",
 		lastSyncState:                  ptp.FREERUN,
-		expectedPtpOffset:              SKIP,
-		expectedPtpMaxOffset:           SKIP,
-		expectedPtpFrequencyAdjustment: SKIP,
-		expectedPtpDelay:               SKIP,
-		expectedSyncState:              SKIP,
-		expectedNmeaStatus:             SKIP,
-		expectedPpsStatus:              SKIP,
+		expectedClockClassMetricsCheck: true,
 		expectedClockClassMetrics:      248,
-		expectedEvent:                  ptp.PtpClockClassChange,
+		expectedEvent:                  []ptp.EventType{ptp.PtpClockClassChange},
+		logPtp4lConfigName:             logPtp4lConfig.Name,
 	},
 	{
 		log:                            "ptp4l[1000000610]:[ptp4l.0.config] CLOCK_CLASS_CHANGE 6.000000",
 		process:                        "ptp4l",
 		iface:                          "master",
 		lastSyncState:                  ptp.FREERUN,
-		expectedPtpOffset:              SKIP,
-		expectedPtpMaxOffset:           SKIP,
-		expectedPtpFrequencyAdjustment: SKIP,
-		expectedPtpDelay:               SKIP,
-		expectedSyncState:              SKIP,
-		expectedNmeaStatus:             SKIP,
-		expectedPpsStatus:              SKIP,
+		expectedClockClassMetricsCheck: true,
 		expectedClockClassMetrics:      6,
-		expectedEvent:                  ptp.PtpClockClassChange,
+		expectedEvent:                  []ptp.EventType{ptp.PtpClockClassChange},
+		logPtp4lConfigName:             logPtp4lConfig.Name,
 	},
 	{
-		log:                            "phc2sys[1000000700]: [ptp4l.0.config] CLOCK_REALTIME phc offset       -62 s0 freq  -78368 delay   1100",
-		from:                           "phc",
-		process:                        "phc2sys",
-		iface:                          metrics.ClockRealTime,
-		lastSyncState:                  ptp.FREERUN,
-		expectedPtpOffset:              -62,
-		expectedPtpMaxOffset:           SKIP,
-		expectedPtpFrequencyAdjustment: -78368,
-		expectedPtpDelay:               1100,
-		expectedSyncState:              s0,
-		expectedNmeaStatus:             SKIP,
-		expectedPpsStatus:              SKIP,
-		expectedClockClassMetrics:      SKIP,
+		log:                                 "phc2sys[1000000700]: [ptp4l.0.config] CLOCK_REALTIME phc offset       -62 s0 freq  -78368 delay   1100",
+		from:                                "phc",
+		process:                             "phc2sys",
+		iface:                               metrics.ClockRealTime,
+		expectedPtpOffsetCheck:              true,
+		expectedPtpOffset:                   -62,
+		expectedPtpFrequencyAdjustmentCheck: true,
+		expectedPtpFrequencyAdjustment:      -78368,
+		expectedPtpDelayCheck:               true,
+		expectedPtpDelay:                    1100,
+		expectedSyncStateCheck:              true,
+		expectedSyncState:                   float64(types.FREERUN),
+		expectedEvent:                       []ptp.EventType{ptp.OsClockSyncStateChange, ptp.SyncStateChange},
+		logPtp4lConfigName:                  logPtp4lConfig.Name,
 	},
 	{
-		log:                            "phc2sys[1000000710]: [ptp4l.0.config] CLOCK_REALTIME phc offset       -62 s0 freq  -78368 delay   1100",
-		from:                           "phc",
-		process:                        "phc2sys",
-		iface:                          metrics.ClockRealTime,
-		lastSyncState:                  ptp.LOCKED,
-		expectedPtpOffset:              -62,
-		expectedPtpMaxOffset:           SKIP,
-		expectedPtpFrequencyAdjustment: -78368,
-		expectedPtpDelay:               1100,
-		expectedSyncState:              s0,
-		expectedNmeaStatus:             SKIP,
-		expectedPpsStatus:              SKIP,
-		expectedClockClassMetrics:      SKIP,
-		expectedEvent:                  ptp.OsClockSyncStateChange,
+		log:                                 "phc2sys[1000000710]: [ptp4l.0.config] CLOCK_REALTIME phc offset       -62 s0 freq  -78368 delay   1100",
+		from:                                "phc",
+		process:                             "phc2sys",
+		iface:                               metrics.ClockRealTime,
+		lastSyncState:                       ptp.LOCKED,
+		expectedPtpOffsetCheck:              true,
+		expectedPtpOffset:                   -62,
+		expectedPtpFrequencyAdjustmentCheck: true,
+		expectedPtpFrequencyAdjustment:      -78368,
+		expectedPtpDelayCheck:               true,
+		expectedPtpDelay:                    1100,
+		expectedSyncStateCheck:              true,
+		expectedSyncState:                   float64(types.FREERUN),
+		expectedEvent:                       []ptp.EventType{ptp.OsClockSyncStateChange, ptp.SyncStateChange},
+		logPtp4lConfigName:                  logPtp4lConfig.Name,
 	},
 }
 
@@ -367,10 +338,16 @@ func setup() {
 
 	ptpEventManager.AddPTPConfig(types.ConfigName(logPtp4lConfig.Name), logPtp4lConfig)
 
-	stats_master := stats.NewStats(logPtp4lConfig.Name)
-	stats_master.SetOffsetSource("master")
-	stats_master.SetProcessName("ts2phc")
-	stats_master.SetAlias("ens2fx")
+	statsMaster := stats.NewStats(logPtp4lConfig.Name)
+	statsMaster.SetOffsetSource("master")
+	statsMaster.SetProcessName("ts2phc")
+	statsMaster.SetAlias("ens2fx")
+
+	statsSlave := stats.NewStats(logPtp4lConfig.Name)
+	statsSlave.SetOffsetSource("phc")
+	statsSlave.SetProcessName("phc2sys")
+	statsSlave.SetLastSyncState("LOCKED")
+	statsSlave.SetClockClass(0)
 
 	stats_slave := stats.NewStats(logPtp4lConfig.Name)
 	stats_slave.SetOffsetSource("phc")
@@ -379,10 +356,11 @@ func setup() {
 	stats_slave.SetClockClass(0)
 
 	ptpEventManager.Stats[types.ConfigName(logPtp4lConfig.Name)] = make(stats.PTPStats)
-	ptpEventManager.Stats[types.ConfigName(logPtp4lConfig.Name)][types.IFace("master")] = stats_master
-	ptpEventManager.Stats[types.ConfigName(logPtp4lConfig.Name)][types.IFace("CLOCK_REALTIME")] = stats_slave
-	ptpEventManager.Stats[types.ConfigName(logPtp4lConfig.Name)][types.IFace("ens2f0")] = stats_master
-	ptpEventManager.Stats[types.ConfigName(logPtp4lConfig.Name)][types.IFace("ens7f0")] = stats_slave
+	ptpEventManager.Stats[types.ConfigName(logPtp4lConfig.Name)][types.IFace("master")] = statsMaster
+	ptpEventManager.Stats[types.ConfigName(logPtp4lConfig.Name)][types.IFace("CLOCK_REALTIME")] = statsSlave
+	ptpEventManager.Stats[types.ConfigName(logPtp4lConfig.Name)][types.IFace("ens2f0")] = statsMaster
+	ptpEventManager.Stats[types.ConfigName(logPtp4lConfig.Name)][types.IFace("ens7f0")] = statsSlave
+
 	ptpEventManager.PtpConfigMapUpdates = config.NewLinuxPTPConfUpdate()
 
 	metrics.RegisterMetrics("mynode")
@@ -401,36 +379,52 @@ func Test_ExtractMetrics(t *testing.T) {
 
 	assert := assert.New(t)
 	for _, tc := range testCases {
+		tc := tc
 		tc.node = MYNODE
-		tc.cleanupMetrics()
-		setLastSyncState(tc.iface, tc.lastSyncState)
+		if !tc.skipCleanupMetrics {
+			tc.cleanupMetrics()
+		}
+		if !tc.skipSetLastSyncState {
+			setLastSyncState(tc.iface, tc.lastSyncState, tc.logPtp4lConfigName)
+		}
+		ptpEventManager.ResetMockEvent()
 		ptpEventManager.ExtractMetrics(tc.log)
-		if tc.expectedPtpOffset != SKIP {
+
+		if tc.expectedRoleCheck {
+			role := metrics.InterfaceRole.With(map[string]string{"process": tc.process, "node": tc.node, "iface": tc.iface})
+			statsAddValue(tc.iface, int64(testutil.ToFloat64(role)), tc.logPtp4lConfigName)
+			value := types.PtpPortRole(testutil.ToFloat64(role))
+			assert.Equal(tc.expectedRole, value, "ptp role does not match\n%s", tc.String())
+		}
+
+		if tc.expectedPtpOffsetCheck {
 			ptpOffset := metrics.PtpOffset.With(map[string]string{"from": tc.from, "process": tc.process, "node": tc.node, "iface": tc.iface})
-			statsAddValue(tc.iface, int64(testutil.ToFloat64(ptpOffset)))
+			statsAddValue(tc.iface, int64(testutil.ToFloat64(ptpOffset)), tc.logPtp4lConfigName)
 			assert.Equal(tc.expectedPtpOffset, testutil.ToFloat64(ptpOffset), "PtpOffset does not match\n%s", tc.String())
 		}
-		if tc.expectedPtpMaxOffset != SKIP {
+		if tc.expectedPtpMaxOffsetCheck {
 			ptpMaxOffset := metrics.PtpMaxOffset.With(map[string]string{"from": tc.from, "process": tc.process, "node": tc.node, "iface": tc.iface})
 			assert.Equal(tc.expectedPtpMaxOffset, testutil.ToFloat64(ptpMaxOffset), "PtpMaxOffset does not match\n%s", tc.String())
 		}
-		if tc.expectedPtpFrequencyAdjustment != SKIP {
+		if tc.expectedPtpFrequencyAdjustmentCheck {
 			ptpFrequencyAdjustment := metrics.PtpFrequencyAdjustment.With(map[string]string{"from": tc.from, "process": tc.process, "node": tc.node, "iface": tc.iface})
 			assert.Equal(tc.expectedPtpFrequencyAdjustment, testutil.ToFloat64(ptpFrequencyAdjustment), "PtpFrequencyAdjustment does not match\n%s", tc.String())
 		}
-		if tc.expectedPtpDelay != SKIP {
+		if tc.expectedPtpDelayCheck {
 			ptpDelay := metrics.PtpDelay.With(map[string]string{"from": tc.from, "process": tc.process, "node": tc.node, "iface": tc.iface})
 			assert.Equal(tc.expectedPtpDelay, testutil.ToFloat64(ptpDelay), "PtpDelay does not match\n%s", tc.String())
 		}
-		if tc.expectedSyncState != SKIP {
+		if tc.expectedSyncStateCheck {
 			clockState := metrics.SyncState.With(map[string]string{"process": tc.process, "node": tc.node, "iface": tc.iface})
-			assert.Equal(tc.expectedSyncState, testutil.ToFloat64(clockState), "SyncState does not match\n%s", tc.String())
+
+			cs := testutil.ToFloat64(clockState)
+			assert.Equal(tc.expectedSyncState, cs, "SyncState does not match\n%s", tc.String())
 		}
-		if tc.expectedNmeaStatus != SKIP {
+		if tc.expectedNmeaStatusCheck {
 			nmeaStatus := metrics.NmeaStatus.With(map[string]string{"process": tc.process, "node": tc.node, "iface": tc.iface})
 			assert.Equal(tc.expectedNmeaStatus, testutil.ToFloat64(nmeaStatus), "NmeaStatus does not match\n%s", tc.String())
 		}
-		if tc.expectedClockClassMetrics != SKIP {
+		if tc.expectedClockClassMetricsCheck {
 			clockClassMetrics := metrics.ClockClassMetrics.With(map[string]string{"process": tc.process, "node": tc.node})
 			assert.Equal(tc.expectedClockClassMetrics, testutil.ToFloat64(clockClassMetrics), "ClockClassMetrics does not match\n%s", tc.String())
 		}

--- a/plugins/ptp_operator/metrics/ptp4lParse.go
+++ b/plugins/ptp_operator/metrics/ptp4lParse.go
@@ -56,6 +56,7 @@ func (p *PTPEventManager) ParsePTP4l(processName, configName, profileName, outpu
 		if portID == 0 || role == types.UNKNOWN {
 			return
 		}
+
 		if ptpInterface, err = ptp4lCfg.ByPortID(portID); err != nil {
 			log.Error(err)
 			log.Errorf("possible error due to file watcher not updated")
@@ -84,30 +85,16 @@ func (p *PTPEventManager) ParsePTP4l(processName, configName, profileName, outpu
 			// based on its last role  as slave port  we should make sure we report HOLDOVER event
 			if lastRole == types.FAULTY { // recovery
 				if role == types.SLAVE { // cancel any HOLDOVER timeout, if new role is slave
-					if masterOffsetSource == ptp4lProcessName {
-						if t, ok := p.PtpConfigMapUpdates.EventThreshold[profileName]; ok { // only if offset was reported by ptp4l process
-							log.Infof("interface %s is not anymore faulty, cancel any holdover states", ptpIFace)
-							t.SafeClose() // close any holdover go routines
-						}
-						alias := ptpStats[master].Alias()
-						if alias == "" {
-							alias = ptp4lCfg.GetAliasByInterface(ptpInterface) // this is default to any interface
-						}
-						masterResource := fmt.Sprintf("%s/%s", alias, MasterClockType)
-						p.GenPTPEvent(profileName, ptpStats[master], masterResource, FreeRunOffsetValue, ptp.FREERUN, ptp.PtpStateChange)
-						UpdateSyncStateMetrics(ptpStats[master].ProcessName(), alias, ptp.FREERUN)
-						// Send os clock sync state only if os clock is synced via phc
-						if t, ok := p.PtpConfigMapUpdates.PtpProcessOpts[profileName]; ok && t.Phc2SysEnabled() {
-							p.GenPTPEvent(profileName, ptpStats[ClockRealTime], ClockRealTime, FreeRunOffsetValue, ptp.FREERUN, ptp.OsClockSyncStateChange)
-							UpdateSyncStateMetrics(phc2sysProcessName, ClockRealTime, ptp.FREERUN)
-						} else {
-							log.Infof("phc2sys is not enabled for profile %s, skiping os clock syn state ", profileName)
-						}
+					// Do not cancel any HOLDOVER until holodover times out or PTP sync state is back in locked state
+					if masterOffsetSource == ptp4lProcessName && ptpStats[master].LastSyncState() == ptp.HOLDOVER {
+						log.Infof("Interface %s is no longer faulty. The holdover state will remain active until the PTP sync state is detected as LOCKED or the holdover times out.", ptpIFace)
+						// No events or metrics will  be generated instead will remain in Holdover state, when net iteration finds it in locked state
 					}
+
 					ptpStats[master].SetRole(role)
 				}
 			}
-			log.Infof("update interface %s with portid %d from role %s to role %s", ptpIFace, portID, lastRole, role)
+			log.Infof("update interface %s with portid %d from role %s to role %s  out %s", ptpIFace, portID, lastRole, role, output)
 			ptp4lCfg.Interfaces[portID-1].UpdateRole(role)
 
 			// update role metrics
@@ -131,19 +118,18 @@ func (p *PTPEventManager) ParsePTP4l(processName, configName, profileName, outpu
 			if ptpStats[master].ProcessName() == masterOffsetSource {
 				alias := ptpStats[master].Alias()
 				masterResource := fmt.Sprintf("%s/%s", alias, MasterClockType)
-				p.PublishEvent(syncState, ptpStats[master].LastOffset(), masterResource, ptp.PtpStateChange)
 				ptpStats[master].SetLastSyncState(syncState)
+				p.PublishEvent(syncState, ptpStats[master].LastOffset(), masterResource, ptp.PtpStateChange)
 				UpdateSyncStateMetrics(ptpStats[master].ProcessName(), alias, syncState)
-				// Put CLOCK_REALTIME in FREERUN state
-				var ptpOpts *ptpConfig.PtpProcessOpts
-				var ok bool
-				if ptpOpts, ok = p.PtpConfigMapUpdates.PtpProcessOpts[profileName]; ok && ptpOpts != nil && ptpOpts.Phc2SysEnabled() {
-					p.PublishEvent(ptp.FREERUN, ptpStats[ClockRealTime].LastOffset(), ClockRealTime, ptp.OsClockSyncStateChange)
-					ptpStats[ClockRealTime].SetLastSyncState(ptp.FREERUN)
-					UpdateSyncStateMetrics(phc2sysProcessName, ClockRealTime, ptp.FREERUN)
+				if ptpOpts, ok := p.PtpConfigMapUpdates.PtpProcessOpts[profileName]; ok && ptpOpts != nil {
+					p.maybePublishOSClockSyncStateChangeEvent(ptpOpts, configName, profileName)
+					threshold := p.PtpThreshold(profileName, true)
+					if p.mock {
+						log.Infof("mock holdover is set to %s", ptpStats[MasterClockType].Alias())
+					} else {
+						go handleHoldOverState(p, ptpOpts, configName, profileName, threshold.HoldOverTimeout, ptpStats[MasterClockType].Alias(), threshold.Close)
+					}
 				}
-				threshold := p.PtpThreshold(profileName, true)
-				go handleHoldOverState(p, ptpOpts, configName, profileName, threshold.HoldOverTimeout, MasterClockType, threshold.Close)
 			}
 		}
 	}
@@ -154,7 +140,7 @@ func handleHoldOverState(ptpManager *PTPEventManager,
 	ptpProfileName string, holdoverTimeout int64,
 	ptpIFace string, c chan struct{}) {
 	defer func() {
-		log.Infof("exiting holdover for interface %s", ptpIFace)
+		log.Infof("exiting holdover for profile %s with interface %s", ptpProfileName, ptpIFace)
 		if r := recover(); r != nil {
 			fmt.Println("Recovered in f", r)
 		}
@@ -164,27 +150,85 @@ func handleHoldOverState(ptpManager *PTPEventManager,
 		log.Infof("call received to close holderover timeout")
 		return
 	case <-time.After(time.Duration(holdoverTimeout) * time.Second):
-		log.Infof("time expired for interface %s", ptpIFace)
+		log.Infof("holdover time expired for interface %s", ptpIFace)
 		ptpStats := ptpManager.GetStats(types.ConfigName(configName))
 		if mStats, found := ptpStats[master]; found {
-			if mStats.LastSyncState() == ptp.HOLDOVER {
+			if mStats.LastSyncState() == ptp.HOLDOVER { // if it was still in holdover while timing out then switch to FREERUN
 				log.Infof("HOLDOVER timeout after %d secs,setting clock state to FREERUN from HOLDOVER state for %s",
 					holdoverTimeout, master)
 				masterResource := fmt.Sprintf("%s/%s", mStats.Alias(), MasterClockType)
-				ptpManager.PublishEvent(ptp.FREERUN, ptpStats[MasterClockType].LastOffset(), masterResource, ptp.PtpStateChange)
 				ptpStats[MasterClockType].SetLastSyncState(ptp.FREERUN)
+				ptpManager.PublishEvent(ptp.FREERUN, ptpStats[MasterClockType].LastOffset(), masterResource, ptp.PtpStateChange)
 				UpdateSyncStateMetrics(mStats.ProcessName(), mStats.Alias(), ptp.FREERUN)
 				// don't check of os clock sync state if phc2 not enabled
-				if cStats, ok := ptpStats[ClockRealTime]; ok && ptpOpts != nil && ptpOpts.Phc2SysEnabled() {
-					ptpManager.GenPTPEvent(ptpProfileName, cStats, ClockRealTime, FreeRunOffsetValue, ptp.FREERUN, ptp.OsClockSyncStateChange)
-					UpdateSyncStateMetrics(phc2sysProcessName, ClockRealTime, ptp.FREERUN)
-				} else {
-					log.Infof("phc2sys is not enabled for profile %s, skiping os clock syn state ", ptpProfileName)
-				}
-				// s.reset()
+				ptpManager.maybePublishOSClockSyncStateChangeEvent(ptpOpts, configName, ptpProfileName)
 			}
 		} else {
 			log.Errorf("failed to switch from holdover, could not find ptpStats for interface %s", ptpIFace)
 		}
+	}
+}
+
+func (p *PTPEventManager) maybePublishOSClockSyncStateChangeEvent(
+	ptpOpts *ptpConfig.PtpProcessOpts, configName, ptpProfileName string) {
+	if ptpOpts == nil {
+		log.Error("No profile found in configuration; OS clock sync state change event not published.")
+		return
+	}
+
+	// Already in a synced state, check if we need to emit FREERUN event
+	publish := false
+	haProfile, haProfiles := p.ListHAProfilesWith(ptpProfileName)
+
+	if ptpOpts.Phc2SysEnabled() {
+		publish = true
+	} else if len(haProfiles) > 0 { // Check if we are in a HA profile
+		haConfigName := p.GetPTPConfigByProfile(haProfile)
+
+		// Proceed only if we were able to retrieve the system clock config
+		if len(haConfigName) > 0 {
+			configName = haConfigName // change to phc2sys config name
+			for _, hProfile := range haProfiles {
+				if hProfile == ptpProfileName {
+					continue // Skip current (already known to be faulty)
+				}
+				checkConfig := p.GetPTPConfigByProfile(hProfile)
+				if len(checkConfig) == 0 {
+					continue
+				}
+
+				if haStats, exists := p.GetStats(types.ConfigName(checkConfig))[master]; exists && haStats.Role() == types.SLAVE {
+					log.Infof("HA profile %s is still in SLAVE state, not setting CLOCK_REALTIME to FREERUN", hProfile)
+					return
+				}
+			}
+			// If all other HA profiles are non-SLAVE or missing, we can publish
+			publish = true
+			// set to the one that is in the HA profile
+			ptpProfileName = haProfile
+		} else {
+			return // No HA profile found, nothing to publish
+		}
+	}
+
+	ptpStats := p.GetStats(types.ConfigName(configName))
+	cStats, ok := ptpStats[ClockRealTime]
+	if !ok {
+		// ClockRealTime stats not available, nothing to publish
+		return
+	}
+	if cStats.LastSyncState() == ptp.FREERUN {
+		// Already in FREERUN, no need to publish again
+		return
+	}
+
+	if publish {
+		if p.mock {
+			p.mockEvent = []ptp.EventType{ptp.OsClockSyncStateChange}
+			log.Infof("PublishEvent state=%s, ptpOffset=%d, source=%s, eventType=%s", ptp.FREERUN, FreeRunOffsetValue, ClockRealTime, ptp.OsClockSyncStateChange)
+			return
+		}
+		p.GenPTPEvent(ptpProfileName, cStats, ClockRealTime, FreeRunOffsetValue, ptp.FREERUN, ptp.OsClockSyncStateChange)
+		UpdateSyncStateMetrics(phc2sysProcessName, ClockRealTime, ptp.FREERUN)
 	}
 }

--- a/plugins/ptp_operator/ptp_operator_plugin_test.go
+++ b/plugins/ptp_operator/ptp_operator_plugin_test.go
@@ -18,24 +18,33 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
+	v2 "github.com/cloudevents/sdk-go/v2"
+	"github.com/google/uuid"
+	event2 "github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/event"
+	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/metrics"
+	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/stats"
+	"github.com/redhat-cne/sdk-go/pkg/event"
+	"github.com/redhat-cne/sdk-go/pkg/types"
+	"k8s.io/utils/pointer"
 	"log"
 	"os"
 	"path"
+	"strings"
 	"sync"
 	"testing"
 
 	"github.com/redhat-cne/cloud-event-proxy/pkg/common"
-	"github.com/redhat-cne/cloud-event-proxy/pkg/plugins"
 	ptpTypes "github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/types"
 	restapi "github.com/redhat-cne/rest-api"
 	"github.com/redhat-cne/sdk-go/pkg/channel"
 	ptpEvent "github.com/redhat-cne/sdk-go/pkg/event/ptp"
-	"github.com/redhat-cne/sdk-go/pkg/types"
 	v1event "github.com/redhat-cne/sdk-go/v1/event"
 	"github.com/stretchr/testify/assert"
 
 	v1pubsub "github.com/redhat-cne/sdk-go/v1/pubsub"
+	subscriberApi "github.com/redhat-cne/sdk-go/v1/subscriber"
 )
 
 var (
@@ -47,96 +56,41 @@ var (
 	apiPort           int = 8990
 	c                 chan os.Signal
 	pubsubTypes       map[ptpEvent.EventType]*ptpTypes.EventPublisherType
+	nodeName          = "test_node"
 )
 
 func TestMain(m *testing.M) {
+	defer cleanUP()
 	scConfig = &common.SCConfiguration{
-		EventInCh:  make(chan *channel.DataChan, channelBufferSize),
-		EventOutCh: make(chan *channel.DataChan, channelBufferSize),
-		CloseCh:    make(chan struct{}),
-		APIPort:    apiPort,
-		APIPath:    "/api/test-cloud/",
-		APIVersion: "1.0",
-		PubSubAPI:  v1pubsub.GetAPIInstance(storePath),
-		StorePath:  storePath,
+		EventInCh:     make(chan *channel.DataChan, channelBufferSize),
+		EventOutCh:    make(chan *channel.DataChan, channelBufferSize),
+		CloseCh:       make(chan struct{}),
+		APIPort:       apiPort,
+		APIPath:       "/api/ocloudNotifications/v2/",
+		APIVersion:    "2.0",
+		PubSubAPI:     v1pubsub.GetAPIInstance(storePath),
+		SubscriberAPI: subscriberApi.GetAPIInstance(storePath),
+		StorePath:     storePath,
 		TransportHost: &common.TransportHost{
 			Type: common.HTTP,
-			URL:  "localhost:8089",
+			URL:  "localhost:8990",
 			Host: "localhost",
-			Port: 8089,
+			Port: 8990,
 			Err:  nil,
 		},
 		BaseURL: nil,
 	}
 
 	c = make(chan os.Signal)
+	cleanUP()
 	common.StartPubSubService(scConfig)
 	pubsubTypes = InitPubSubTypes(scConfig)
-	cleanUP()
+	scConfig.RestAPI.SetOnStatusReceiveOverrideFn(getMockOverrideFn())
 	os.Exit(m.Run())
 }
 func cleanUP() {
+	_, _ = scConfig.SubscriberAPI.DeleteAllSubscriptions()
 	_ = scConfig.PubSubAPI.DeleteAllPublishers()
-	_ = scConfig.PubSubAPI.DeleteAllSubscriptions()
-}
-
-// Test_StartWithHTTP ...
-func Test_StartWithHTTP(t *testing.T) {
-	os.Setenv("NODE_NAME", "test_node")
-	scConfig.TransportHost = &common.TransportHost{
-		Type:   0,
-		URL:    "http://localhost:9096",
-		Host:   "",
-		Port:   0,
-		Scheme: "",
-		Err:    nil,
-	}
-	scConfig.TransportHost.ParseTransportHost()
-	pl := plugins.Handler{Path: "../../plugins"}
-
-	defer cleanUP()
-	scConfig.CloseCh = make(chan struct{})
-	scConfig.PubSubAPI.EnableTransport()
-	log.Printf("loading http with host %s", scConfig.TransportHost.Host)
-	wg := sync.WaitGroup{}
-	httpTransportInstance, err := pl.LoadHTTPPlugin(&wg, scConfig, nil, nil)
-	if err != nil {
-		t.Skipf("http.Dial(%#v): %v", httpTransportInstance, err)
-	}
-
-	// build your client
-	//CLIENT SUBSCRIPTION: create a subscription to consume events
-	endpointURL := fmt.Sprintf("%s%s", scConfig.BaseURL, "dummy")
-	for _, pTypes := range pubsubTypes {
-		sub := v1pubsub.NewPubSub(types.ParseURI(endpointURL), path.Join(resourcePrefix, "test_node", string(pTypes.Resource)), scConfig.APIVersion)
-		sub, _ = common.CreateSubscription(scConfig, sub)
-		assert.NotEmpty(t, sub.ID)
-		assert.NotEmpty(t, sub.URILocation)
-		pTypes.PubID = sub.ID
-		pTypes.Pub = &sub
-	}
-	log.Printf("created subscriptions")
-
-	// start ptp plugin
-	//err = Start(&wg, scConfig, nil)
-	err = pl.LoadPTPPlugin(&wg, scConfig, nil)
-	assert.Nil(t, err)
-	log.Printf("started ptpPlugin")
-	for _, pTypes := range pubsubTypes {
-		e := v1event.CloudNativeEvent()
-		ce, _ := v1event.CreateCloudEvents(e, *pTypes.Pub)
-		ce.SetSource(pTypes.Pub.Resource)
-		v1event.SendNewEventToDataChannel(scConfig.EventInCh, fmt.Sprintf("%s", pTypes.Pub.Resource), ce)
-	}
-	log.Printf("waiting for Event Chan")
-	//EventData := <-scConfig.EventOutCh // status updated
-	//assert.Equal(t, channel.EVENT, EventData.Type)
-
-	close(scConfig.CloseCh) // close the channel
-	pubs := scConfig.PubSubAPI.GetPublishers()
-	assert.Equal(t, 7, len(pubs))
-	subs := scConfig.PubSubAPI.GetSubscriptions()
-	assert.Equal(t, 7, len(subs))
 }
 
 // ProcessInChannel will be  called if Transport is disabled
@@ -168,5 +122,313 @@ func ProcessInChannel() {
 		case <-scConfig.CloseCh:
 			return
 		}
+	}
+}
+
+func TestGetCurrentStatOverrideFn(t *testing.T) {
+	// Setup
+	//CLIENT SUBSCRIPTION: create a subscription to consume events
+
+	var err error
+	endpointURL := fmt.Sprintf("%s%s", scConfig.BaseURL, "dummy")
+	for _, pTypes := range pubsubTypes {
+		pub := v1pubsub.NewPubSub(types.ParseURI(endpointURL), path.Join(resourcePrefix, nodeName, string(pTypes.Resource)), scConfig.APIVersion)
+		pub, err = common.CreatePublisher(scConfig, pub)
+		assert.Nil(t, err)
+		assert.NotEmpty(t, pub.ID)
+		assert.NotEmpty(t, pub.URILocation)
+		pTypes.PubID = pub.ID
+		pTypes.Pub = &pub
+	}
+	assert.Equal(t, 7, len(pubsubTypes))
+	eventManager = metrics.NewPTPEventManager("/cluster/node", pubsubTypes, nodeName, scConfig)
+	eventManager.MockTest(true)
+
+	tests := []struct {
+		name                    string
+		eventSource             ptpEvent.EventResource
+		eventType               ptpEvent.EventType
+		expectedSyncState       ptpTypes.SyncState
+		expectedResourceAddress string
+		statsData               []statsData
+		depsClockState          []event2.ClockState
+	}{
+		{
+			name:                    "PTP State is Locked - Single Event",
+			expectedSyncState:       ptpTypes.LOCKED,
+			eventSource:             ptpEvent.PtpLockState,
+			eventType:               ptpEvent.PtpStateChange,
+			expectedResourceAddress: fmt.Sprintf("/cluster/node/%s/%s/%s", nodeName, "ens1fx", MasterClockType),
+			statsData: []statsData{
+				{clockType: MasterClockType, configName: "ptp4l.0.config", processName: "ptp4l", alias: "ens1fx", iface: "ens1f0", syncState: ptpEvent.LOCKED},
+			},
+		},
+		{
+			name:                    "OS CLOCK event not found",
+			expectedSyncState:       ptpTypes.FREERUN,
+			eventSource:             ptpEvent.OsClockSyncState,
+			eventType:               ptpEvent.OsClockSyncStateChange,
+			expectedResourceAddress: fmt.Sprintf("/cluster/node/%s/%s", nodeName, "event-not-found"),
+			statsData: []statsData{
+				{clockType: MasterClockType, configName: "ptp4l.0.config", processName: "phc2sys", alias: "ens1fx", iface: "ens1f0", syncState: ptpEvent.LOCKED},
+			},
+		},
+		{
+			name:                    "OS CLOCK is Locked - Single Event",
+			expectedSyncState:       ptpTypes.LOCKED,
+			eventSource:             ptpEvent.OsClockSyncState,
+			eventType:               ptpEvent.OsClockSyncStateChange,
+			expectedResourceAddress: fmt.Sprintf("/cluster/node/%s/%s", nodeName, ClockRealTime),
+			statsData: []statsData{
+				{clockType: ClockRealTime, configName: "ptp4l.0.config", processName: "phc2sys", alias: "", iface: "", syncState: ptpEvent.LOCKED},
+			},
+		},
+		{
+			name:                    "SyncStatusState := LOCKED Master + FREERUN OS",
+			eventSource:             ptpEvent.SyncStatusState,
+			eventType:               ptpEvent.SyncStateChange,
+			expectedSyncState:       ptpTypes.FREERUN,
+			expectedResourceAddress: fmt.Sprintf("/cluster/node/%s%s", nodeName, ptpEvent.SyncStatusState),
+			statsData: []statsData{
+				{clockType: MasterClockType, configName: "ptp4l.0.config", processName: "ptp4l", alias: "ens1fx", iface: "ens1f0", syncState: ptpEvent.LOCKED},
+				{clockType: ClockRealTime, configName: "ptp4l.0.config", processName: "phc2sys", syncState: ptpEvent.FREERUN},
+			},
+		},
+		{
+			name:                    "SyncStatusState:= FREERUN Master + FREERUN OS",
+			eventSource:             ptpEvent.SyncStatusState,
+			eventType:               ptpEvent.SyncStateChange,
+			expectedSyncState:       ptpTypes.FREERUN,
+			expectedResourceAddress: fmt.Sprintf("/cluster/node/%s%s", nodeName, ptpEvent.SyncStatusState),
+			statsData: []statsData{
+				{clockType: MasterClockType, configName: "ptp4l.0.config", processName: "ptp4l", alias: "ens1fx", iface: "ens1f0", syncState: ptpEvent.FREERUN},
+				{clockType: ClockRealTime, configName: "ptp4l.0.config", processName: "phc2sys", syncState: ptpEvent.FREERUN},
+			},
+		},
+		{
+			name:                    "SyncStatusState:= LOCKED Master + LOCKED OS",
+			eventSource:             ptpEvent.SyncStatusState,
+			eventType:               ptpEvent.SyncStateChange,
+			expectedSyncState:       ptpTypes.LOCKED,
+			expectedResourceAddress: fmt.Sprintf("/cluster/node/%s%s", nodeName, ptpEvent.SyncStatusState),
+			statsData: []statsData{
+				{clockType: MasterClockType, configName: "ptp4l.0.config", processName: "ptp4l", alias: "ens1fx", iface: "ens1f0", syncState: ptpEvent.LOCKED},
+				{clockType: ClockRealTime, configName: "ptp4l.0.config", processName: "phc2sys", syncState: ptpEvent.LOCKED},
+			},
+		},
+		{
+			name:                    "SyncStatusState:= T-GM everything is  locked ",
+			eventSource:             ptpEvent.SyncStatusState,
+			eventType:               ptpEvent.SyncStateChange,
+			expectedSyncState:       ptpTypes.LOCKED,
+			expectedResourceAddress: fmt.Sprintf("/cluster/node/%s%s", nodeName, ptpEvent.SyncStatusState),
+			statsData: []statsData{
+				{clockType: MasterClockType, configName: "ptp4l.0.config", processName: "ptp4l", alias: "ens1fx", iface: "ens1f0", syncState: ptpEvent.LOCKED},
+				{clockType: ClockRealTime, configName: "ptp4l.0.config", processName: "phc2sys", syncState: ptpEvent.LOCKED},
+			},
+			depsClockState: []event2.ClockState{
+				{ClockSource: event2.GNSS, Process: gnssProcessName, Offset: pointer.Float64(1.0), IFace: pointer.String("ens1f0"), State: ptpEvent.LOCKED},
+				{ClockSource: event2.DPLL, Process: "dpll", Offset: pointer.Float64(1.0), IFace: pointer.String("ens1f0"), State: ptpEvent.LOCKED},
+				{ClockSource: event2.GM, Process: "gm", Offset: pointer.Float64(1.0), IFace: pointer.String("ens1f0"), State: ptpEvent.LOCKED},
+			},
+		},
+		{
+			name:                    "SyncStatusState:= T-GM everything is  locked ",
+			eventSource:             ptpEvent.SyncStatusState,
+			eventType:               ptpEvent.SyncStateChange,
+			expectedSyncState:       ptpTypes.FREERUN,
+			expectedResourceAddress: fmt.Sprintf("/cluster/node/%s%s", nodeName, ptpEvent.SyncStatusState),
+			statsData: []statsData{
+				{clockType: MasterClockType, configName: "ptp4l.0.config", processName: "ptp4l", alias: "ens1fx", iface: "ens1f0", syncState: ptpEvent.LOCKED},
+				{clockType: ClockRealTime, configName: "ptp4l.0.config", processName: "phc2sys", syncState: ptpEvent.FREERUN},
+			},
+			depsClockState: []event2.ClockState{
+				{ClockSource: event2.GNSS, Process: gnssProcessName, Offset: pointer.Float64(1.0), IFace: pointer.String("ens1f0"), State: ptpEvent.LOCKED},
+				{ClockSource: event2.DPLL, Process: "dpll", Offset: pointer.Float64(1.0), IFace: pointer.String("ens1f0"), State: ptpEvent.LOCKED},
+				{ClockSource: event2.GM, Process: "gm", Offset: pointer.Float64(1.0), IFace: pointer.String("ens1f0"), State: ptpEvent.LOCKED},
+			},
+		},
+		{
+			name:                    "SyncStatusState:= T-GM not everything is locked ",
+			eventSource:             ptpEvent.SyncStatusState,
+			eventType:               ptpEvent.SyncStateChange,
+			expectedSyncState:       ptpTypes.LOCKED,
+			expectedResourceAddress: fmt.Sprintf("/cluster/node/%s%s", nodeName, ptpEvent.SyncStatusState),
+			statsData: []statsData{
+				{clockType: MasterClockType, configName: "ptp4l.0.config", processName: "ptp4l", alias: "ens1fx", iface: "ens1f0", syncState: ptpEvent.LOCKED},
+				{clockType: ClockRealTime, configName: "ptp4l.0.config", processName: "phc2sys", syncState: ptpEvent.LOCKED},
+			},
+			depsClockState: []event2.ClockState{
+				{ClockSource: event2.GNSS, Process: gnssProcessName, Offset: pointer.Float64(1.0), IFace: pointer.String("ens1f0"), State: ptpEvent.LOCKED},
+				{ClockSource: event2.DPLL, Process: "dpll", Offset: pointer.Float64(1.0), IFace: pointer.String("ens1f0"), State: ptpEvent.FREERUN},
+				{ClockSource: event2.GM, Process: "gm", Offset: pointer.Float64(1.0), IFace: pointer.String("ens1f0"), State: ptpEvent.LOCKED},
+			},
+		},
+	}
+
+	// Iterate over test cases
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			event := buildEvent(nodeName, tt.eventSource, tt.eventType)
+			eventManager.Stats = getStats(tt.statsData, tt.depsClockState)
+
+			// Initialize Stats object
+			// Invoke the function
+			// Mock input
+			mockDataChan := &channel.DataChan{
+				ClientID: uuid.MustParse("123e4567-e89b-12d3-a456-426614174000"),
+			}
+
+			overrideFn := getCurrentStatOverrideFn()
+			err := overrideFn(event, mockDataChan)
+
+			// Assertions
+			assert.NoError(t, err, "Expected no error from getCurrentStatOverrideFn")
+			assert.NotNil(t, mockDataChan.Data, "Expected DataChan.Data to be populated")
+			eventReceived, err2 := v1event.GetCloudNativeEvents(*mockDataChan.Data)
+
+			assert.Nil(t, err2)
+			assert.Equal(t, tt.expectedSyncState.String(), eventReceived.Data.Values[0].Value, "Expected SyncState to match event state")
+			assert.Equal(t, tt.expectedResourceAddress, eventReceived.Data.Values[0].Resource, "Expected resource to match expected resource")
+			expectedReturnAddr := fmt.Sprintf("/cluster/node/%s%s", nodeName, string(tt.eventSource))
+			assert.Equal(t, expectedReturnAddr, *mockDataChan.ReturnAddress)
+		})
+	}
+}
+
+// Define the struct to match the JSON structure
+
+type statsData struct {
+	clockType   string
+	configName  string
+	alias       string
+	iface       string
+	processName string
+	syncState   ptpEvent.SyncState
+}
+
+func getStats(statsData []statsData, depsClockState []event2.ClockState) map[ptpTypes.ConfigName]stats.PTPStats {
+	s := make(map[ptpTypes.ConfigName]stats.PTPStats)
+
+	for index, statsObj := range statsData {
+
+		if _, found := s[ptpTypes.ConfigName(statsObj.configName)]; !found {
+			s[ptpTypes.ConfigName(statsObj.configName)] = make(stats.PTPStats)
+		}
+		if _, found := s[ptpTypes.ConfigName(statsObj.configName)][ptpTypes.IFace(statsObj.clockType)]; !found {
+			s[ptpTypes.ConfigName(statsObj.configName)][ptpTypes.IFace(statsObj.clockType)] = stats.NewStats(string(statsObj.clockType))
+			s[ptpTypes.ConfigName(statsObj.configName)][ptpTypes.IFace(statsObj.clockType)].SetOffsetSource(statsObj.processName)
+			s[ptpTypes.ConfigName(statsObj.configName)][ptpTypes.IFace(statsObj.clockType)].SetAlias(statsObj.alias)
+			s[ptpTypes.ConfigName(statsObj.configName)][ptpTypes.IFace(statsObj.clockType)].SetProcessName(statsObj.processName)
+			s[ptpTypes.ConfigName(statsObj.configName)][ptpTypes.IFace(statsObj.clockType)].SetLastSyncState(statsObj.syncState)
+
+			// Loop through depsClockState and call SetPtpDependentEventState for each ClockState
+			if index == 0 {
+				for _, clockState := range depsClockState {
+					s[ptpTypes.ConfigName(statsObj.configName)][ptpTypes.IFace(statsObj.clockType)].SetPtpDependentEventState(
+						clockState,
+						map[string]*event2.PMetric{
+							"metric1": {},
+						},
+						map[string]string{
+							"metric1": "Metric 1 description",
+						},
+					)
+				}
+			}
+		}
+
+	}
+	return s
+}
+
+func getDeps(state ptpEvent.SyncState, iface, processName string) event2.ClockState {
+	return event2.ClockState{
+		State:   state,
+		Offset:  pointer.Float64(5.0),
+		IFace:   pointer.String(iface),
+		Process: processName,
+	}
+
+}
+
+func ConvertToEvent(dataEncoded []byte) (*event.Event, error) {
+	// Unmarshal the JSON data into the Event struct
+	var event event.Event
+	err := json.Unmarshal(dataEncoded, &event)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshaling JSON: %w", err)
+	}
+	return &event, nil
+}
+
+func buildEvent(node string, source ptpEvent.EventResource, eventType ptpEvent.EventType) v2.Event {
+	e := v2.NewEvent()
+	e.SetSource(fmt.Sprintf("/cluster/node/%s%s", node, string(source)))
+	e.SetType(string(eventType))
+	return e
+}
+
+func getMockOverrideFn() func(e v2.Event, d *channel.DataChan) error {
+	return func(e v2.Event, d *channel.DataChan) error {
+		if e.Source() != "" {
+			d.ReturnAddress = pointer.String(e.Source())
+		}
+
+		var eventType ptpEvent.EventType
+		var eventSource ptpEvent.EventResource
+
+		switch {
+		case strings.Contains(e.Source(), string(ptpEvent.PtpLockState)):
+			eventType = ptpEvent.PtpStateChange
+			eventSource = ptpEvent.PtpLockState
+		case strings.Contains(e.Source(), string(ptpEvent.OsClockSyncState)):
+			eventType = ptpEvent.OsClockSyncStateChange
+			eventSource = ptpEvent.OsClockSyncState
+		case strings.Contains(e.Source(), string(ptpEvent.PtpClockClass)):
+			eventType = ptpEvent.PtpClockClassChange
+			eventSource = ptpEvent.PtpClockClass
+		case strings.Contains(e.Source(), string(ptpEvent.PtpClockClassV1)):
+			eventType = ptpEvent.PtpClockClassChange
+			eventSource = ptpEvent.PtpClockClassV1
+		case strings.Contains(e.Source(), string(ptpEvent.GnssSyncStatus)):
+			eventType = ptpEvent.GnssStateChange
+			eventSource = ptpEvent.GnssSyncStatus
+		case strings.Contains(e.Source(), string(ptpEvent.SyncStatusState)):
+			eventType = ptpEvent.SyncStateChange
+			eventSource = ptpEvent.SyncStatusState
+		case strings.Contains(e.Source(), string(ptpEvent.SyncStatusState)):
+			eventType = ptpEvent.SynceStateChange
+			eventSource = ptpEvent.SyncStatusState
+		case strings.Contains(e.Source(), string(ptpEvent.SynceClockQuality)):
+			eventType = ptpEvent.SynceClockQualityChange
+			eventSource = ptpEvent.SynceClockQuality
+		default:
+			return fmt.Errorf("mock: unsupported event source: %s", e.Source())
+		}
+
+		// Create dummy event data
+		data := &event.Data{
+			Version: "1.0",
+			Values: []event.DataValue{
+				{
+					Resource:  fmt.Sprintf("/mock/resource/%s", eventSource),
+					Value:     ptpEvent.LOCKED,
+					ValueType: event.ENUMERATION,
+					DataType:  event.NOTIFICATION,
+				},
+			},
+		}
+
+		// Encode to CloudEvent format
+		evts, err := eventManager.GetPTPCloudEvents(*data, eventType)
+		if err != nil {
+			return fmt.Errorf("mock: failed to get cloud event: %w", err)
+		}
+		evts.SetSource(string(eventSource))
+		d.Data = evts
+
+		return nil
 	}
 }

--- a/plugins/ptp_operator/types/types.go
+++ b/plugins/ptp_operator/types/types.go
@@ -17,6 +17,8 @@ type (
 	IFace string
 	// ConfigName ... config name
 	ConfigName string
+	// SyncState ... Sync state
+	SyncState int
 )
 
 const (
@@ -69,4 +71,26 @@ type EventPublisherType struct {
 	Resource  ptp.EventResource
 	PubID     string
 	Pub       *pubsub.PubSub
+}
+
+const (
+	// FREERUN
+	FREERUN SyncState = iota
+	// LOCKED
+	LOCKED
+	// HOLDOVER
+	HOLDOVER
+)
+
+func (syncState SyncState) String() string {
+	switch syncState {
+	case FREERUN:
+		return "FREERUN"
+	case LOCKED:
+		return "LOCKED"
+	case HOLDOVER:
+		return "HOLDOVER"
+	default:
+		return fmt.Sprintf("%d", int(syncState))
+	}
 }


### PR DESCRIPTION
manual cherry pick of https://github.com/redhat-cne/cloud-event-proxy/pull/515

This PR introduces two key improvements in the getCurrentStatOverrideFn logic used to determine and report PTP synchronization state.

Consistent Node Sync State Evaluation
The node-level synchronization state is now determined based on a consistent and comprehensive evaluation of:
PHC lock state(master)
OS clock (CLOCK_REALTIME) state
For T-GM nodes, additional dependencies:
DPLL state
GNSS signal state
Frequency traceability, etc.
This ensures that the overall sync state accurately reflects the health and synchronization status of all relevant components on the node.
2. Structured and Hierarchical ResourceAddress in CloudEvents
To improve clarity and traceability, the ResourceAddress field in the event data now accurately reflects the origin of the event with a hierarchical path. This follows the CloudEvents spec and supports multiple sources (e.g., multi-NIC PTP setups):
Source Type Resource Address Format

PTP Stats : /cluster/node/{nodename}/{interfaceIndex}/master
OS Clock : /cluster/node/{nodename}/CLOCK_REALTIME
GNSS : /cluster/node/{nodename}/{interfaceIndex}/master

Node Sync Summary : /cluster/node/{nodename}/sync/sync-status/sync-state
The actual source is set in the CloudEvents envelope’s source field, allowing event consumers to identify and filter events by origin:
This design is essential to support multiple PTP-capable interfaces and pinpoint the exact source of state transitions.
In Case of /sync/sync-status/sync-state, This gives over status of the node in that case the resource address wil be reported as /cluster/node/{nodename}/sync/sync-status/sync-state

{ "specversion": "1.0", "type": "event.synchronization-state-change", "source": "/sync/sync-status/sync-state", "id": "831e1650-001e-001b-66ab-eeb76e069631", "time": "2021-03-05T20:59:59.998888999Z", "data": { "version": "1.0",, "values": [ { "type": "notification", "ResourceAddress": "/cluster/node/{nodename}/sync/sync-status/sync-state", "value_type": "enumeration", "value": "HOLDOVER" } ] } }

Unit Test Enhancements
This PR also includes new unit test to verify TestGetCurrentStatOverrideFn
Test Cases Covered:
Single Locked Clock – Verifies correct PTP LOCKED state.
LOCKED GM + FREERUN OS – Expected result: FREERUN.
FREERUN GM + FREERUN OS – Expected result: FREERUN.
LOCKED GM + LOCKED OS – Expected result: LOCKED.