### PR TITLE
Re-add alias logic

### DIFF
--- a/plugins/ptp_operator/metrics/metrics.go
+++ b/plugins/ptp_operator/metrics/metrics.go
@@ -273,6 +273,10 @@ func (p *PTPEventManager) ExtractMetrics(msg string) {
 				// Report events for master  by masking the index  number of the slave interface
 				if ptpInterface.Name != "" {
 					alias := ptpStats[types.IFace(interfaceName)].Alias()
+					if alias == "" {
+						alias = utils.GetAlias(ptpInterface.Name)
+						ptpStats[types.IFace(interfaceName)].SetAlias(alias)
+					}
 					// forT-BC only update metrics/ but we are missing maxAbs for T-BC, fro now it will use  T-BC offsets
 					UpdatePTPMetrics(offsetSource, processName, alias, ptpOffset, float64(ptpStats[types.IFace(interfaceName)].MaxAbs()),
 						frequencyAdjustment, delay)


### PR DESCRIPTION
This PR attemps to fix an issue introduced by https://github.com/redhat-cne/cloud-event-proxy/pull/552 where the alias interface is not populated in the metrics output, similar to this:
`openshift_ptp_clock_state{iface="",node="kind-netdevsim-worker",process="ptp4l"} 1`
The fix is to read the removed logic.