### PR TITLE
Add automated coverage quality gate

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,0 +1,35 @@
+---
+name: "Coverage Quality Gate"
+on:
+  push:
+    paths-ignore:
+      - ".github/**"
+      - "docs/**"
+      - "examples/manifests/**"
+      - "**.md"
+  pull_request:
+    paths-ignore:
+      - ".github/**"
+      - "docs/**"
+      - "examples/manifests/**"
+      - "**.md"
+jobs:
+  coverage:
+    if: "!contains(github.event.pull_request.labels.*.name, 'skip-coverage')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - name: tidy
+        run: go mod tidy
+      - name: Coverage Gate
+        if: github.event_name == 'pull_request'
+        run: make coverage-gate BASE_REF=${{ github.event.pull_request.base.sha }}
+      - name: Generate Coverage
+        if: github.event_name == 'push'
+        run: make test

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,17 +18,3 @@ jobs:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.64
           args: --timeout 3m0s
-  unit-tests:
-    name: Unit Tests
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version: 1.23
-      - name: tidy
-        run: go mod tidy
-      - name: Run Test Scripts
-        run: |
-          make gha

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,15 @@ else
 endif
 
 export GOPATH=$(shell go env GOPATH)
+# Fix GOPATH == GOROOT for GO111MODULE=off builds (common on servers with Go at ~/go).
+_SYS_GOROOT := $(shell GO111MODULE=off go env GOROOT 2>/dev/null)
+_SYS_GOPATH := $(shell GO111MODULE=off go env GOPATH 2>/dev/null)
+ifeq ($(_SYS_GOPATH),$(_SYS_GOROOT))
+export GOMODCACHE := $(_SYS_GOPATH)/pkg/mod
+export GOPATH := /tmp/gopath
+endif
+# Module-aware GOROOT (may point to an auto-downloaded newer toolchain)
+_MOD_GOROOT := $(shell go env GOROOT 2>/dev/null)
 
 ##@ Build Dependencies
 
@@ -109,6 +118,12 @@ undeploy-consumer:kustomize
 # For GitHub Actions CI
 gha:
 	mkdir -p $(GOPATH)/src/github.com/redhat-cne/cloud-event-proxy
+	@if [ "$(_SYS_GOPATH)" = "$(_SYS_GOROOT)" ] && [ -n "$(_SYS_GOROOT)" ]; then \
+		echo "Cleaning stale vendor copies from GOROOT/src..."; \
+		for d in golang.org github.com k8s.io sigs.k8s.io google.golang.org; do \
+			rm -rf "$(_SYS_GOROOT)/src/$$d" 2>/dev/null || true; \
+		done; \
+	fi
 	@if [ "$$(realpath $(GOPATH)/src/github.com/redhat-cne/cloud-event-proxy)" != "$$(realpath .)" ]; then \
 		echo "✅ Safe to delete: cleaning GOPATH workspace..."; \
 		rm -rf $(GOPATH)/src/github.com/redhat-cne/cloud-event-proxy/*; \
@@ -119,9 +134,9 @@ gha:
 		echo "⚠️ Skipping delete: GOPATH is pointing to current working directory!"; \
 	fi
 
-	GO111MODULE=off go build -a -o plugins/ptp_operator_plugin.so -buildmode=plugin plugins/ptp_operator/ptp_operator_plugin.go
-	GO111MODULE=off go build -a -o plugins/mock_plugin.so -buildmode=plugin plugins/mock/mock_plugin.go
-	GO111MODULE=off STORE_PATH=/tmp/sub-store go test ./... --tags=unittests -coverprofile=cover.out
+	PATH=$(_MOD_GOROOT)/bin:$$PATH GOROOT=$(_MOD_GOROOT) GO111MODULE=off go build -a -o plugins/ptp_operator_plugin.so -buildmode=plugin plugins/ptp_operator/ptp_operator_plugin.go
+	PATH=$(_MOD_GOROOT)/bin:$$PATH GOROOT=$(_MOD_GOROOT) GO111MODULE=off go build -a -o plugins/mock_plugin.so -buildmode=plugin plugins/mock/mock_plugin.go
+	PATH=$(_MOD_GOROOT)/bin:$$PATH GOROOT=$(_MOD_GOROOT) GO111MODULE=off STORE_PATH=/tmp/sub-store go test ./... --tags=unittests -coverprofile=cover.out
 
 docker-build:
 	# make sure build the right target when developer using a Mac

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build, test
+.PHONY: build test coverage-gate
 
 #for examples
 # Current  version
@@ -88,7 +88,11 @@ run:
 run-consumer:
 	go run examples/consumer/main.go
 
-test: gha
+test:
+	./hack/unit-test.sh
+
+coverage-gate:
+	./hack/coverage-gate.sh $(BASE_REF)
 
 functests:
 	SUITE=./test/cne hack/run-functests.sh

--- a/README.md
+++ b/README.md
@@ -301,6 +301,30 @@ Cloud native events rest API comes with following metrics collectors .
 1. Number of events received.
 
 [Metrics details ](docs/metrics.md)
+## Test Coverage
+
+Run `make coverage-gate` to compare test coverage of your branch against the upstream main branch. The script auto-detects the upstream remote and its tracking branch.
+
+```sh
+$ make coverage-gate
+
+Base coverage (up-main): 32.1%
+Current coverage:            32.1%
+Difference:                  0%
+✅ Coverage unchanged.
+```
+
+You can also compare against a specific branch:
+
+```sh
+$ BASE_REF=release-4.20 make coverage-gate
+
+Base coverage (release-4.20): 28.5%
+Current coverage:            32.1%
+Difference:                  3.6%
+🎉 Coverage increased by 3.6%, good job!
+```
+
 ## Plugin
 [Plugin details](plugins/README.md)
 

--- a/hack/coverage-gate.sh
+++ b/hack/coverage-gate.sh
@@ -35,8 +35,11 @@ resolve_base_ref() {
     git branch --set-upstream-to="${UPSTREAM_REF}" "${LOCAL_BRANCH}" --quiet >/dev/null
   fi
 
-  # Update tracking branch to latest without checkout
-  git branch -f "${LOCAL_BRANCH}" "${UPSTREAM_REF}" --quiet
+  # Update tracking branch to latest (skip if currently checked out)
+  CURRENT=$(git symbolic-ref --short HEAD 2>/dev/null || true)
+  if [ "${LOCAL_BRANCH}" != "${CURRENT}" ]; then
+    git branch -f "${LOCAL_BRANCH}" "${UPSTREAM_REF}" --quiet 2>/dev/null || true
+  fi
 
   echo "${LOCAL_BRANCH}"
 }

--- a/hack/coverage-gate.sh
+++ b/hack/coverage-gate.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Compare test coverage of the current branch against a base ref.
+# Usage: hack/coverage-gate.sh [base-ref]
+# When base-ref is omitted, auto-detects the local branch tracking
+# the upstream redhat-cne remote's default branch.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+resolve_base_ref() {
+  if [ -n "$1" ]; then
+    echo "$1"
+    return
+  fi
+
+  # Find the remote pointing to redhat-cne
+  UPSTREAM_REMOTE=$(git remote -v | grep 'redhat-cne/.*fetch' | awk '{print $1}' | head -1)
+  if [ -z "${UPSTREAM_REMOTE}" ]; then
+    echo "main"
+    return
+  fi
+
+  git fetch "${UPSTREAM_REMOTE}" --quiet
+
+  # Find the default branch of the upstream remote
+  UPSTREAM_HEAD=$(git remote show "${UPSTREAM_REMOTE}" | sed -n '/HEAD branch/s/.*: //p')
+  UPSTREAM_REF="${UPSTREAM_REMOTE}/${UPSTREAM_HEAD}"
+
+  # Find or create a local branch tracking this remote branch
+  LOCAL_BRANCH=$(git branch --list --format='%(refname:short) %(upstream:short)' | grep " ${UPSTREAM_REF}$" | awk '{print $1}' | head -1)
+  if [ -z "${LOCAL_BRANCH}" ]; then
+    LOCAL_BRANCH="up-${UPSTREAM_HEAD}"
+    echo "==> Creating tracking branch '${LOCAL_BRANCH}' for '${UPSTREAM_REF}'..." >&2
+    git branch "${LOCAL_BRANCH}" "${UPSTREAM_REF}" --quiet
+    git branch --set-upstream-to="${UPSTREAM_REF}" "${LOCAL_BRANCH}" --quiet >/dev/null
+  fi
+
+  # Update tracking branch to latest without checkout
+  git branch -f "${LOCAL_BRANCH}" "${UPSTREAM_REF}" --quiet
+
+  echo "${LOCAL_BRANCH}"
+}
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "==> No git repository found, running tests only..."
+  "${SCRIPT_DIR}/unit-test.sh"
+  CURRENT_COV=$(go tool cover -func=coverage.out | grep ^total | awk '{print $3}' | tr -d '%')
+  echo ""
+  echo "Current coverage: ${CURRENT_COV}%"
+  echo "(base-ref comparison skipped — not a git repo)"
+  exit 0
+fi
+
+BASE_REF=$(resolve_base_ref "$1")
+
+echo "==> Running tests on current branch..."
+"${SCRIPT_DIR}/unit-test.sh"
+CURRENT_COV=$(go tool cover -func=coverage.out | grep ^total | awk '{print $3}' | tr -d '%')
+
+echo "==> Running tests on base ref '${BASE_REF}'..."
+CURRENT_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || git rev-parse HEAD)
+TMPDIR_SAVE=$(mktemp -d)
+cp "${SCRIPT_DIR}/unit-test.sh" "${TMPDIR_SAVE}/unit-test.sh"
+cp "${SCRIPT_DIR}/../Makefile" "${TMPDIR_SAVE}/Makefile"
+STASHED=false
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  git stash --quiet
+  STASHED=true
+fi
+git checkout "${BASE_REF}" --quiet
+cp "${TMPDIR_SAVE}/Makefile" "${SCRIPT_DIR}/../Makefile"
+cp "${TMPDIR_SAVE}/unit-test.sh" "${SCRIPT_DIR}/unit-test.sh"
+rm -rf "${TMPDIR_SAVE}"
+"${SCRIPT_DIR}/unit-test.sh"
+BASE_COV=$(go tool cover -func=coverage.out | grep ^total | awk '{print $3}' | tr -d '%')
+git checkout -- "${SCRIPT_DIR}/../Makefile" 2>/dev/null || true
+rm -f "${SCRIPT_DIR}/unit-test.sh" 2>/dev/null || true
+git checkout "${CURRENT_BRANCH}" --quiet
+if [ "${STASHED}" = true ]; then
+  git stash pop --quiet
+fi
+
+DIFF=$(echo "${CURRENT_COV} - ${BASE_COV}" | bc)
+echo ""
+echo "Base coverage (${BASE_REF}): ${BASE_COV}%"
+echo "Current coverage:            ${CURRENT_COV}%"
+echo "Difference:                  ${DIFF}%"
+
+if (( $(echo "${DIFF} < 0" | bc -l) )); then
+  echo "❌ FAIL: Coverage decreased by ${DIFF}%"
+  exit 1
+elif (( $(echo "${DIFF} > 0" | bc -l) )); then
+  echo "🎉 Coverage increased by ${DIFF}%, good job!"
+else
+  echo "✅ Coverage unchanged."
+fi

--- a/hack/unit-test.sh
+++ b/hack/unit-test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Run unit tests and generate filtered coverage profile.
+# This wraps `make gha` which handles GOPATH setup and plugin builds
+# required for GO111MODULE=off test execution.
+set -e
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+make gha
+grep -vE "/test/|/examples/|/plugins/mock/|vendor/" cover.out > coverage.out

--- a/pkg/plugins/handler_test.go
+++ b/pkg/plugins/handler_test.go
@@ -50,7 +50,7 @@ func init() {
 		CloseCh:       make(chan struct{}),
 		APIPort:       8989,
 		APIPath:       "/api/cne/",
-		PubSubAPI:     v1pubsub.GetAPIInstance("../.."),
+		PubSubAPI:     v1pubsub.GetAPIInstance(storePath),
 		SubscriberAPI: subscriberApi.GetAPIInstance(storePath),
 		StorePath:     storePath,
 		BaseURL:       nil,

--- a/plugins/ptp_operator/ptp_operator_plugin_test.go
+++ b/plugins/ptp_operator/ptp_operator_plugin_test.go
@@ -62,6 +62,9 @@ var (
 
 func TestMain(m *testing.M) {
 	defer cleanUP()
+	if sPath, ok := os.LookupEnv("STORE_PATH"); ok && sPath != "" {
+		storePath = sPath
+	}
 	scConfig = &common.SCConfiguration{
 		EventInCh:     make(chan *channel.DataChan, channelBufferSize),
 		EventOutCh:    make(chan *channel.DataChan, channelBufferSize),


### PR DESCRIPTION
Add CI workflow and local tooling to enforce test coverage does not decrease on PRs. Developers can verify coverage locally via `make coverage-gate` before pushing.

- hack/unit-test.sh: wraps `make gha` with coverage filtering
- hack/coverage-gate.sh: compares coverage against a base ref
- .github/workflows/coverage.yml: blocks PRs with coverage regression
- Makefile: add test and coverage-gate targets
- README.md: document coverage gate usage