### PR TITLE
OCPBUGS-61367: Remove sidecar log is spamming IsHAProfile messages [release-4.19]

### DIFF
--- a/plugins/ptp_operator/metrics/manager.go
+++ b/plugins/ptp_operator/metrics/manager.go
@@ -521,10 +521,8 @@ func (p *PTPEventManager) PrintStats() string {
 
 // IsHAProfile ... if profile for ha found pass
 func (p *PTPEventManager) IsHAProfile(name string) bool {
-	// Check if this profile is the HA profile (the one containing haProfiles setting)
-	isHA := p.PtpConfigMapUpdates.HAProfile == name
-	log.Debugf("IsHAProfile: profile=%s, HAProfile=%s, isHA=%t", name, p.PtpConfigMapUpdates.HAProfile, isHA)
-	return isHA
+	// Check if PtpSettings exist, if so proceed with confidence
+	return p.PtpConfigMapUpdates.HAProfile == name
 }
 
 // HAProfiles ... if profile for ha found pass the settings


### PR DESCRIPTION
removed spamming  of logs that is found only in 4.19 
ime="2025-09-08T16:19:08Z" level=debug msg="IsHAProfile: profile=boundary-ha, HAProfile=boundary-ha, isHA=true"
time="2025-09-08T16:19:08Z" level=debug msg="IsHAProfile: profile=boundary-ha, HAProfile=boundary-ha, isHA=true"
time="2025-09-08T16:19:08Z" level=debug msg="IsHAProfile: profile=boundary-ha, HAProfile=boundary-ha, isHA=true"
time="2025-09-08T16:19:08Z" level=debug msg="IsHAProfile: profile=boundary-ha, HAProfile=boundary-ha, isHA=true"
time="2025-09-08T16:19:08Z" level=debug msg="IsHAProfile: profile=boundary-ha, HAProfile=boundary-ha, isHA=true"
time="2025-09-08T16:19:08Z" level=debug msg="IsHAProfile: profile=boundary-ha, HAProfile=boundary-ha, isHA=true"
time="2025-09-08T16:19:08Z" level=debug msg="IsHAProfile: profile=boundary-ha, HAProfile=boundary-ha, isHA=true"
time="2025-09-08T16:19:08Z" level=debug msg="IsHAProfile: profile=boundary-ha, HAProfile=boundary-ha, isHA=true"