### PR TITLE
Save and load basic metrics to file in store and trigger logs from linuxptp-daemon

### DIFF
--- a/plugins/ptp_operator/metrics/filesystem.go
+++ b/plugins/ptp_operator/metrics/filesystem.go
@@ -1,0 +1,31 @@
+package metrics
+
+import (
+	"os"
+)
+
+type WFiles interface {
+	WriteFile(name string, data []byte, perm os.FileMode) error
+}
+
+type OSFileSystem struct {
+}
+
+func (f OSFileSystem) WriteFile(name string, data []byte, perm os.FileMode) error {
+	return os.WriteFile(name, data, perm)
+}
+
+type MockFileSystem struct {
+	WriteCount int
+}
+
+func (m *MockFileSystem) WriteFile(name string, data []byte, perm os.FileMode) error {
+	m.WriteCount += 1
+	return nil
+}
+
+func (m *MockFileSystem) Clear() {
+	m.WriteCount = 0
+}
+
+var Filesystem WFiles = OSFileSystem{}

--- a/plugins/ptp_operator/metrics/logparser.go
+++ b/plugins/ptp_operator/metrics/logparser.go
@@ -330,7 +330,7 @@ func isOffsetInRange(ptpOffset, maxOffsetThreshold, minOffsetThreshold int64) bo
 	return false
 }
 
-func parsePTPStatus(output string, fields []string) (int64, error) {
+func (p *PTPEventManager) parsePTPStatus(output string, fields []string) (int64, error) {
 	// ptp4l 5196819.100 ptp4l.0.config PTP_PROCESS_STOPPED:0/1
 
 	if len(fields) < 5 {
@@ -343,6 +343,7 @@ func parsePTPStatus(output string, fields []string) (int64, error) {
 		log.Error("error process status value")
 		return PtpProcessDown, err
 	}
+	p.updateProcessStatus(types.ConfigName(fields[2]), fields[0], (status == 1))
 	// ptp4l 5196819.100 ptp4l.0.config PTP_PROCESS_STOPPED:0/1
 	UpdateProcessStatusMetrics(fields[0], fields[2], status)
 	return status, nil

--- a/plugins/ptp_operator/metrics/manager_test.go
+++ b/plugins/ptp_operator/metrics/manager_test.go
@@ -10,6 +10,7 @@ import (
 
 	"sync"
 
+	"github.com/redhat-cne/cloud-event-proxy/pkg/common"
 	ptpConfig "github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/config"
 	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/metrics"
 	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/stats"
@@ -127,13 +128,13 @@ func TestPTPEventManager_GenPTPEvent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.oStats.SetLastSyncState(tt.lastClockState)
-			p := &metrics.PTPEventManager{
-				PtpConfigMapUpdates: &ptpConfig.LinuxPTPConfigMapUpdate{
-					EventThreshold: map[string]*ptpConfig.PtpClockThreshold{
-						tt.ptpProfileName: {
-							MaxOffsetThreshold: 500,
-							MinOffsetThreshold: 10,
-						},
+			metrics.Filesystem = &metrics.MockFileSystem{}
+			p := metrics.NewPTPEventManager("", nil, "testnode", &common.SCConfiguration{StorePath: "/tmp/store"})
+			p.PtpConfigMapUpdates = &ptpConfig.LinuxPTPConfigMapUpdate{
+				EventThreshold: map[string]*ptpConfig.PtpClockThreshold{
+					tt.ptpProfileName: {
+						MaxOffsetThreshold: 500,
+						MinOffsetThreshold: 10,
 					},
 				},
 			}
@@ -153,14 +154,13 @@ func TestPTPEventManager_GenPTPEvent(t *testing.T) {
 
 func TestConcurrentMapAccess(t *testing.T) {
 	// Initialize the PTPEventManager with a map and a mutex
-	manager := &metrics.PTPEventManager{
-		Stats: map[types.ConfigName]stats.PTPStats{},
-		PtpConfigMapUpdates: &ptpConfig.LinuxPTPConfigMapUpdate{
-			EventThreshold: map[string]*ptpConfig.PtpClockThreshold{
-				"ptofile": {
-					MaxOffsetThreshold: 500,
-					MinOffsetThreshold: 10,
-				},
+	metrics.Filesystem = &metrics.MockFileSystem{}
+	manager := metrics.NewPTPEventManager("", nil, "testnode", &common.SCConfiguration{StorePath: "/tmp/store"})
+	manager.PtpConfigMapUpdates = &ptpConfig.LinuxPTPConfigMapUpdate{
+		EventThreshold: map[string]*ptpConfig.PtpClockThreshold{
+			"ptofile": {
+				MaxOffsetThreshold: 500,
+				MinOffsetThreshold: 10,
 			},
 		},
 	}

--- a/plugins/ptp_operator/metrics/metrics.go
+++ b/plugins/ptp_operator/metrics/metrics.go
@@ -130,7 +130,7 @@ func (p *PTPEventManager) ExtractMetrics(msg string) {
 	}
 	// if process is down fire an event
 	if strings.Contains(output, ptpProcessStatusIdentifier) {
-		if status, e := parsePTPStatus(output, fields); e == nil {
+		if status, e := p.parsePTPStatus(output, fields); e == nil {
 			if status == PtpProcessDown {
 				p.processDownEvent(profileName, processName, ptpStats)
 			}

--- a/plugins/ptp_operator/metrics/ptp4lParse.go
+++ b/plugins/ptp_operator/metrics/ptp4lParse.go
@@ -74,8 +74,8 @@ func (p *PTPEventManager) ParsePTP4l(processName, configName, profileName, outpu
 
 		if lastRole != role {
 			/*
-			   If role changes from FAULTY to SLAVE/PASSIVE/MASTER , then cancel HOLDOVER timer
-			    and publish metrics
+				If role changes from FAULTY to SLAVE/PASSIVE/MASTER , then cancel HOLDOVER timer
+					and publish metrics
 			*/
 			/* with ts2phc enabled , when ptp4l reports port goes to faulty
 			there is no HOLDOVER State
@@ -95,6 +95,10 @@ func (p *PTPEventManager) ParsePTP4l(processName, configName, profileName, outpu
 			}
 			log.Infof("update interface %s with portid %d from role %s to role %s  out %s", ptpIFace, portID, lastRole, role, output)
 			ptp4lCfg.Interfaces[portID-1].UpdateRole(role)
+			err = p.saveToStore()
+			if err != nil {
+				log.Errorf("failed to save metrics to store: %s", err)
+			}
 
 			// update role metrics
 			UpdateInterfaceRoleMetrics(processName, ptpIFace, role)

--- a/plugins/ptp_operator/ptp_operator_plugin.go
+++ b/plugins/ptp_operator/ptp_operator_plugin.go
@@ -102,6 +102,15 @@ func Start(wg *sync.WaitGroup, configuration *common.SCConfiguration, _ func(e i
 
 	// Initialize the Event Manager
 	eventManager = ptpMetrics.NewPTPEventManager(resourcePrefix, publishers, nodeName, config)
+	_, err = eventManager.LoadFromStore(config)
+	if err != nil {
+		log.Warn(err)
+	}
+	err = eventManager.TriggerLogs()
+	if err != nil {
+		log.Warn(err)
+	}
+	eventManager.SetInitalMetrics()
 	wg.Add(1)
 	// create socket listener
 	go listenToSocket(wg)


### PR DESCRIPTION
Saves data to file so it survives a crash
Then triggers logs to see if state changed during crash to starting back up.

Depends on: https://github.com/k8snetworkplumbingwg/linuxptp-daemon/pull/80
  