### PR TITLE
[release-4.18] OCPBUGS-59984: Handle missing event data in getCurrentState with 404/400 response

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.23.0
 	github.com/prometheus/client_golang v1.14.0
-	github.com/redhat-cne/rest-api v1.22.3
-	github.com/redhat-cne/sdk-go v1.22.5
+	github.com/redhat-cne/rest-api v1.22.5
+	github.com/redhat-cne/sdk-go v1.22.6
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/net v0.33.0

--- a/go.sum
+++ b/go.sum
@@ -420,10 +420,10 @@ github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5mo=
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/redhat-cne/rest-api v1.22.3 h1:3ZyqcMPVAvgp9TNT8h59IwzDqxwCAHzGL9KMGLpXGVg=
-github.com/redhat-cne/rest-api v1.22.3/go.mod h1:WB0zvsUczoAUzSWBb9NML2qdBc/9KCND0dDOe94gQBM=
-github.com/redhat-cne/sdk-go v1.22.5 h1:ikZK3yjbQdHx4NetPVfwWMkWGhYW8VgBB3M54gnUmXA=
-github.com/redhat-cne/sdk-go v1.22.5/go.mod h1:qeir05dwTscLvqGCIoQPCUM6HUoVmhR7521nXn28utA=
+github.com/redhat-cne/rest-api v1.22.5 h1:rXExxpM+YRUzubwKtn5TmKj4PrYzKA37mfT/WE4nBW8=
+github.com/redhat-cne/rest-api v1.22.5/go.mod h1:vnLh99fOTeLNKsSqTB/q4GNRE9eudCR/lOlKFTlPfxs=
+github.com/redhat-cne/sdk-go v1.22.6 h1:AAVG5KwOKtno2WpL7hLQ9ZWJryJZuo2WgNt2u7o257E=
+github.com/redhat-cne/sdk-go v1.22.6/go.mod h1:qeir05dwTscLvqGCIoQPCUM6HUoVmhR7521nXn28utA=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/plugins/ptp_operator/ptp_operator_plugin.go
+++ b/plugins/ptp_operator/ptp_operator_plugin.go
@@ -60,6 +60,8 @@ const (
 	ClockRealTime = "CLOCK_REALTIME"
 	// MasterClockType is the slave sync slave clock to master
 	MasterClockType = "master"
+	EventNotFound   = "event-not-found"
+	PTPNotSet       = "ptp-not-set"
 )
 
 var (
@@ -221,7 +223,7 @@ func getCurrentStatOverrideFn() func(e v2.Event, d *channel.DataChan) error {
 			return fmt.Errorf("could not find any events for requested resource type %s", e.Source())
 		}
 		if len(eventManager.Stats) == 0 {
-			data := eventManager.GetPTPEventsData(ptp.FREERUN, 0, "ptp-not-set", eventType)
+			data := eventManager.GetPTPEventsData(ptp.FREERUN, 0, PTPNotSet, eventType)
 			d.Data, err = eventManager.GetPTPCloudEvents(*data, eventType)
 			if err != nil {
 				return err
@@ -254,7 +256,12 @@ func getCurrentStatOverrideFn() func(e v2.Event, d *channel.DataChan) error {
 						data = processDataFn(data, eventManager.GetPTPEventsData(s.SyncState(), s.LastOffset(), string(ptpInterface), eventType))
 					case ptp.PtpClockClassChange:
 						clockClass := fmt.Sprintf("%s/%s", string(ptpInterface), ptpMetrics.ClockClass)
-						data = processDataFn(data, eventManager.GetPTPEventsData(s.SyncState(), s.ClockClass(), clockClass, eventType))
+						// make sure clock class has real value
+						if s.ClockClass() != 0 {
+							data = processDataFn(data, eventManager.GetPTPEventsData(s.SyncState(), s.ClockClass(), clockClass, eventType))
+						} else {
+							log.Debugf("Skipping PTP clock class change event for %s - clockClass not populated yet", string(ptpInterface))
+						}
 					case ptp.SyncStateChange:
 						overallSyncState = getOverallState(overallSyncState, s.SyncState())
 					}
@@ -337,7 +344,7 @@ func getCurrentStatOverrideFn() func(e v2.Event, d *channel.DataChan) error {
 			}
 			d.Data.SetSource(string(eventSource))
 		} else {
-			data = eventManager.GetPTPEventsData(ptp.FREERUN, 0, "event-not-found", eventType)
+			data = eventManager.GetPTPEventsData(ptp.FREERUN, 0, EventNotFound, eventType)
 			d.Data, err = eventManager.GetPTPCloudEvents(*data, eventType)
 			if err != nil {
 				return err

--- a/vendor/github.com/redhat-cne/rest-api/v2/routes.go
+++ b/vendor/github.com/redhat-cne/rest-api/v2/routes.go
@@ -40,6 +40,17 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const (
+	// the following special resource addresses are used in POST /subscriptions to
+	// send initial notification to test EndpointURI in order to successfully
+	// create a subscription when event data is not available.
+
+	// EventNotFound is a special resource address set when event data is not found.
+	EventNotFound = "event-not-found"
+	// PTPNotSet is a special resource address set when PTP stats is not yet populated.
+	PTPNotSet = "ptp-not-set"
+)
+
 // createSubscription create subscription and send it to a channel that is shared by middleware to process
 // Creates a new subscription .
 // If subscription exists with same resource then existing subscription is returned .
@@ -487,10 +498,22 @@ func (s *Server) getCurrentState(w http.ResponseWriter, r *http.Request) {
 	if s.statusReceiveOverrideFn != nil {
 		if statusErr := s.statusReceiveOverrideFn(*e, &out); statusErr != nil {
 			respondWithStatusCode(w, http.StatusNotFound, statusErr.Error())
-		} else if out.Data != nil {
-			respondWithJSON(w, http.StatusOK, *out.Data)
-		} else {
+		} else if out.Data == nil {
 			respondWithStatusCode(w, http.StatusNotFound, fmt.Sprintf("event not found for %s", resourceAddress))
+		} else {
+			// Unmarshal the cloud event data to check for resource data
+			var eventData cne.Data
+			if out.Data.Data() == nil {
+				respondWithStatusCode(w, http.StatusNotFound, fmt.Sprintf("event data is empty for %s", resourceAddress))
+			} else if err := json.Unmarshal(out.Data.Data(), &eventData); err != nil {
+				respondWithStatusCode(w, http.StatusNotFound, fmt.Sprintf("failed to unmarshal event data for %s: %v", resourceAddress, err))
+			} else if len(eventData.Values) == 0 || eventData.Values[0].Resource == "" {
+				respondWithStatusCode(w, http.StatusNotFound, fmt.Sprintf("event data invalid for %s", resourceAddress))
+			} else if strings.HasSuffix(eventData.Values[0].Resource, EventNotFound) || strings.HasSuffix(eventData.Values[0].Resource, PTPNotSet) {
+				respondWithStatusCode(w, http.StatusNotFound, fmt.Sprintf("event data not found for %s", resourceAddress))
+			} else {
+				respondWithJSON(w, http.StatusOK, *out.Data)
+			}
 		}
 	} else {
 		respondWithStatusCode(w, http.StatusNotFound, "onReceive function not defined")

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -186,13 +186,13 @@ github.com/prometheus/common/model
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/redhat-cne/rest-api v1.22.3
+# github.com/redhat-cne/rest-api v1.22.5
 ## explicit; go 1.22
 github.com/redhat-cne/rest-api
 github.com/redhat-cne/rest-api/pkg/localmetrics
 github.com/redhat-cne/rest-api/pkg/restclient
 github.com/redhat-cne/rest-api/v2
-# github.com/redhat-cne/sdk-go v1.22.5
+# github.com/redhat-cne/sdk-go v1.22.6
 ## explicit; go 1.22
 github.com/redhat-cne/sdk-go/pkg/channel
 github.com/redhat-cne/sdk-go/pkg/common


### PR DESCRIPTION
Previously, getCurrentState returned a FREERUN state with placeholder ResourceAddresses ("event-not-found" or "ptp-not-set") when event data was unavailable, for example when the event socket wasn't ready, risking cell site outages. This update ensures a 404(v2)/400(v1) status is returned instead, accurately signaling the absence of valid event data.

Add validation to prevent Stats.ClockClass() from returning an uninitialized value (0), which could result in unintended events with clockClass=0.