### PR TITLE
OCPBUGS-61703 : Fix T-BC ts2phc upstream interface metric

### DIFF
--- a/plugins/ptp_operator/metrics/logparser.go
+++ b/plugins/ptp_operator/metrics/logparser.go
@@ -472,6 +472,12 @@ func (p *PTPEventManager) ParseTBCLogs(processName, configName, output string, f
 		ptpStats[masterType].SetLastSyncState(clockState.State)
 		p.PublishEvent(clockState.State, lastOffset, masterResource, ptp.PtpStateChange)
 		UpdateSyncStateMetrics(processName, alias, ptpStats[masterType].LastSyncState())
+
+		// Impose T-BC state onto the ts2phc process state for the upstream interface
+		// This is needed because ts2phc doesn't update the upstream interface
+		// when ptp4l updates it in the T-BC mode
+		UpdateSyncStateMetrics(ts2phcProcessName, alias, ptpStats[masterType].LastSyncState())
+
 		UpdatePTPOffsetMetrics(processName, processName, alias, float64(lastOffset))
 		// if there is phc2sys ooptions enabled then when the clock is FREERUN annouce OSCLOCK as FREERUN
 		if clockState.State == ptp.FREERUN {

--- a/plugins/ptp_operator/ptp_operator_plugin.go
+++ b/plugins/ptp_operator/ptp_operator_plugin.go
@@ -544,6 +544,12 @@ func processPtp4lConfigFileUpdates() {
 					ptpMetrics.DeletePTPHAMetrics(ptpConfig.Profile)
 					for _, ptpInterface := range ptpConfig.Interfaces {
 						ptpMetrics.DeleteInterfaceRoleMetrics(ptp4lProcessName, ptpInterface.Name)
+						// Clean up ts2phc sync state metrics for T-BC profiles
+						// These metrics are created by T-BC state synchronization logic
+						if eventManager.GetProfileType(ptpConfig.Profile) == ptp4lconf.TBC {
+							ptpMetrics.SyncState.Delete(prometheus.Labels{
+								"process": ts2PhcProcessName, "node": eventManager.NodeName(), "iface": ptpInterface.Name})
+						}
 					}
 					if t, ok2 := eventManager.PtpConfigMapUpdates.EventThreshold[ptpConfig.Profile]; ok2 {
 						// Make sure that the function does close the channel


### PR DESCRIPTION
This commit fixes a bug in ts2phc state metric in the T-BC use case. The ts2phc metric for the upstream interface was missing after the pod start, or stuck on 0 after a configuration change and daemon restart. This was caused by the fact that ts2phc in the T-BC use case does not log clock updates when ptp4l updates the same clock. The solution is to impose the leading PHC state (derived from the overall T-BC state) onto the ts2phc metric for the same PHC

/cc @aneeshkp @jzding @nocturnalastro @josephdrichard 