### PR TITLE
Fix PTP interface role assignment and metrics generation on container restart [release-4.20]

### DIFF
--- a/plugins/ptp_operator/metrics/manager.go
+++ b/plugins/ptp_operator/metrics/manager.go
@@ -292,17 +292,13 @@ func (p *PTPEventManager) publishSyncEEvent(syncState ptp.SyncState, source stri
 
 // GetPTPEventsData ... get PTP event data object
 func (p *PTPEventManager) GetPTPEventsData(state ptp.SyncState, ptpOffset int64, source string, eventType ptp.EventType) *ceevent.Data {
-	// create an event
-	if state == "" {
-		return nil
-	}
 	// /cluster/xyz/ptp/CLOCK_REALTIME this is not address the event is published to
 	eventSource := path.Join(p.resourcePrefix, p.nodeName, source)
 	data := ceevent.Data{
 		Version: ceevent.APISchemaVersion,
 		Values:  []ceevent.DataValue{},
 	}
-	if eventType != ptp.PtpClockClassChange && eventType != ptp.SynceClockQualityChange {
+	if eventType != ptp.PtpClockClassChange && eventType != ptp.SynceClockQualityChange && state != "" {
 		data.Values = append(data.Values, ceevent.DataValue{
 			Resource:  eventSource,
 			DataType:  ceevent.NOTIFICATION,


### PR DESCRIPTION
manual Cherry picked from 4.18 https://github.com/redhat-cne/cloud-event-proxy/pull/572
Problem
When the PTP container restarts, it fails to properly pick up config information and complete metrics for interface roles. This results in:
Interface roles remain UNKNOWN: The validLogToProcess function fails validation because interfaces have incomplete role assignments
Missing interface_role metrics: Metrics are not generated for interface roles during config processing
Log processing skipped: The system skips processing PTP logs due to validation failures, preventing proper metrics collection.

KNOWN ISSUE: ```
The interface role will be based on ptp config , if anything changed , side car won't know.
Future fix to update interface role from the daemon will fix this problem