### PR TITLE
[release-4.20] OCPBUGS-77881: Fix clock class metrics not restored after sidecar restart

### DIFF
--- a/plugins/ptp_operator/metrics/manager.go
+++ b/plugins/ptp_operator/metrics/manager.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"fmt"
+	"net/http"
 	"path"
 	"strings"
 	"sync"
@@ -644,4 +645,17 @@ func OverallState(current, updated ptp.SyncState) ptp.SyncState {
 		log.Warnf("last sync state is unknown: %s", updated)
 	}
 	return ""
+}
+
+const logsEndpoint = "http://localhost:8081/emit-logs"
+
+// TriggerLogs makes an HTTP request to the linuxptp-daemon to re-emit
+// all metrics logs so that cloud-event-proxy can repopulate its state.
+func (p *PTPEventManager) TriggerLogs() error {
+	resp, err := http.Get(logsEndpoint) //nolint:gosec
+	if err != nil {
+		return fmt.Errorf("failed to trigger logs: %w", err)
+	}
+	defer resp.Body.Close()
+	return nil
 }

--- a/plugins/ptp_operator/ptp_operator_plugin.go
+++ b/plugins/ptp_operator/ptp_operator_plugin.go
@@ -104,7 +104,9 @@ func Start(wg *sync.WaitGroup, configuration *common.SCConfiguration, _ func(e i
 	// Initialize the Event Manager
 	eventManager = ptpMetrics.NewPTPEventManager(resourcePrefix, publishers, nodeName, config)
 	wg.Add(1)
-	// create socket listener
+	// create socket listener; the daemon sends log lines and CMD RESTART commands here.
+	// When a new connection is accepted, processMessages calls TriggerLogs() to request
+	// the daemon to re-emit all metrics logs.
 	go listenToSocket(wg)
 	// watch for ptp any config updates
 	go eventManager.PtpConfigMapUpdates.WatchConfigMapUpdate(nodeName, configuration.CloseCh, false)
@@ -658,6 +660,13 @@ func listenToSocket(wg *sync.WaitGroup) {
 }
 
 func processMessages(c net.Conn) {
+	// A new socket connection means the daemon (re)connected.
+	// Request a full state re-emit so metrics are populated after restart.
+	if eventManager != nil {
+		if err := eventManager.TriggerLogs(); err != nil {
+			log.Warnf("failed to trigger logs on new connection: %v", err)
+		}
+	}
 	scanner := bufio.NewScanner(c)
 	for {
 		ok := scanner.Scan()


### PR DESCRIPTION
This is a backport from https://github.com/redhat-cne/cloud-event-proxy/pull/657

When cloud-event-proxy restarts, TriggerLogs() was called before the socket listener was started, so the linuxptp-daemon had nowhere to reconnect when re-emitting metrics. Remove the startup TriggerLogs() call and instead trigger logs in processMessages() when a new socket connection is accepted, which handles both initial startup and reconnection scenarios.