### PR TITLE
basic support for chronyd

### DIFF
--- a/plugins/ptp_operator/config/config.go
+++ b/plugins/ptp_operator/config/config.go
@@ -59,8 +59,10 @@ type PtpProfile struct {
 	Ptp4lOpts         *string            `json:"ptp4lOpts,omitempty"`
 	Phc2sysOpts       *string            `json:"phc2sysOpts,omitempty"`
 	TS2PhcOpts        *string            `json:"ts2PhcOpts,omitempty"`
+	ChronydOpts       *string            `json:"chronydOpts,omitempty"`
 	Ptp4lConf         *string            `json:"ptp4lConf,omitempty"`
 	TS2PhcConf        *string            `json:"ts2PhcConf,omitempty"`
+	ChronydConf       *string            `json:"chronydConf,omitempty"`
 	PtpSettings       map[string]string  `json:"ptpSettings,omitempty"`
 	Interfaces        []*string
 }
@@ -85,6 +87,8 @@ type PtpProcessOpts struct {
 	Phc2Opts *string `json:"Phc2Opts,omitempty"`
 	// TS2PhcOpts
 	TS2PhcOpts *string `json:"TS2PhcOpts,omitempty"`
+	// ChronydOpts
+	ChronydOpts *string `json:"ChronydOpts,omitempty"`
 	// SyncE4lOpts
 	SyncE4lOpts *string `json:"SyncE4lOpts,omitempty"`
 }
@@ -107,6 +111,11 @@ func (ptpOpts *PtpProcessOpts) Phc2SysEnabled() bool {
 // TS2PhcEnabled check if ts2phc is enabled
 func (ptpOpts *PtpProcessOpts) TS2PhcEnabled() bool {
 	return ptpOpts.TS2PhcOpts != nil && *ptpOpts.TS2PhcOpts != ""
+}
+
+// ChronydEnabled check if chronyd is enabled
+func (ptpOpts *PtpProcessOpts) ChronydEnabled() bool {
+	return ptpOpts.ChronydOpts != nil && *ptpOpts.ChronydOpts != ""
 }
 
 // GetPTPProfileName  ... get profile name from ptpconfig

--- a/plugins/ptp_operator/metrics/logparser.go
+++ b/plugins/ptp_operator/metrics/logparser.go
@@ -156,16 +156,22 @@ func extractRegularMetrics(processName, output string) (interfaceName string, pt
 	ptpOffset, err := strconv.ParseFloat(fields[3], 64)
 	if err != nil {
 		log.Errorf("%s failed to parse offset from master output %s error %v", processName, fields[3], err)
+		interfaceName = "" // skip line
+		return
 	}
 
 	maxPtpOffset, err = strconv.ParseFloat(fields[3], 64)
 	if err != nil {
 		log.Errorf("%s failed to parse max offset from master output %s error %v", processName, fields[3], err)
+		interfaceName = "" // skip line
+		return
 	}
 
 	frequencyAdjustment, err = strconv.ParseFloat(fields[6], 64)
 	if err != nil {
 		log.Errorf("%s failed to parse frequency adjustment output %s error %v", processName, fields[6], err)
+		interfaceName = "" // skip line
+		return
 	}
 
 	state := fields[4]
@@ -179,13 +185,15 @@ func extractRegularMetrics(processName, output string) (interfaceName string, pt
 		clockState = ptp.LOCKED
 	default:
 		log.Errorf("%s -  failed to parse clock state output `%s` ", processName, fields[4])
+		interfaceName = "" // skip line
+		return
 	}
 
 	//   0                1     2           3    4       5        6    7
 	// ts2phc.0.config  ens7f0 offset       1    s3    freq      +1 holdover
 	if len(fields) >= 8 && processName == ts2phcProcessName && fields[7] == "holdover" {
 		clockState = ptp.HOLDOVER
-	} else if len(fields) >= 8 { // anything new we ignor
+	} else if len(fields) >= 8 { // anything new we ignore
 		delay, err = strconv.ParseFloat(fields[8], 64)
 		if err != nil {
 			log.Errorf("%s failed to parse delay from master output %s error %v", processName, fields[8], err)

--- a/plugins/ptp_operator/ptp4lconf/ptp4lConfig.go
+++ b/plugins/ptp_operator/ptp4lconf/ptp4lConfig.go
@@ -32,6 +32,7 @@ var (
 	ptpConfigFileRegEx        = regexp.MustCompile(`ptp4l.[0-9]*.config`)
 	ptpPhc2sysConfigFileRegEx = regexp.MustCompile(`phc2sys.[0-9]*.config`)
 	ptpSyncE4lConfigFileRegEx = regexp.MustCompile(`synce4l.[0-9]*.config`)
+	ptpChronydConfigFileRegEx = regexp.MustCompile(`chronyd.[0-9]*.config`)
 	sectionHead               = regexp.MustCompile(`\[([^\[\]]*)\]`)
 	profileRegEx              = regexp.MustCompile(`profile: \s*([\w-_]+)`)
 	fileNameRegEx             = regexp.MustCompile("([^/]+$)")
@@ -247,14 +248,14 @@ func NewPtp4lConfigWatcher(dirToWatch string, updatedConfig chan<- *PtpConfigUpd
 					continue
 				}
 				if event.Op&fsnotify.Write == fsnotify.Write {
-					if checkIfPtP4lConf(event.Name) || checkIfPhc2SysConf(event.Name) || checkIfSyncE4lConf(event.Name) {
+					if checkIfPtP4lConf(event.Name) || checkIfPhc2SysConf(event.Name) || checkIfSyncE4lConf(event.Name) || checkIfChronydConf(event.Name) {
 						if ptpConfig, configErr := readConfig(event.Name); configErr == nil {
 							log.Infof("sending ptpconfig changes for %s", *ptpConfig.Name)
 							updatedConfig <- ptpConfig
 						}
 					}
 				} else if event.Op&fsnotify.Remove == fsnotify.Remove {
-					if checkIfPtP4lConf(event.Name) || checkIfPhc2SysConf(event.Name) || checkIfSyncE4lConf(event.Name) {
+					if checkIfPtP4lConf(event.Name) || checkIfPhc2SysConf(event.Name) || checkIfSyncE4lConf(event.Name) || checkIfChronydConf(event.Name) {
 						fName := filename(event.Name)
 						ptpConfig := &PtpConfigUpdate{
 							Name:      &fName,
@@ -285,7 +286,7 @@ func readAllConfig(dir string) []*PtpConfigUpdate {
 		log.Errorf("error reading all config fils %s", fileErr)
 	}
 	for _, file := range files {
-		if checkIfPtP4lConf(file.Name()) || checkIfPhc2SysConf(file.Name()) || checkIfSyncE4lConf(file.Name()) {
+		if checkIfPtP4lConf(file.Name()) || checkIfPhc2SysConf(file.Name()) || checkIfSyncE4lConf(file.Name()) || checkIfChronydConf(file.Name()) {
 			if p, err := readConfig(filepath.Join(dir, file.Name())); err == nil {
 				ptpConfigs = append(ptpConfigs, p)
 			}
@@ -327,6 +328,10 @@ func checkIfPhc2SysConf(filename string) bool {
 }
 func checkIfSyncE4lConf(filename string) bool {
 	return ptpSyncE4lConfigFileRegEx.MatchString(filename)
+}
+
+func checkIfChronydConf(filename string) bool {
+	return ptpChronydConfigFileRegEx.MatchString(filename)
 }
 
 // GetPTPProfileName  ... get profile name from ptpconfig

--- a/plugins/ptp_operator/ptp_operator_plugin.go
+++ b/plugins/ptp_operator/ptp_operator_plugin.go
@@ -53,6 +53,7 @@ const (
 	phc2sysProcessName = "phc2sys"
 	ptp4lProcessName   = "ptp4l"
 	ts2PhcProcessName  = "ts2phc"
+	chronydProcessName = "chronyd"
 	gnssProcessName    = "gnss"
 	syncE4lProcessName = "synce4l"
 	// ClockRealTime is the slave
@@ -512,6 +513,11 @@ func processPtp4lConfigFileUpdates() {
 						ptpMetrics.DeleteProcessStatusMetricsForConfig(eventManager.NodeName(),
 							strings.Replace(cName, ptp4lProcessName, ts2PhcProcessName, 1), ts2PhcProcessName)
 					}
+					// special chronyd due to different configName replace ptp4l.0.conf to chronyd.0.cnf
+					if !opts.ChronydEnabled() {
+						ptpMetrics.DeleteProcessStatusMetricsForConfig(eventManager.NodeName(),
+							strings.Replace(cName, ptp4lProcessName, chronydProcessName, 1), chronydProcessName)
+					}
 				}
 				for key, np := range eventManager.PtpConfigMapUpdates.EventThreshold {
 					ptpMetrics.Threshold.With(prometheus.Labels{
@@ -607,6 +613,7 @@ func processPtp4lConfigFileUpdates() {
 				// clean up process metrics
 				ptpMetrics.DeleteProcessStatusMetricsForConfig(eventManager.NodeName(), string(ptpConfigFileName), ptp4lProcessName, phc2sysProcessName, syncE4lProcessName)
 				ptpMetrics.DeleteProcessStatusMetricsForConfig(eventManager.NodeName(), strings.Replace(string(ptpConfigFileName), ptp4lProcessName, ts2PhcProcessName, 1), ts2PhcProcessName)
+				ptpMetrics.DeleteProcessStatusMetricsForConfig(eventManager.NodeName(), strings.Replace(string(ptpConfigFileName), ptp4lProcessName, chronydProcessName, 1), chronydProcessName)
 				fileModified <- true
 			}
 		case <-config.CloseCh:


### PR DESCRIPTION
Add support for setting OS clock sync state based on information from chronyd.  More specifically, when chronyd is controlling the OS clock, then the OS clock sync state should be reported as locked.