### PR TITLE
OCPBUGS-81591: Fix tbc alias gating

### DIFF
--- a/hack/log-events.py
+++ b/hack/log-events.py
@@ -8,25 +8,79 @@ class ActionType(Enum):
     PUSH = "PUSH"
     PULL = "PULL"
 
+RESET = "\033[0m"
+GREEN = "\033[32m"
+RED = "\033[31m"
+YELLOW = "\033[33m"
+CYAN = "\033[36m"
+BOLD = "\033[1m"
+DIM = "\033[2m"
+
+STATE_COLORS = {
+    "LOCKED": GREEN,
+    "FREERUN": RED,
+    "HOLDOVER": YELLOW,
+    "ACQUIRING": YELLOW,
+}
+
+def resource_short_name(address):
+    """Extract the interface/port part from a full ResourceAddress."""
+    parts = address.rstrip("/").split("/")
+    # Typically: /cluster/node/<hostname>/<iface>/<role>
+    if len(parts) >= 2:
+        return "/".join(parts[-2:])
+    return address
+
+def extract_iface(source):
+    """Extract the network interface from a CloudEvent source path."""
+    parts = source.rstrip("/").split("/")
+    # /cluster/node/<hostname>/<iface>[/<role>]
+    if len(parts) >= 5:
+        return parts[4]
+    return None
+
+def format_values(values):
+    """Extract meaningful fields from the data.values array."""
+    state = None
+    offset = None
+    clock_class = None
+    resource = None
+
+    for v in values:
+        resource = resource or v.get("ResourceAddress", "")
+        if v.get("data_type") == "notification" and v.get("value_type") == "enumeration":
+            state = v.get("value")
+        elif v.get("data_type") == "metric":
+            val = v.get("value")
+            if clock_class is None and state is None:
+                clock_class = val
+            else:
+                offset = val
+
+    parts = []
+    if resource:
+        parts.append(f"{CYAN}{resource_short_name(resource)}{RESET}")
+    if state:
+        color = STATE_COLORS.get(state, YELLOW)
+        parts.append(f"state={color}{BOLD}{state}{RESET}")
+    if offset is not None:
+        parts.append(f"offset={BOLD}{offset}{RESET}")
+    if clock_class is not None:
+        parts.append(f"class={BOLD}{clock_class}{RESET}")
+    return "  ".join(parts)
+
 def process_log(log_message, push_pull):
     try:
-        # Remove escape characters
+        log_message = log_message.replace('\\n', '\n')
         log_message = log_message.replace('\\"', '"')
 
-        # Extract JSON part from the log message
-        json_part = re.search(r'{.*}', log_message).group()
+        json_part = re.search(r'\{.*\}', log_message, re.DOTALL).group()
         if not json_part:
             print("No JSON part found in log message: " + log_message)
             return
 
-        # Decode the JSON message
         log_entry = json.loads(json_part)
 
-        # ANSI escape code for green color
-        green_color = "\033[32m"
-        reset_color = "\033[0m"
-
-        # Print the value of "type" in green color
         type_value = log_entry["type"]
         time_value = log_entry["time"]
         direction_value = ""
@@ -35,21 +89,29 @@ def process_log(log_message, push_pull):
         elif push_pull == ActionType.PUSH:
             direction_value = "➡️"
 
-
-        # Format the time value to only 4 digits of precision after the decimal point
         time_value_fixed = re.sub(r"(\.\d{4})\d+", r"\1", time_value)
-        print(f"{direction_value} {time_value_fixed}: {green_color}{type_value}{reset_color}")
+
+        short_type = type_value.replace("event.sync.sync-status.", "").replace("event.sync.ptp-status.", "")
+        values_info = ""
+        if "data" in log_entry and "values" in log_entry["data"]:
+            values_info = format_values(log_entry["data"]["values"])
+
+        iface = extract_iface(log_entry.get("source", ""))
+        iface_tag = f" {CYAN}{iface}{RESET}" if iface else ""
+        print(f"{direction_value} {time_value_fixed}:{iface_tag} {GREEN}{short_type}{RESET}  {values_info}", flush=True)
     except Exception as e:
-        print(f"Error processing log message: {e}")
+        print(f"Error processing log message: {e}", flush=True)
 
 def main():
     print("Listening for events...")
     try:
         for log_message in sys.stdin:
             log_message = log_message.strip()
-            if "received event" in log_message and log_message:
+            if "event sent" in log_message and log_message:
                 process_log(log_message, ActionType.PUSH)
-            if "Got CurrentState" in log_message and log_message:
+            elif "received event" in log_message and log_message:
+                process_log(log_message, ActionType.PUSH)
+            elif "Got CurrentState" in log_message and log_message:
                 process_log(log_message, ActionType.PULL)
 
     except KeyboardInterrupt:

--- a/plugins/ptp_operator/metrics/alias_sync.go
+++ b/plugins/ptp_operator/metrics/alias_sync.go
@@ -11,23 +11,24 @@ import (
 
 const portAliasesEndpoint = "http://localhost:8081/port-aliases"
 
-// SyncAliasesFromDaemon fetches aliases from linuxptp-daemon and populates the local alias store
-func SyncAliasesFromDaemon() error {
+// SyncAliasesFromDaemon fetches aliases from linuxptp-daemon and populates
+// the local alias store. It returns the number of aliases synced.
+func SyncAliasesFromDaemon() (int, error) {
 	client := &http.Client{Timeout: 2 * time.Second}
 	resp, err := client.Get(portAliasesEndpoint)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	defer resp.Body.Close()
 
 	var aliases map[string]string
 	if err = json.NewDecoder(resp.Body).Decode(&aliases); err != nil {
-		return err
+		return 0, err
 	}
 
 	for ifName, aliasValue := range aliases {
 		alias.SetAlias(ifName, aliasValue)
 	}
 	log.Infof("Synced %d port aliases from linuxptp-daemon", len(aliases))
-	return nil
+	return len(aliases), nil
 }

--- a/plugins/ptp_operator/ptp_operator_plugin.go
+++ b/plugins/ptp_operator/ptp_operator_plugin.go
@@ -69,6 +69,8 @@ const (
 	EventNotFound               = "event-not-found"
 	PTPNotSet                   = "ptp-not-set"
 	ptpConfigSyncInitialTimeout = 1 * time.Second
+	aliasRetryInterval          = 1 * time.Second
+	aliasRetryTimeout           = 30 * time.Second
 )
 
 var (
@@ -76,6 +78,7 @@ var (
 	publishers     = map[ptp.EventType]*ptpTypes.EventPublisherType{}
 	config         *common.SCConfiguration
 	eventManager   *ptpMetrics.PTPEventManager
+	aliasReady     chan struct{}
 )
 
 // restartProcess replaces the current process with a fresh copy of itself via
@@ -106,11 +109,34 @@ func restartProcess(reason string) {
 // from ptpConfigDir once at startup and registers them with the event manager.
 // If no files exist yet (daemon hasn't written them), the function returns
 // gracefully; the daemon will send CMD RESTART once configs are ready.
-func loadInitialPtp4lConfigs() {
+func loadInitialPtp4lConfigs() int {
 	configs := ptp4lconf.ReadAllConfig(ptpConfigDir)
 	log.Infof("loading %d initial ptp4l config(s) from %s", len(configs), ptpConfigDir)
 	for _, ptpConfigEvent := range configs {
 		processConfigCreate(ptpConfigEvent)
+	}
+	return len(configs)
+}
+
+// waitForAliases retries SyncAliasesFromDaemon until at least one alias is
+// returned or the timeout expires. This ensures linuxptp-daemon has finished
+// reading its ptp4l configs and can serve alias mappings before we start
+// processing events on the socket.
+func waitForAliases(timeout, interval time.Duration) {
+	deadline := time.After(timeout)
+	for {
+		n, err := ptpMetrics.SyncAliasesFromDaemon()
+		if err != nil {
+			log.Warnf("alias sync failed: %v, retrying...", err)
+		} else if n > 0 {
+			return
+		}
+		select {
+		case <-deadline:
+			log.Warnf("alias sync: no aliases available after %s, proceeding without aliases", timeout)
+			return
+		case <-time.After(interval):
+		}
 	}
 }
 
@@ -176,7 +202,9 @@ func processConfigCreate(ptpConfigEvent *ptp4lconf.PtpConfigUpdate) {
 	}
 	ptp4lConfig.ProfileType = eventManager.GetProfileType(ptp4lConfig.Profile)
 	eventManager.AddPTPConfig(ptpConfigFileName, ptp4lConfig)
-	ptpMetrics.SyncAliasesFromDaemon()
+	if _, err := ptpMetrics.SyncAliasesFromDaemon(); err != nil {
+		log.Warnf("failed to sync aliases for config %s: %v", *ptpConfigEvent.Name, err)
+	}
 }
 
 // startPtpConfigSync starts the configmap watcher and blocks until the first
@@ -245,14 +273,25 @@ func Start(wg *sync.WaitGroup, configuration *common.SCConfiguration, _ func(e i
 		log.Warn(err)
 	}
 	eventManager.SetInitalMetrics()
-	// We must attempt to get aliases here for the case of restarting cloud-event-proxy
-	// against an extablished linuxptp-daemon, which will have aliases already populated
-	// and log lines waiting in the buffer.
-	ptpMetrics.SyncAliasesFromDaemon()
 	startPtpConfigSync(ptpConfigSyncInitialTimeout, nodeName, configuration)
-	loadInitialPtp4lConfigs()
+	nConfigs := loadInitialPtp4lConfigs()
+
+	// Wait for port aliases from linuxptp-daemon in the background. The socket
+	// listener starts immediately so the daemon can connect, but processMessages
+	// blocks on aliasReady before processing events -- ensuring aliases are
+	// populated before any metrics/events use interface names.
+	aliasReady = make(chan struct{})
+	if nConfigs > 0 {
+		go func() {
+			waitForAliases(aliasRetryTimeout, aliasRetryInterval)
+			close(aliasReady)
+		}()
+	} else {
+		close(aliasReady)
+	}
+
 	wg.Add(1)
-	// create socket listener; the daemon sends log lines and CMD RESTART commands here.
+	// Create socket listener; the daemon sends log lines and CMD RESTART commands here.
 	// When a new connection is accepted, processMessages calls TriggerLogs() to request
 	// the daemon to re-emit all metrics logs.
 	go listenToSocket(wg)
@@ -476,6 +515,8 @@ func listenToSocket(wg *sync.WaitGroup) {
 }
 
 func processMessages(c net.Conn) {
+	<-aliasReady // wait until alias found and this is closed
+	log.Info("alias found, starting to process messages")
 	// Request a full state re-emit in a separate goroutine so the scanner
 	// can start reading immediately. TriggerLogs writes emit data back through
 	// this same socket connection; if we block here waiting for the HTTP response,


### PR DESCRIPTION
## Summary

Fix T-BC alias race condition where events published during startup use raw interface names (e.g. `ens8f0`) instead of aliases (e.g. `ens8fx`), because `SyncAliasesFromDaemon` was called before linuxptp-daemon had populated its alias store.

- Gate event processing on alias availability: start the socket listener immediately so the daemon can connect, but block `processMessages` on a channel that closes once aliases are confirmed available
- Add `waitForAliases` retry loop (30s timeout, 1s interval) to poll until linuxptp-daemon serves at least one alias
- After aliases load, `TriggerLogs` re-emits the daemon's full state so no events are missed during the wait
- Return alias count from `SyncAliasesFromDaemon` so callers can distinguish "empty response" from "endpoint unreachable"
- Rewrite `hack/log-events.py` with structured CloudEvent parsing, ANSI color-coded state transitions (green/red/yellow for LOCKED/FREERUN/HOLDOVER), per-interface tagging, and real-time flushed output

Fixes: [OCPBUGS-81591](https://redhat.atlassian.net/browse/OCPBUGS-81591)

## Test plan

- [ ] Deploy T-BC config, restart cloud-event-proxy pod, verify events use alias names from first event onward
- [ ] Verify `processMessages` blocks until aliases are available (check "alias found, starting to process messages" log)
- [ ] Verify no events are lost: `TriggerLogs` re-emits full state after alias gate opens
- [ ] Test `hack/log-events.py` with piped cloud-event-proxy logs — confirm color-coded output with interface names
- [ ] Verify graceful degradation: if aliases never appear within 30s, processing proceeds with raw names