### PR TITLE
ci: use ptp-operator main branch in netdevsim CI

### DIFF
--- a/.github/workflows/netdevsim-ci.yml
+++ b/.github/workflows/netdevsim-ci.yml
@@ -17,7 +17,7 @@ env:
   DKMS_REPO: https://github.com/redhat-cne/netdevsim-dkms.git
   DKMS_BRANCH: main
   PTP_REPO: https://github.com/edcdavid/ptp-operator-upstream.git
-  PTP_BRANCH: netdevsim-dkms
+  PTP_BRANCH: main
 
 jobs:
   # ------------------------------------------------------------------

--- a/plugins/ptp_operator/metrics/tbc_test.go
+++ b/plugins/ptp_operator/metrics/tbc_test.go
@@ -118,7 +118,7 @@ func TestTBCPtp4lMasterOffsetNoHoldover(t *testing.T) {
 	eventManager := metrics.NewPTPEventManager("", initPubSubTypes(), "testnode", &common.SCConfiguration{StorePath: "/tmp/store"})
 	eventManager.MockTest(true)
 
-	configName = "ptp4l.0.config"
+	configName = "ptp4l.0.config" //nolint:goconst // reused test config name
 	tbcProfile := "tbc-test-profile"
 
 	// Setup TBC profile


### PR DESCRIPTION
## Summary
- Switch `PTP_BRANCH` from `netdevsim-dkms` to `main` in the netdevsim CI workflow
- Ensures CI picks up the serialized image build fix and stays in sync with upstream ptp-operator

## Test plan
- [ ] Verify netdevsim CI triggers and clones the correct ptp-operator branch
- [ ] Confirm image build completes without podman crashes