### PR TITLE
[4. 19 ]  OCPBUGS-61053: When Locking PTP Source, Incorrect Clock Class Reported via REST API 

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -5,14 +5,14 @@ package main
 
 import (
 	"fmt"
-	"os"
-	"k8s.io/utils/pointer"
 	v2 "github.com/cloudevents/sdk-go/v2"
+	"k8s.io/utils/pointer"
+	"os"
 
 	"github.com/redhat-cne/cloud-event-proxy/pkg/common"
+	ceEvent "github.com/redhat-cne/sdk-go/pkg/event"
 	"github.com/redhat-cne/sdk-go/pkg/event/ptp"
 	"github.com/redhat-cne/sdk-go/pkg/types"
-	ceEvent "github.com/redhat-cne/sdk-go/pkg/event"
 
 	"sync"
 	"testing"
@@ -43,14 +43,14 @@ func TestSidecar_Main(t *testing.T) {
 		storePath = sPath
 	}
 	scConfig = &common.SCConfiguration{
-		EventInCh:  make(chan *channel.DataChan, channelBufferSize),
-		EventOutCh: make(chan *channel.DataChan, channelBufferSize),
-		CloseCh:    make(chan struct{}),
-		APIPort:    apiPort,
-		APIPath:    "/api/ocloudNotifications/v2/",
-		PubSubAPI:  v1pubsub.GetAPIInstance(storePath),
+		EventInCh:     make(chan *channel.DataChan, channelBufferSize),
+		EventOutCh:    make(chan *channel.DataChan, channelBufferSize),
+		CloseCh:       make(chan struct{}),
+		APIPort:       apiPort,
+		APIPath:       "/api/ocloudNotifications/v2/",
+		PubSubAPI:     v1pubsub.GetAPIInstance(storePath),
 		SubscriberAPI: subscriberApi.GetAPIInstance(storePath),
-		StorePath:  storePath,
+		StorePath:     storePath,
 		TransportHost: &common.TransportHost{
 			Type: common.HTTP,
 			URL:  "localhost:8089",

--- a/pkg/plugins/handler_test.go
+++ b/pkg/plugins/handler_test.go
@@ -45,15 +45,15 @@ func init() {
 	}
 
 	scConfig = &common.SCConfiguration{
-		EventInCh:  make(chan *channel.DataChan, channelBufferSize),
-		EventOutCh: make(chan *channel.DataChan, channelBufferSize),
-		CloseCh:    make(chan struct{}),
-		APIPort:    8989,
-		APIPath:    "/api/cne/",
-		PubSubAPI:  v1pubsub.GetAPIInstance("../.."),
+		EventInCh:     make(chan *channel.DataChan, channelBufferSize),
+		EventOutCh:    make(chan *channel.DataChan, channelBufferSize),
+		CloseCh:       make(chan struct{}),
+		APIPort:       8989,
+		APIPath:       "/api/cne/",
+		PubSubAPI:     v1pubsub.GetAPIInstance("../.."),
 		SubscriberAPI: subscriberApi.GetAPIInstance(storePath),
-		StorePath:  storePath,
-		BaseURL:    nil,
+		StorePath:     storePath,
+		BaseURL:       nil,
 		TransportHost: &common.TransportHost{
 			Type: 0,
 			URL:  "",

--- a/plugins/ptp_operator/metrics/metrics_test.go
+++ b/plugins/ptp_operator/metrics/metrics_test.go
@@ -170,7 +170,7 @@ func (tc *TestCase) cleanupMetrics() {
 	metrics.PtpDelay.With(map[string]string{"from": tc.from, "process": tc.process, "node": tc.node, "iface": tc.iface}).Set(CLEANUP)
 	metrics.SyncState.With(map[string]string{"process": tc.process, "node": tc.node, "iface": tc.iface}).Set(CLEANUP)
 	metrics.NmeaStatus.With(map[string]string{"process": tc.process, "node": tc.node, "iface": tc.iface}).Set(CLEANUP)
-	metrics.ClockClassMetrics.With(map[string]string{"process": tc.process, "node": tc.node}).Set(CLEANUP)
+	metrics.ClockClassMetrics.With(map[string]string{"process": tc.process, "config": "ptp4l.0.config", "node": tc.node}).Set(CLEANUP)
 	metrics.InterfaceRole.With(map[string]string{"process": tc.process, "node": tc.node, "iface": tc.iface}).Set(CLEANUP)
 	ptpEventManager.ResetMockEvent()
 }
@@ -500,7 +500,7 @@ func Test_ExtractMetrics(t *testing.T) {
 			assert.Equal(tc.expectedNmeaStatus, testutil.ToFloat64(nmeaStatus), "NmeaStatus does not match\n%s", tc.String())
 		}
 		if tc.expectedClockClassMetricsCheck {
-			clockClassMetrics := metrics.ClockClassMetrics.With(map[string]string{"process": tc.process, "node": tc.node})
+			clockClassMetrics := metrics.ClockClassMetrics.With(map[string]string{"process": tc.process, "config": "ptp4l.0.config", "node": tc.node})
 			assert.Equal(tc.expectedClockClassMetrics, testutil.ToFloat64(clockClassMetrics), "ClockClassMetrics does not match\n%s", tc.String())
 		}
 		assert.Equal(tc.expectedEvent, ptpEventManager.GetMockEvent(), "Expected Event does not match\n%s", tc.String())

--- a/plugins/ptp_operator/metrics/registry.go
+++ b/plugins/ptp_operator/metrics/registry.go
@@ -94,7 +94,7 @@ var (
 			Subsystem: ptpSubsystem,
 			Name:      "clock_class",
 			Help:      "6 = Locked, 7 = PRC unlocked in-spec, 52/187 = PRC unlocked out-of-spec, 248 = Default, 255 = Slave Only Clock",
-		}, []string{"process", "node"})
+		}, []string{"process", "config", "node"})
 
 	// ProcessStatus  ... update process status
 	ProcessStatus = prometheus.NewGaugeVec(

--- a/plugins/ptp_operator/ptp_operator_plugin.go
+++ b/plugins/ptp_operator/ptp_operator_plugin.go
@@ -573,7 +573,7 @@ func processPtp4lConfigFileUpdates() {
 							}
 							if ptpMetrics.ClockClassMetrics != nil {
 								ptpMetrics.ClockClassMetrics.Delete(prometheus.Labels{
-									"process": ptp4lProcessName, "node": eventManager.NodeName()})
+									"process": ptp4lProcessName, "config": string(ptpConfigFileName), "node": eventManager.NodeName()})
 							}
 							ptpMetrics.DeletedPTPMetrics(MasterClockType, ts2PhcProcessName, p.Alias())
 							p.DeleteAllMetrics([]*prometheus.GaugeVec{ptpMetrics.PtpOffset, ptpMetrics.SyncState})


### PR DESCRIPTION
Update clock class metrics to identify clock class by ptp config .
This PR depends on https://issues.redhat.com/browse/OCPBUGS-61053

also includes  fixes from make fmt run 