### PR TITLE
OCPBUGS-83551: Fix tbc startup ordering

### DIFF
--- a/plugins/ptp_operator/config/config.go
+++ b/plugins/ptp_operator/config/config.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	"github.com/redhat-cne/cloud-event-proxy/pkg/common"
+	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/filesystem"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -434,7 +435,7 @@ func (l *LinuxPTPConfigMapUpdate) PushPtpConfigMapChanges(nodeName string) {
 
 func (l *LinuxPTPConfigMapUpdate) updatePtpConfig(nodeName string) (updated bool) {
 	nodeProfile := filepath.Join(l.profilePath, nodeName)
-	if _, err := os.Stat(nodeProfile); err != nil {
+	if _, err := filesystem.Stat(nodeProfile); err != nil {
 		if os.IsNotExist(err) {
 			log.Infof("ptp profile %s doesn't exist for node: %v , error %s", nodeProfile, nodeName, err.Error())
 			l.UpdateCh <- true // if profile doesn't exist let the caller know
@@ -448,7 +449,7 @@ func (l *LinuxPTPConfigMapUpdate) updatePtpConfig(nodeName string) (updated bool
 		log.Errorf("reading nodeProfile %s from unknon path ", nodeProfile)
 		return
 	}
-	nodeProfilesJSON, err := os.ReadFile(nodeProfile)
+	nodeProfilesJSON, err := filesystem.ReadFile(nodeProfile)
 	if err != nil {
 		log.Errorf("error reading node profile: %v", nodeProfile)
 		return

--- a/plugins/ptp_operator/config/config.go
+++ b/plugins/ptp_operator/config/config.go
@@ -77,7 +77,7 @@ type PtpClockThreshold struct {
 	// min offset in nano secs
 	MinOffsetThreshold int64 `json:"minOffsetThreshold,omitempty"`
 	// Close  any  previous holdover
-	Close chan struct{} `json:"close,omitempty"`
+	Close chan struct{} `json:"-"`
 }
 
 // PtpProcessOpts ... prp process options

--- a/plugins/ptp_operator/filesystem/filesystem.go
+++ b/plugins/ptp_operator/filesystem/filesystem.go
@@ -1,0 +1,34 @@
+package filesystem
+
+import (
+	"os"
+)
+
+// FileSystemInterface defines the interface for filesystem operations to enable mocking.
+// Modeled after linuxptp-daemon's addons/intel/common.go FileSystemInterface.
+type FileSystemInterface interface {
+	Stat(name string) (os.FileInfo, error)
+	ReadDir(dirname string) ([]os.DirEntry, error)
+	ReadFile(filename string) ([]byte, error)
+}
+
+// RealFileSystem implements FileSystemInterface using real OS operations
+type RealFileSystem struct{}
+
+func (fs *RealFileSystem) Stat(name string) (os.FileInfo, error) {
+	return os.Stat(name)
+}
+
+func (fs *RealFileSystem) ReadDir(dirname string) ([]os.DirEntry, error) {
+	return os.ReadDir(dirname)
+}
+
+func (fs *RealFileSystem) ReadFile(filename string) ([]byte, error) {
+	return os.ReadFile(filename)
+}
+
+var impl FileSystemInterface = &RealFileSystem{}
+
+func Stat(name string) (os.FileInfo, error)         { return impl.Stat(name) }
+func ReadDir(dirname string) ([]os.DirEntry, error) { return impl.ReadDir(dirname) }
+func ReadFile(filename string) ([]byte, error)      { return impl.ReadFile(filename) }

--- a/plugins/ptp_operator/filesystem/mock.go
+++ b/plugins/ptp_operator/filesystem/mock.go
@@ -1,0 +1,174 @@
+package filesystem
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// MockFileSystem is a mock implementation of FileSystemInterface for testing.
+// Modeled after linuxptp-daemon's addons/intel/mock_test.go MockFileSystem.
+type MockFileSystem struct {
+	statCalls     []StatCall
+	readDirCalls  []ReadDirCall
+	readFileCalls []ReadFileCall
+
+	currentStat     int
+	currentReadDir  int
+	currentReadFile int
+
+	allowedStat     map[string]StatCall
+	allowedReadDir  map[string]ReadDirCall
+	allowedReadFile map[string]ReadFileCall
+}
+
+// SetupMockFS swaps the global filesystem implementation with a mock and returns a cleanup function.
+func SetupMockFS() (*MockFileSystem, func()) {
+	original := impl
+	mock := &MockFileSystem{}
+	impl = mock
+	return mock, func() { impl = original }
+}
+
+// StatCall represents an expected or allowed Stat call
+type StatCall struct {
+	ExpectedPath string
+	ReturnInfo   os.FileInfo
+	ReturnError  error
+}
+
+// ReadDirCall represents an expected or allowed ReadDir call
+type ReadDirCall struct {
+	ExpectedPath string
+	ReturnDirs   []os.DirEntry
+	ReturnError  error
+}
+
+// ReadFileCall represents an expected or allowed ReadFile call
+type ReadFileCall struct {
+	ExpectedPath string
+	ReturnData   []byte
+	ReturnError  error
+}
+
+func (m *MockFileSystem) ExpectStat(path string, info os.FileInfo, err error) {
+	m.statCalls = append(m.statCalls, StatCall{
+		ExpectedPath: path,
+		ReturnInfo:   info,
+		ReturnError:  err,
+	})
+}
+
+func (m *MockFileSystem) AllowStat(path string, info os.FileInfo, err error) {
+	if m.allowedStat == nil {
+		m.allowedStat = make(map[string]StatCall)
+	}
+	m.allowedStat[path] = StatCall{
+		ExpectedPath: path,
+		ReturnInfo:   info,
+		ReturnError:  err,
+	}
+}
+
+func (m *MockFileSystem) ExpectReadDir(path string, dirs []os.DirEntry, err error) {
+	m.readDirCalls = append(m.readDirCalls, ReadDirCall{
+		ExpectedPath: path,
+		ReturnDirs:   dirs,
+		ReturnError:  err,
+	})
+}
+
+func (m *MockFileSystem) AllowReadDir(path string, dirs []os.DirEntry, err error) {
+	if m.allowedReadDir == nil {
+		m.allowedReadDir = make(map[string]ReadDirCall)
+	}
+	m.allowedReadDir[path] = ReadDirCall{
+		ExpectedPath: path,
+		ReturnDirs:   dirs,
+		ReturnError:  err,
+	}
+}
+
+func (m *MockFileSystem) ExpectReadFile(path string, data []byte, err error) {
+	m.readFileCalls = append(m.readFileCalls, ReadFileCall{
+		ExpectedPath: path,
+		ReturnData:   data,
+		ReturnError:  err,
+	})
+}
+
+func (m *MockFileSystem) AllowReadFile(path string, data []byte, err error) {
+	if m.allowedReadFile == nil {
+		m.allowedReadFile = make(map[string]ReadFileCall)
+	}
+	m.allowedReadFile[path] = ReadFileCall{
+		ExpectedPath: path,
+		ReturnData:   data,
+		ReturnError:  err,
+	}
+}
+
+func (m *MockFileSystem) Stat(name string) (os.FileInfo, error) {
+	if allowed, ok := m.allowedStat[name]; ok {
+		return allowed.ReturnInfo, allowed.ReturnError
+	}
+	if m.currentStat >= len(m.statCalls) {
+		return nil, fmt.Errorf("unexpected Stat call (%s)", name)
+	}
+	call := m.statCalls[m.currentStat]
+	m.currentStat++
+	if call.ExpectedPath != "" && call.ExpectedPath != name {
+		return nil, fmt.Errorf("Stat called with unexpected path (%s), was expecting %s", name, call.ExpectedPath)
+	}
+	return call.ReturnInfo, call.ReturnError
+}
+
+func (m *MockFileSystem) ReadDir(dirname string) ([]os.DirEntry, error) {
+	if allowed, ok := m.allowedReadDir[dirname]; ok {
+		return allowed.ReturnDirs, allowed.ReturnError
+	}
+	if m.currentReadDir >= len(m.readDirCalls) {
+		return nil, fmt.Errorf("unexpected ReadDir call (%s)", dirname)
+	}
+	call := m.readDirCalls[m.currentReadDir]
+	m.currentReadDir++
+	if call.ExpectedPath != "" && call.ExpectedPath != dirname {
+		return nil, fmt.Errorf("ReadDir called with unexpected path (%s), was expecting %s", dirname, call.ExpectedPath)
+	}
+	return call.ReturnDirs, call.ReturnError
+}
+
+func (m *MockFileSystem) ReadFile(filename string) ([]byte, error) {
+	if allowed, ok := m.allowedReadFile[filename]; ok {
+		return allowed.ReturnData, allowed.ReturnError
+	}
+	if m.currentReadFile >= len(m.readFileCalls) {
+		return nil, fmt.Errorf("unexpected ReadFile call (%s)", filename)
+	}
+	call := m.readFileCalls[m.currentReadFile]
+	m.currentReadFile++
+	if call.ExpectedPath != "" && call.ExpectedPath != filename {
+		return nil, fmt.Errorf("ReadFile called with unexpected filename (%s), was expecting %s", filename, call.ExpectedPath)
+	}
+	return call.ReturnData, call.ReturnError
+}
+
+// VerifyAllCalls asserts that all expected calls were made
+func (m *MockFileSystem) VerifyAllCalls(t *testing.T) {
+	assert.Equal(t, len(m.statCalls), m.currentStat, "Not all expected Stat calls were made")
+	assert.Equal(t, len(m.readDirCalls), m.currentReadDir, "Not all expected ReadDir calls were made")
+	assert.Equal(t, len(m.readFileCalls), m.currentReadFile, "Not all expected ReadFile calls were made")
+}
+
+// MockDirEntry implements os.DirEntry for testing
+type MockDirEntry struct {
+	EntryName string
+	Dir       bool
+}
+
+func (m MockDirEntry) Name() string               { return m.EntryName }
+func (m MockDirEntry) IsDir() bool                { return m.Dir }
+func (m MockDirEntry) Type() os.FileMode          { return 0 }
+func (m MockDirEntry) Info() (os.FileInfo, error) { return nil, nil }

--- a/plugins/ptp_operator/metrics/manager.go
+++ b/plugins/ptp_operator/metrics/manager.go
@@ -615,6 +615,18 @@ func (p *PTPEventManager) GetProfileType(name string) ptp4lconf.PtpProfileType {
 	return ptp4lconf.NONE
 }
 
+// RefreshProfileTypes re-evaluates the cached ProfileType on all registered
+// PTP4lConfigs from the current TBCProfiles list. Call this after
+// UpdatePTPSetting() has populated TBCProfiles so that configs registered
+// before the configmap loaded get the correct ProfileType.
+func (p *PTPEventManager) RefreshProfileTypes() {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	for _, cfg := range p.Ptp4lConfigInterfaces {
+		cfg.ProfileType = p.GetProfileType(cfg.Profile)
+	}
+}
+
 func (p *PTPEventManager) ListHAProfilesWith(currentProfile string) (profile string, profiles []string) {
 	// Check if PtpSettings exist, if so proceed
 	currentProfile = strings.TrimSpace(currentProfile)

--- a/plugins/ptp_operator/ptp4lconf/ptp4lConfig.go
+++ b/plugins/ptp_operator/ptp4lconf/ptp4lConfig.go
@@ -17,13 +17,13 @@ package ptp4lconf
 import (
 	"bufio"
 	"fmt"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/alias"
+	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/filesystem"
 	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/types"
 	log "github.com/sirupsen/logrus"
 )
@@ -286,7 +286,7 @@ func NewPtp4lConfigWatcher(dirToWatch string, updatedConfig chan<- *PtpConfigUpd
 // ReadAllConfig reads all ptp4l, phc2sys, synce4l and chronyd config files from dir.
 func ReadAllConfig(dir string) []*PtpConfigUpdate {
 	var ptpConfigs []*PtpConfigUpdate
-	files, fileErr := os.ReadDir(dir)
+	files, fileErr := filesystem.ReadDir(dir)
 	if fileErr != nil {
 		log.Errorf("error reading all config fils %s", fileErr)
 	}
@@ -306,7 +306,7 @@ func readConfig(path string) (*PtpConfigUpdate, error) {
 		log.Errorf("reading ptpconfig %s from unknon path ", path)
 		return nil, fmt.Errorf("reading ptpconfig %s from unknon path ", path)
 	}
-	b, err := os.ReadFile(path)
+	b, err := filesystem.ReadFile(path)
 	if err != nil {
 		log.Errorf("error reading ptpconfig %s error %s", path, err)
 		return nil, err

--- a/plugins/ptp_operator/ptp_operator_plugin.go
+++ b/plugins/ptp_operator/ptp_operator_plugin.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"k8s.io/utils/pointer"
 
@@ -64,9 +65,10 @@ const (
 	// ClockRealTime is the slave
 	ClockRealTime = "CLOCK_REALTIME"
 	// MasterClockType is the slave sync slave clock to master
-	MasterClockType = "master"
-	EventNotFound   = "event-not-found"
-	PTPNotSet       = "ptp-not-set"
+	MasterClockType             = "master"
+	EventNotFound               = "event-not-found"
+	PTPNotSet                   = "ptp-not-set"
+	ptpConfigSyncInitialTimeout = 1 * time.Second
 )
 
 var (
@@ -177,6 +179,37 @@ func processConfigCreate(ptpConfigEvent *ptp4lconf.PtpConfigUpdate) {
 	ptpMetrics.SyncAliasesFromDaemon()
 }
 
+// startPtpConfigSync starts the configmap watcher and blocks until the first
+// update arrives or the timeout expires. This ensures TBCProfiles and
+// thresholds are populated before loadInitialPtp4lConfigs registers configs,
+// eliminating the race where ProfileType is cached as NONE because the
+// configmap hasn't been read yet.
+func startPtpConfigSync(timeout time.Duration, nodeName string, configuration *common.SCConfiguration) {
+	go eventManager.PtpConfigMapUpdates.WatchConfigMapUpdate(nodeName, configuration.CloseCh, false)
+	select {
+	case <-eventManager.PtpConfigMapUpdates.UpdateCh:
+		log.Infof("loading ptp profile config: %d profiles", len(eventManager.PtpConfigMapUpdates.NodeProfiles))
+		if len(eventManager.PtpConfigMapUpdates.NodeProfiles) > 0 {
+			eventManager.PtpConfigMapUpdates.UpdatePTPProcessOptions()
+			eventManager.PtpConfigMapUpdates.UpdatePTPThreshold()
+			eventManager.PtpConfigMapUpdates.UpdatePTPSetting()
+			eventManager.RefreshProfileTypes()
+			for key, np := range eventManager.PtpConfigMapUpdates.EventThreshold {
+				ptpMetrics.Threshold.With(prometheus.Labels{
+					"threshold": "MinOffsetThreshold", "node": nodeName, "profile": key}).Set(float64(np.MinOffsetThreshold))
+				ptpMetrics.Threshold.With(prometheus.Labels{
+					"threshold": "MaxOffsetThreshold", "node": nodeName, "profile": key}).Set(float64(np.MaxOffsetThreshold))
+				ptpMetrics.Threshold.With(prometheus.Labels{
+					"threshold": "HoldOverTimeout", "node": nodeName, "profile": key}).Set(float64(np.HoldOverTimeout))
+			}
+		}
+	case <-time.After(timeout):
+		log.Warnf("configmap not available after %s, proceeding without profile settings", timeout)
+	case <-config.CloseCh:
+		log.Info("shutdown signal received during configmap sync")
+	}
+}
+
 // Start ptp plugin to process events,metrics and status, expects rest api available to create publisher and subscriptions
 func Start(wg *sync.WaitGroup, configuration *common.SCConfiguration, _ func(e interface{}) error) error { //nolint:deadcode,unused
 	// The name of NodePtpDevice CR for this node is equal to the node name
@@ -216,40 +249,13 @@ func Start(wg *sync.WaitGroup, configuration *common.SCConfiguration, _ func(e i
 	// against an extablished linuxptp-daemon, which will have aliases already populated
 	// and log lines waiting in the buffer.
 	ptpMetrics.SyncAliasesFromDaemon()
+	startPtpConfigSync(ptpConfigSyncInitialTimeout, nodeName, configuration)
+	loadInitialPtp4lConfigs()
 	wg.Add(1)
 	// create socket listener; the daemon sends log lines and CMD RESTART commands here.
 	// When a new connection is accepted, processMessages calls TriggerLogs() to request
 	// the daemon to re-emit all metrics logs.
 	go listenToSocket(wg)
-	// read configmap once at startup to load thresholds, process options and settings
-	go eventManager.PtpConfigMapUpdates.WatchConfigMapUpdate(nodeName, configuration.CloseCh, false)
-	// read existing config files once at startup to register interface/role mappings;
-	// if no files exist yet the daemon will send CMD RESTART once configs are ready
-	loadInitialPtp4lConfigs()
-
-	// one-shot configmap handler: load thresholds/options on the first update then exit
-	go func() {
-		select {
-		case <-eventManager.PtpConfigMapUpdates.UpdateCh:
-			log.Infof("loading ptp profile config: %d profiles", len(eventManager.PtpConfigMapUpdates.NodeProfiles))
-			if len(eventManager.PtpConfigMapUpdates.NodeProfiles) > 0 {
-				eventManager.PtpConfigMapUpdates.UpdatePTPProcessOptions()
-				eventManager.PtpConfigMapUpdates.UpdatePTPThreshold()
-				eventManager.PtpConfigMapUpdates.UpdatePTPSetting()
-				for key, np := range eventManager.PtpConfigMapUpdates.EventThreshold {
-					ptpMetrics.Threshold.With(prometheus.Labels{
-						"threshold": "MinOffsetThreshold", "node": nodeName, "profile": key}).Set(float64(np.MinOffsetThreshold))
-					ptpMetrics.Threshold.With(prometheus.Labels{
-						"threshold": "MaxOffsetThreshold", "node": nodeName, "profile": key}).Set(float64(np.MaxOffsetThreshold))
-					ptpMetrics.Threshold.With(prometheus.Labels{
-						"threshold": "HoldOverTimeout", "node": nodeName, "profile": key}).Set(float64(np.HoldOverTimeout))
-				}
-			}
-			// exit after first load; ConfigMap changes trigger a daemon-sent CMD RESTART
-		case <-config.CloseCh:
-			return
-		}
-	}()
 
 	// 2.Create Status Listener
 	// method to be called when ping received

--- a/plugins/ptp_operator/ptp_operator_plugin_tbc_test.go
+++ b/plugins/ptp_operator/ptp_operator_plugin_tbc_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/redhat-cne/cloud-event-proxy/pkg/common"
+	ptpConfig "github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/config"
+	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/filesystem"
+	ptpMetrics "github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/metrics"
+	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/ptp4lconf"
+	"github.com/redhat-cne/sdk-go/pkg/event/ptp"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/pointer"
+)
+
+func TestTBCFixedStartupNoSpuriousFreerun(t *testing.T) {
+	mockFS, cleanup := filesystem.SetupMockFS()
+	defer cleanup()
+
+	profileName := "tsc-holdover"
+	cfgFileName := "ptp4l.0.config"
+	testNodeName := "test-node"
+	profilePath := "/etc/linuxptp"
+
+	ptp4lConfData := "# profile: " + profileName + "\n[global]\nslaveOnly 0\nboundary_clock_jbod 1\n[ens3f2]\nserverOnly 0\n"
+
+	profiles := []ptpConfig.PtpProfile{
+		{
+			Name:        pointer.String(profileName),
+			Interface:   pointer.String("ens3f2"),
+			Ptp4lOpts:   pointer.String("-2 -s --summary_interval -4"),
+			Phc2sysOpts: pointer.String("-r -n 24 -N 8 -R 16 -u 0 -m -s ens3f2"),
+			TS2PhcOpts:  pointer.String("-s generic -a --ts2phc.rh_external_pps 1"),
+			Ptp4lConf:   pointer.String(ptp4lConfData),
+			PtpSettings: map[string]string{},
+			PtpClockThreshold: &ptpConfig.PtpClockThreshold{
+				HoldOverTimeout:    5,
+				MaxOffsetThreshold: 100,
+				MinOffsetThreshold: -100,
+			},
+		},
+	}
+	profileJSON, err := json.Marshal(profiles)
+	assert.NoError(t, err)
+
+	// Mock the configmap profile file read by WatchConfigMapUpdate -> updatePtpConfig
+	configMapPath := profilePath + "/" + testNodeName
+	mockFS.AllowStat(configMapPath, nil, nil)
+	mockFS.AllowReadFile(configMapPath, profileJSON, nil)
+
+	// Mock the ptp4l config file listing and read by loadInitialPtp4lConfigs -> ReadAllConfig -> readConfig
+	mockFS.AllowReadDir(ptpConfigDir, []os.DirEntry{
+		filesystem.MockDirEntry{EntryName: cfgFileName, Dir: false},
+	}, nil)
+	mockFS.AllowReadFile("/var/run/"+cfgFileName, []byte(ptp4lConfData), nil)
+
+	// Set up environment for WatchConfigMapUpdate to use our profile path
+	originalPath := os.Getenv("PTP_PROFILE_PATH")
+	os.Setenv("PTP_PROFILE_PATH", profilePath)
+	defer os.Setenv("PTP_PROFILE_PATH", originalPath)
+
+	// Initialize eventManager the same way Start() does
+	publishers = InitPubSubTypes()
+	scConfig := &common.SCConfiguration{
+		StorePath: t.TempDir(),
+		CloseCh:   make(chan struct{}),
+	}
+	config = scConfig
+	eventManager = ptpMetrics.NewPTPEventManager(resourcePrefix, publishers, testNodeName, scConfig)
+	eventManager.MockTest(true)
+	ptpMetrics.RegisterMetrics(testNodeName)
+
+	// Phase 1: startPtpConfigSync — real code path: reads mocked configmap, populates TBCProfiles
+	startPtpConfigSync(2*time.Second, testNodeName, scConfig)
+
+	assert.Contains(t, eventManager.PtpConfigMapUpdates.TBCProfiles, profileName,
+		"TBCProfiles should contain the profile after configmap sync")
+
+	// Phase 2: loadInitialPtp4lConfigs — real code path: reads mocked config files,
+	// calls processConfigCreate which calls GetProfileType, should return TBC
+	loadInitialPtp4lConfigs()
+
+	storedCfg := eventManager.GetPTPConfig("ptp4l.0.config")
+	assert.Equal(t, ptp4lconf.TBC, storedCfg.ProfileType,
+		"ProfileType should be TBC because configmap was loaded before config registration")
+
+	// Phase 3: simulate buffered socket log lines — real code path via ExtractMetrics
+	bufferedLogs := []string{
+		"ptp4l[5196819.100]: [ptp4l.0.config] master offset -5 s2 freq +500 path delay 89",
+		"phc2sys[3263.065]: [ptp4l.0.config] CLOCK_REALTIME phc offset 3 s2 freq -20217 delay 536",
+	}
+	for _, line := range bufferedLogs {
+		eventManager.ExtractMetrics(line)
+	}
+
+	eventManager.ResetMockEvent()
+
+	// The critical event: SLAVE to FAULTY
+	ptp4lFaulty := "ptp4l[3263.061]: [ptp4l.0.config:5] port 1 (ens3f2): SLAVE to FAULTY on FAULT_DETECTED (FT_UNSPECIFIED)"
+	eventManager.ExtractMetrics(ptp4lFaulty)
+
+	mockEvents := eventManager.GetMockEvent()
+	for _, evt := range mockEvents {
+		assert.NotEqual(t, ptp.OsClockSyncStateChange, evt,
+			"No spurious OsClockSyncStateChange should be emitted because ProfileType=TBC was set correctly before log processing")
+	}
+}


### PR DESCRIPTION
This PR fixes a startup race condition in the cloud-event-proxy PTP plugin where T-BC (Transparent Boundary Clock) configs were registered with ProfileType=NONE because loadInitialPtp4lConfigs() ran before the configmap was loaded and TBCProfiles populated. This caused spurious OsClockSyncStateChange FREERUN events on SLAVE-to-FAULTY transitions.
  