### PR TITLE
OCPBUGS-85330: Fix T-BC ptp-state-change event not firing after ptp4l kill

### DIFF
--- a/plugins/ptp_operator/metrics/metrics.go
+++ b/plugins/ptp_operator/metrics/metrics.go
@@ -121,7 +121,7 @@ func (p *PTPEventManager) ExtractMetrics(msg string) {
 	if strings.Contains(output, ptpProcessStatusIdentifier) {
 		if status, err := p.parsePTPStatus(output, fields); err == nil {
 			if status == PtpProcessDown {
-				p.processDownEvent(profileName, processName, ptpStats)
+				p.processDownEvent(profileName, processName, ptpStats, ptp4lCfg.ProfileType)
 			}
 		} else {
 			log.Errorf("error in process status %s: %v", output, err)
@@ -363,7 +363,7 @@ func (p *PTPEventManager) ExtractMetrics(msg string) {
 		ptpInterface, ptp4lCfg, ptpStats)
 }
 
-func (p *PTPEventManager) processDownEvent(profileName, processName string, ptpStats stats.PTPStats) {
+func (p *PTPEventManager) processDownEvent(profileName, processName string, ptpStats stats.PTPStats, profileType ptp4lconf.PtpProfileType) {
 	// if the process is responsible to set master offset
 	if processName == ts2phcProcessName {
 		//  update metrics for all interface defined by ts2phc
@@ -384,6 +384,17 @@ func (p *PTPEventManager) processDownEvent(profileName, processName string, ptpS
 			}
 		}
 	} else { // other profiles
+		// T-BC: when ptp4l dies, fire FREERUN for the T-BC aggregate resource.
+		// Without this, the T-BC stats key is never set to FREERUN (DPLL/ts2phc
+		// keep T-BC-STATUS at s2), so ParseTBCLogs never detects a state
+		// transition and the recovery LOCKED event is never published.
+		if profileType == ptp4lconf.TBC && processName == ptp4lProcessName {
+			tbcKey := types.IFace(stats.TBCMainClockName)
+			if tbcStat, ok := ptpStats[tbcKey]; ok && tbcStat.Alias() != "" {
+				masterResource := fmt.Sprintf("%s/%s", tbcStat.Alias(), MasterClockType)
+				p.GenPTPEvent(profileName, tbcStat, masterResource, FreeRunOffsetValue, ptp.FREERUN, ptp.PtpStateChange)
+			}
+		}
 		if masterOffsetSource == processName {
 			if ptpStats[master].Alias() != "" {
 				masterResource := fmt.Sprintf("%s/%s", ptpStats[master].Alias(), MasterClockType)

--- a/plugins/ptp_operator/metrics/tbc_test.go
+++ b/plugins/ptp_operator/metrics/tbc_test.go
@@ -396,3 +396,68 @@ func TestTBCOffsetMetricUpdatedEveryLog(t *testing.T) {
 		})
 	}
 }
+
+// TestTBCProcessDownEventFiresFreerun verifies that killing ptp4l on a T-BC
+// profile sets the T-BC stats key to FREERUN and publishes a ptp-state-change
+// event, and that subsequent T-BC-STATUS s2 publishes a LOCKED event.
+// Regression test for OCPBUGS-85330.
+func TestTBCProcessDownEventFiresFreerun(t *testing.T) {
+	eventManager := metrics.NewPTPEventManager("", initPubSubTypes(), "testnode", &common.SCConfiguration{StorePath: "/tmp/store"})
+	eventManager.MockTest(true)
+
+	configName = "ptp4l.1.config"
+	tbcProfile := "tbc-tr"
+
+	eventManager.PtpConfigMapUpdates.TBCProfiles = []string{tbcProfile}
+	eventManager.PtpConfigMapUpdates.PtpProcessOpts = make(map[string]*ptpConfig.PtpProcessOpts)
+
+	ptp4lCfg := &ptp4lconf.PTP4lConfig{
+		Name:        configName,
+		Profile:     tbcProfile,
+		ProfileType: ptp4lconf.TBC,
+		Interfaces: []*ptp4lconf.PTPInterface{
+			{
+				Name:     "ens2f0",
+				PortID:   1,
+				PortName: "port 1",
+				Role:     types.SLAVE,
+			},
+		},
+	}
+	eventManager.AddPTPConfig(types.ConfigName(configName), ptp4lCfg)
+
+	ptpStats := eventManager.GetStats(types.ConfigName(configName))
+	ptpStats[metrics.MasterClockType] = &stats.Stats{}
+	ptpStats[metrics.MasterClockType].SetAlias("enox")
+	tbcKey := types.IFace(stats.TBCMainClockName)
+	ptpStats[tbcKey] = &stats.Stats{}
+	ptpStats[tbcKey].SetAlias("enox")
+	ptpStats[tbcKey].SetLastSyncState(ptp.LOCKED)
+
+	// Step 1: Simulate ptp4l process down (PTP_PROCESS_STATUS:0)
+	downLog := "ptp4l[1780430740]:[ptp4l.1.config] PTP_PROCESS_STATUS:0"
+	eventManager.ResetMockEvent()
+	eventManager.ExtractMetrics(downLog)
+
+	// Verify T-BC stats key is now FREERUN
+	assert.Equal(t, ptp.FREERUN, ptpStats[tbcKey].LastSyncState(),
+		"T-BC stats should be FREERUN after ptp4l down")
+
+	// Verify a PtpStateChange event was published
+	mockEvents := eventManager.GetMockEvent()
+	assert.Contains(t, mockEvents, ptp.PtpStateChange,
+		"PtpStateChange event should fire on ptp4l down for T-BC")
+
+	// Step 2: Simulate T-BC-STATUS s2 arriving (DPLL still locked)
+	replacer := strings.NewReplacer("[", " ", "]", " ", ":", " ")
+	tbcLog := "T-BC[1780430800]:[ts2phc.1.config] ens2f0 offset 0 T-BC-STATUS s2"
+	output := replacer.Replace(tbcLog)
+	fields := strings.Fields(output)
+
+	eventManager.ResetMockEvent()
+	eventManager.ParseTBCLogs("T-BC", configName, output, fields, ptpStats)
+
+	// Verify T-BC stats key transitions back to LOCKED
+	assert.Equal(t, ptp.LOCKED, ptpStats[tbcKey].LastSyncState(),
+		"T-BC stats should be LOCKED after T-BC-STATUS s2")
+}


### PR DESCRIPTION
## Summary

- Fix `processDownEvent()` to handle T-BC profiles: when ptp4l dies on a T-BC config, fire FREERUN on the `"T-BC"` stats key so `ParseTBCLogs` detects the recovery LOCKED transition
- Add regression test `TestTBCProcessDownEventFiresFreerun`

## Root Cause

`processDownEvent()` only generated FREERUN events when `masterOffsetSource == processName`. For T-BC profiles, `masterOffsetSource` is `"ts2phc"` (not `"ptp4l"`), so the condition silently failed and no FREERUN event was published.

This was masked before PR #671 because a startup race caused `ProfileType` to be cached as `NONE`, making T-BC profiles take the non-TBC code path where `masterOffsetSource` was set to `"ptp4l"`. PR #671 correctly fixed the startup ordering, which exposed this latent bug.

Without the FREERUN event, the `"T-BC"` stats key (from PR #619) was never set to FREERUN. When T-BC-STATUS continued reporting s2 (DPLL/ts2phc kept the clock locked), `ParseTBCLogs` saw LOCKED==LOCKED → no state transition → no LOCKED event.

## Verification

Reproduced and verified on helix98 (4.22.0-rc.5, GNR-D T-BC config):

- **Without fix**: QE test polarion 49737 FAILED — LOCKED ptp-state-change timed out
- **With fix**: QE test polarion 49737 PASSED — FREERUN event fired 1s after kill, LOCKED event 1s later

## Test plan

- [x] Unit tests pass (`go test ./plugins/ptp_operator/...`)
- [x] New regression test: `TestTBCProcessDownEventFiresFreerun`
- [x] QE test polarion 49737 passes on helix98 with fix image
- [x] QE test polarion 49737 fails on helix98 without fix (original image)

🤖 Generated with [Claude Code](https://claude.com/claude-code)