### PR TITLE
[release-4.15] OCPBUGS-60622: Handle missing event data in getCurrentState with 400 response

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.23.0
 	github.com/prometheus/client_golang v1.14.0
-	github.com/redhat-cne/rest-api v1.20.0
-	github.com/redhat-cne/sdk-go v1.20.3
+	github.com/redhat-cne/rest-api v1.20.1
+	github.com/redhat-cne/sdk-go v1.20.4
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/net v0.33.0

--- a/go.sum
+++ b/go.sum
@@ -424,10 +424,10 @@ github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5mo=
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/redhat-cne/rest-api v1.20.0 h1:rL5ojUq+y9tcne/8UExV/YC8q1a8D7AdWPHDFgSpbLU=
-github.com/redhat-cne/rest-api v1.20.0/go.mod h1:rRW+MVyHxBtSGwnwYdRVoRl6w57j40sYE1ACmMjm6wo=
-github.com/redhat-cne/sdk-go v1.20.3 h1:KLcQx/Xq6NywPpI+6sp4Ok+fXhabCWfg+zk/TcOVgzM=
-github.com/redhat-cne/sdk-go v1.20.3/go.mod h1:FY1bNkTp86TzUQvTDAuhJHS4IC78r+XsNc9L9ZOtGgU=
+github.com/redhat-cne/rest-api v1.20.1 h1:TThHLNYYo3khSKkyJJsqTMYjsZsuUXTYM+ppH7cIN4g=
+github.com/redhat-cne/rest-api v1.20.1/go.mod h1:wH+hdu7MDI0h2i45rqk493naYdhCrSkuz59Ib3tbqtg=
+github.com/redhat-cne/sdk-go v1.20.4 h1:lacFny9iCHC8QVlUbm1jBM92sz9ESSRCnQR1fNG+E8g=
+github.com/redhat-cne/sdk-go v1.20.4/go.mod h1:FY1bNkTp86TzUQvTDAuhJHS4IC78r+XsNc9L9ZOtGgU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/plugins/ptp_operator/ptp_operator_plugin.go
+++ b/plugins/ptp_operator/ptp_operator_plugin.go
@@ -60,6 +60,10 @@ const (
 	ClockRealTime = "CLOCK_REALTIME"
 	// MasterClockType is the slave sync slave clock to master
 	MasterClockType = "master"
+	// EventNotFound is a special resource address set when event data is not found.
+	EventNotFound = "event-not-found"
+	// PTPNotSet is a special resource address set when PTP stats is not yet populated.
+	PTPNotSet = "ptp-not-set"
 )
 
 var (
@@ -207,7 +211,7 @@ func getCurrentStatOverrideFn() func(e v2.Event, d *channel.DataChan) error {
 			return fmt.Errorf("could not find any events for requested resource type %s", e.Source())
 		}
 		if len(eventManager.Stats) == 0 {
-			data := eventManager.GetPTPEventsData(ptp.FREERUN, 0, "ptp-not-set", eventType)
+			data := eventManager.GetPTPEventsData(ptp.FREERUN, 0, PTPNotSet, eventType)
 			d.Data, err = eventManager.GetPTPCloudEvents(*data, eventType)
 			if err != nil {
 				return err
@@ -241,7 +245,12 @@ func getCurrentStatOverrideFn() func(e v2.Event, d *channel.DataChan) error {
 						data = processDataFn(data, eventManager.GetPTPEventsData(s.SyncState(), s.LastOffset(), string(ptpInterface), eventType))
 					case ptp.PtpClockClassChange:
 						clockClass := fmt.Sprintf("%s/%s", string(ptpInterface), ptpMetrics.ClockClass)
-						data = processDataFn(data, eventManager.GetPTPEventsData(s.SyncState(), s.ClockClass(), clockClass, eventType))
+						// make sure clock class has real value
+						if s.ClockClass() != 0 {
+							data = processDataFn(data, eventManager.GetPTPEventsData(s.SyncState(), s.ClockClass(), clockClass, eventType))
+						} else {
+							log.Debugf("Skipping PTP clock class change event for %s - clockClass not populated yet", string(ptpInterface))
+						}
 					case ptp.SyncStateChange:
 						overallSyncState = getOverallState(overallSyncState, s.SyncState())
 					}
@@ -284,7 +293,7 @@ func getCurrentStatOverrideFn() func(e v2.Event, d *channel.DataChan) error {
 			}
 			d.Data.SetSource(string(eventSource))
 		} else {
-			data = eventManager.GetPTPEventsData(ptp.FREERUN, 0, "event-not-found", eventType)
+			data = eventManager.GetPTPEventsData(ptp.FREERUN, 0, EventNotFound, eventType)
 			d.Data, err = eventManager.GetPTPCloudEvents(*data, eventType)
 			if err != nil {
 				return err

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -196,11 +196,11 @@ github.com/prometheus/common/model
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/redhat-cne/rest-api v1.20.0
+# github.com/redhat-cne/rest-api v1.20.1
 ## explicit; go 1.20
 github.com/redhat-cne/rest-api
 github.com/redhat-cne/rest-api/pkg/localmetrics
-# github.com/redhat-cne/sdk-go v1.20.3
+# github.com/redhat-cne/sdk-go v1.20.4
 ## explicit; go 1.20
 github.com/redhat-cne/sdk-go/pkg/channel
 github.com/redhat-cne/sdk-go/pkg/errorhandler


### PR DESCRIPTION
Previously, getCurrentState returned a FREERUN state with placeholder ResourceAddresses ("event-not-found" or "ptp-not-set") when event data was unavailable, for example when the event socket wasn't ready, risking cell site outages. This update ensures a 400 status is returned instead, accurately signaling the absence of valid event data.

Add validation to prevent Stats.ClockClass() from returning an uninitialized value (0), which could result in unintended events with clockClass=0.