### PR TITLE
OCPBUGS-59969: Handle missing event data in getCurrentState with 404 response

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.23.0
 	github.com/prometheus/client_golang v1.14.0
-	github.com/redhat-cne/rest-api v1.23.3
+	github.com/redhat-cne/rest-api v1.23.5
 	github.com/redhat-cne/sdk-go v1.23.4
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -420,8 +420,8 @@ github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5mo=
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/redhat-cne/rest-api v1.23.3 h1:otyRM2Dhhzva+j6ee2EH5A08253nQiR1yeUGGidkUo4=
-github.com/redhat-cne/rest-api v1.23.3/go.mod h1:HTe6Ojj58b9HBrbfPXma46sJ10UYAlvznbfTo85cWK4=
+github.com/redhat-cne/rest-api v1.23.5 h1:KvaPYhdSysY0IkUbX6DV2EnIHGKs6RFI/RyaMUjpvdA=
+github.com/redhat-cne/rest-api v1.23.5/go.mod h1:HTe6Ojj58b9HBrbfPXma46sJ10UYAlvznbfTo85cWK4=
 github.com/redhat-cne/sdk-go v1.23.4 h1:F30wfGxkzZ9YH566EJOxS8J0v6Y36YsW5WK/QgvMQPs=
 github.com/redhat-cne/sdk-go v1.23.4/go.mod h1:znWihNT1b2sUGT4o1NrxlYE5/AK3C67NYAq7Lk2R5FY=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -186,7 +186,7 @@ github.com/prometheus/common/model
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/redhat-cne/rest-api v1.23.3
+# github.com/redhat-cne/rest-api v1.23.5
 ## explicit; go 1.23.0
 github.com/redhat-cne/rest-api/pkg/localmetrics
 github.com/redhat-cne/rest-api/pkg/restclient


### PR DESCRIPTION
Previously, getCurrentState returned a FREERUN state with placeholder ResourceAddresses ("event-not-found" or "ptp-not-set") when event data was unavailable, for example when the event socket wasn't ready, risking cell site outages. This update ensures a 404 Not Found status is returned instead, accurately signaling the absence of valid event data.

Add validation to prevent Stats.ClockClass() from returning an uninitialized value (0), which could result in unintended events with clockClass=0.