### PR TITLE
[WIP] CNF-24539: T-BC TR ptp4l kill fires HOLDOVER instead of FREERUN

### DIFF
--- a/plugins/ptp_operator/metrics/logparser.go
+++ b/plugins/ptp_operator/metrics/logparser.go
@@ -490,6 +490,20 @@ func (p *PTPEventManager) ParseTBCLogs(processName, configName, output string, f
 
 	if clockState.State != lastClockState && clockState.State != "" { // publish directly here
 		log.Infof("%s sync state %s, last ptp state is : %s", masterResource, clockState.State, lastClockState)
+		// Cancel T-BC holdover timer on HOLDOVER → LOCKED transition.
+		// The timer was started under the TR profile (has phc2sys).
+		if lastClockState == ptp.HOLDOVER && clockState.State == ptp.LOCKED {
+			for _, tbcProfile := range p.PtpConfigMapUpdates.TBCProfiles {
+				ptpOpts := p.PtpConfigMapUpdates.LookupPtpProcessOpts(tbcProfile)
+				if ptpOpts != nil && ptpOpts.Phc2SysEnabled() {
+					if t := p.PtpConfigMapUpdates.LookupEventThreshold(tbcProfile); t != nil {
+						log.Infof("T-BC: cancelling holdover timer on LOCKED recovery: profile=%s", tbcProfile)
+						t.SafeClose()
+					}
+					break
+				}
+			}
+		}
 		ptpStats[tbcClockNameType].SetLastSyncState(clockState.State)
 		p.PublishEvent(clockState.State, lastOffset, masterResource, ptp.PtpStateChange)
 	}

--- a/plugins/ptp_operator/metrics/metrics.go
+++ b/plugins/ptp_operator/metrics/metrics.go
@@ -123,7 +123,7 @@ func (p *PTPEventManager) ExtractMetrics(msg string) {
 		if status, err := p.parsePTPStatus(output, fields); err == nil {
 			log.Debugf("ExtractMetrics: process status detected: process=%s config=%s status=%d", processName, configName, status)
 			if status == PtpProcessDown {
-				p.processDownEvent(profileName, processName, ptpStats, ptp4lCfg.ProfileType)
+				p.processDownEvent(profileName, processName, configName, ptpStats, ptp4lCfg.ProfileType)
 			}
 		} else {
 			log.Errorf("error in process status %s: %v", output, err)
@@ -366,7 +366,7 @@ func (p *PTPEventManager) ExtractMetrics(msg string) {
 		ptpInterface, ptp4lCfg, ptpStats)
 }
 
-func (p *PTPEventManager) processDownEvent(profileName, processName string, ptpStats stats.PTPStats, profileType ptp4lconf.PtpProfileType) {
+func (p *PTPEventManager) processDownEvent(profileName, processName, configName string, ptpStats stats.PTPStats, profileType ptp4lconf.PtpProfileType) {
 	// if the process is responsible to set master offset
 	if processName == ts2phcProcessName {
 		//  update metrics for all interface defined by ts2phc
@@ -387,21 +387,36 @@ func (p *PTPEventManager) processDownEvent(profileName, processName string, ptpS
 			}
 		}
 	} else { // other profiles
-		// T-BC: when ptp4l dies, fire FREERUN for the T-BC aggregate resource.
-		// Without this, the T-BC stats key is never set to FREERUN (DPLL/ts2phc
-		// keep T-BC-STATUS at s2), so ParseTBCLogs never detects a state
-		// transition and the recovery LOCKED event is never published.
+		// T-BC: when ptp4l dies, update the T-BC aggregate resource so
+		// ParseTBCLogs detects a state transition on recovery.
+		// TR ptp4l (has phc2sys): DPLL stays locked → fire HOLDOVER + start timer
+		// TT ptp4l (no phc2sys): downstream clients lose sync → fire FREERUN
 		if profileType == ptp4lconf.TBC && processName == ptp4lProcessName {
 			tbcKey := types.IFace(stats.TBCMainClockName)
 			if tbcStat, ok := ptpStats[tbcKey]; ok && tbcStat.Alias() != "" {
 				masterResource := fmt.Sprintf("%s/%s", tbcStat.Alias(), MasterClockType)
-				p.GenPTPEvent(profileName, tbcStat, masterResource, FreeRunOffsetValue, ptp.FREERUN, ptp.PtpStateChange)
+				ptpOpts := p.PtpConfigMapUpdates.LookupPtpProcessOpts(profileName)
+				isTR := ptpOpts != nil && ptpOpts.Phc2SysEnabled()
+				if isTR {
+					p.GenPTPEvent(profileName, tbcStat, masterResource, FreeRunOffsetValue, ptp.HOLDOVER, ptp.PtpStateChange)
+					p.startTBCHoldoverTimer(ptpOpts, configName, profileName, tbcStat.Alias())
+				} else {
+					p.GenPTPEvent(profileName, tbcStat, masterResource, FreeRunOffsetValue, ptp.FREERUN, ptp.PtpStateChange)
+				}
 			}
 		}
 		if masterOffsetSource == processName {
 			if ptpStats[master].Alias() != "" {
 				masterResource := fmt.Sprintf("%s/%s", ptpStats[master].Alias(), MasterClockType)
 				p.GenPTPEvent(profileName, ptpStats[master], masterResource, FreeRunOffsetValue, ptp.FREERUN, ptp.PtpStateChange)
+			}
+		}
+		// For T-BC TR ptp4l kill, do not fire OsClockSyncStateChange —
+		// DPLL keeps PHC locked, CLOCK_REALTIME stays synced.
+		if profileType == ptp4lconf.TBC {
+			ptpOpts := p.PtpConfigMapUpdates.LookupPtpProcessOpts(profileName)
+			if ptpOpts != nil && ptpOpts.Phc2SysEnabled() {
+				return
 			}
 		}
 		if s, ok := ptpStats[ClockRealTime]; ok {

--- a/plugins/ptp_operator/metrics/ptp4lParse.go
+++ b/plugins/ptp_operator/metrics/ptp4lParse.go
@@ -213,6 +213,62 @@ func handleHoldOverState(ptpManager *PTPEventManager,
 	}
 }
 
+// startTBCHoldoverTimer starts a holdover timer for the T-BC aggregate.
+// When the TR ptp4l dies, the DPLL keeps the PHC locked (holdover).
+// If ptp4l doesn't recover before the timeout, transition to FREERUN.
+func (p *PTPEventManager) startTBCHoldoverTimer(
+	ptpOpts *ptpConfig.PtpProcessOpts, configName, profileName, tbcAlias string) {
+	if p.mock {
+		log.Infof("T-BC holdover timer not started: mock mode (profile=%s config=%s)", profileName, configName)
+		return
+	}
+	threshold := p.PtpThreshold(profileName, true)
+	log.Infof("starting T-BC holdover timer: profile=%s config=%s alias=%s timeout=%ds",
+		profileName, configName, tbcAlias, threshold.HoldOverTimeout)
+	go handleTBCHoldOverState(p, ptpOpts, configName, profileName, threshold.HoldOverTimeout, tbcAlias, threshold.Close)
+}
+
+func handleTBCHoldOverState(ptpManager *PTPEventManager,
+	ptpOpts *ptpConfig.PtpProcessOpts, configName,
+	ptpProfileName string, holdoverTimeout int64,
+	tbcAlias string, c chan struct{}) {
+	defer func() {
+		log.Infof("exiting T-BC holdover for profile %s", ptpProfileName)
+		if r := recover(); r != nil {
+			fmt.Println("Recovered in f", r)
+		}
+	}()
+	tbcKey := types.IFace(stats.TBCMainClockName)
+	select {
+	case <-c:
+		log.Infof("T-BC holdover timer cancelled: profile=%s config=%s", ptpProfileName, configName)
+		return
+	case <-time.After(time.Duration(holdoverTimeout) * time.Second):
+		log.Infof("T-BC holdover timer expired: profile=%s config=%s timeout=%ds", ptpProfileName, configName, holdoverTimeout)
+		ptpStats := ptpManager.GetStats(types.ConfigName(configName))
+		tbcStat, found := ptpStats[tbcKey]
+		if !found {
+			log.Errorf("T-BC holdover expired but T-BC stats not found: config=%s profile=%s", configName, ptpProfileName)
+			return
+		}
+		if tbcStat.LastSyncState() != ptp.HOLDOVER {
+			log.Infof("T-BC holdover expired but state is %s (not HOLDOVER), no-op: profile=%s",
+				tbcStat.LastSyncState(), ptpProfileName)
+			return
+		}
+		alias := tbcStat.Alias()
+		if alias == "" {
+			log.Errorf("T-BC holdover expired but empty alias: config=%s profile=%s", configName, ptpProfileName)
+			return
+		}
+		log.Infof("T-BC holdover expired, transitioning to FREERUN: profile=%s alias=%s", ptpProfileName, alias)
+		masterResource := fmt.Sprintf("%s/%s", alias, MasterClockType)
+		tbcStat.SetLastSyncState(ptp.FREERUN)
+		ptpManager.PublishEvent(ptp.FREERUN, tbcStat.LastOffset(), masterResource, ptp.PtpStateChange)
+		UpdateSyncStateMetrics(ptp4lProcessName, alias, ptp.FREERUN)
+	}
+}
+
 func (p *PTPEventManager) maybePublishOSClockSyncStateChangeEvent(
 	ptpOpts *ptpConfig.PtpProcessOpts, configName, ptpProfileName string) {
 	if ptpOpts == nil {

--- a/plugins/ptp_operator/metrics/tbc_test.go
+++ b/plugins/ptp_operator/metrics/tbc_test.go
@@ -397,19 +397,23 @@ func TestTBCOffsetMetricUpdatedEveryLog(t *testing.T) {
 	}
 }
 
-// TestTBCProcessDownEventFiresFreerun verifies that killing ptp4l on a T-BC
-// profile sets the T-BC stats key to FREERUN and publishes a ptp-state-change
-// event, and that subsequent T-BC-STATUS s2 publishes a LOCKED event.
-// Regression test for OCPBUGS-85330.
-func TestTBCProcessDownEventFiresFreerun(t *testing.T) {
+// TestTBCProcessDownEventTR verifies that killing TR ptp4l (has phc2sys) on
+// a T-BC profile sets the T-BC stats key to HOLDOVER (DPLL stays locked)
+// and publishes a ptp-state-change HOLDOVER event. Subsequent T-BC-STATUS s2
+// publishes a LOCKED event. No OsClockSyncStateChange should fire.
+// Regression test for OCPBUGS-85330 / CNF-24539.
+func TestTBCProcessDownEventTR(t *testing.T) {
 	eventManager := metrics.NewPTPEventManager("", initPubSubTypes(), "testnode", &common.SCConfiguration{StorePath: "/tmp/store"})
 	eventManager.MockTest(true)
 
 	configName = "ptp4l.1.config"
 	tbcProfile := "tbc-tr"
 
+	phc2sysOpts := "-a -r -r -n 24"
 	eventManager.PtpConfigMapUpdates.TBCProfiles = []string{tbcProfile}
-	eventManager.PtpConfigMapUpdates.PtpProcessOpts = make(map[string]*ptpConfig.PtpProcessOpts)
+	eventManager.PtpConfigMapUpdates.PtpProcessOpts = map[string]*ptpConfig.PtpProcessOpts{
+		tbcProfile: {Phc2Opts: &phc2sysOpts},
+	}
 
 	ptp4lCfg := &ptp4lconf.PTP4lConfig{
 		Name:        configName,
@@ -434,21 +438,25 @@ func TestTBCProcessDownEventFiresFreerun(t *testing.T) {
 	ptpStats[tbcKey].SetAlias("enox")
 	ptpStats[tbcKey].SetLastSyncState(ptp.LOCKED)
 
-	// Step 1: Simulate ptp4l process down (PTP_PROCESS_STATUS:0)
+	// Step 1: Simulate TR ptp4l process down (PTP_PROCESS_STATUS:0)
 	downLog := "ptp4l[1780430740]:[ptp4l.1.config] PTP_PROCESS_STATUS:0"
 	eventManager.ResetMockEvent()
 	eventManager.ExtractMetrics(downLog)
 
-	// Verify T-BC stats key is now FREERUN
-	assert.Equal(t, ptp.FREERUN, ptpStats[tbcKey].LastSyncState(),
-		"T-BC stats should be FREERUN after ptp4l down")
+	// Verify T-BC stats key is now HOLDOVER (not FREERUN — DPLL stays locked)
+	assert.Equal(t, ptp.HOLDOVER, ptpStats[tbcKey].LastSyncState(),
+		"T-BC stats should be HOLDOVER after TR ptp4l down")
 
 	// Verify a PtpStateChange event was published
 	mockEvents := eventManager.GetMockEvent()
 	assert.Contains(t, mockEvents, ptp.PtpStateChange,
-		"PtpStateChange event should fire on ptp4l down for T-BC")
+		"PtpStateChange event should fire on TR ptp4l down for T-BC")
 
-	// Step 2: Simulate T-BC-STATUS s2 arriving (DPLL still locked)
+	// Verify no OsClockSyncStateChange was published (DPLL keeps CLOCK_REALTIME synced)
+	assert.NotContains(t, mockEvents, ptp.OsClockSyncStateChange,
+		"OsClockSyncStateChange should NOT fire for TR ptp4l kill on T-BC")
+
+	// Step 2: Simulate T-BC-STATUS s2 arriving (DPLL still locked, ptp4l recovered)
 	replacer := strings.NewReplacer("[", " ", "]", " ", ":", " ")
 	tbcLog := "T-BC[1780430800]:[ts2phc.1.config] ens2f0 offset 0 T-BC-STATUS s2"
 	output := replacer.Replace(tbcLog)
@@ -460,4 +468,55 @@ func TestTBCProcessDownEventFiresFreerun(t *testing.T) {
 	// Verify T-BC stats key transitions back to LOCKED
 	assert.Equal(t, ptp.LOCKED, ptpStats[tbcKey].LastSyncState(),
 		"T-BC stats should be LOCKED after T-BC-STATUS s2")
+}
+
+// TestTBCProcessDownEventTT verifies that killing TT ptp4l (no phc2sys) on
+// a T-BC profile fires FREERUN (downstream clients lose sync).
+func TestTBCProcessDownEventTT(t *testing.T) {
+	eventManager := metrics.NewPTPEventManager("", initPubSubTypes(), "testnode", &common.SCConfiguration{StorePath: "/tmp/store"})
+	eventManager.MockTest(true)
+
+	configName = "ptp4l.0.config"
+	tbcProfile := "tbc-tt"
+
+	eventManager.PtpConfigMapUpdates.TBCProfiles = []string{tbcProfile}
+	eventManager.PtpConfigMapUpdates.PtpProcessOpts = map[string]*ptpConfig.PtpProcessOpts{
+		tbcProfile: {},
+	}
+
+	ptp4lCfg := &ptp4lconf.PTP4lConfig{
+		Name:        configName,
+		Profile:     tbcProfile,
+		ProfileType: ptp4lconf.TBC,
+		Interfaces: []*ptp4lconf.PTPInterface{
+			{
+				Name:     "ens2f1",
+				PortID:   1,
+				PortName: "port 1",
+				Role:     types.MASTER,
+			},
+		},
+	}
+	eventManager.AddPTPConfig(types.ConfigName(configName), ptp4lCfg)
+
+	ptpStats := eventManager.GetStats(types.ConfigName(configName))
+	ptpStats[metrics.MasterClockType] = &stats.Stats{}
+	ptpStats[metrics.MasterClockType].SetAlias("enox")
+	tbcKey := types.IFace(stats.TBCMainClockName)
+	ptpStats[tbcKey] = &stats.Stats{}
+	ptpStats[tbcKey].SetAlias("enox")
+	ptpStats[tbcKey].SetLastSyncState(ptp.LOCKED)
+
+	// Simulate TT ptp4l process down
+	downLog := "ptp4l[1780430740]:[ptp4l.0.config] PTP_PROCESS_STATUS:0"
+	eventManager.ResetMockEvent()
+	eventManager.ExtractMetrics(downLog)
+
+	// Verify T-BC stats key is FREERUN (TT has no DPLL protection for downstream)
+	assert.Equal(t, ptp.FREERUN, ptpStats[tbcKey].LastSyncState(),
+		"T-BC stats should be FREERUN after TT ptp4l down")
+
+	mockEvents := eventManager.GetMockEvent()
+	assert.Contains(t, mockEvents, ptp.PtpStateChange,
+		"PtpStateChange event should fire on TT ptp4l down for T-BC")
 }


### PR DESCRIPTION
When the TR (time receiver) ptp4l is killed on a T-BC with DPLL hardware, the DPLL stays locked (LHAQ) and T-BC-STATUS never leaves s2. The clock is in holdover, not freerun.

- processDownEvent: distinguish TR (has phc2sys) from TT via Phc2SysEnabled(). TR fires HOLDOVER + starts holdover timer. TT fires FREERUN (downstream clients lose sync).
- TR ptp4l kill suppresses OsClockSyncStateChange — DPLL keeps PHC locked, CLOCK_REALTIME stays synced.
- Add startTBCHoldoverTimer/handleTBCHoldOverState: if ptp4l doesn't recover before timeout, transitions to FREERUN.
- ParseTBCLogs: cancel holdover timer on HOLDOVER→LOCKED recovery.
- Tests: TestTBCProcessDownEventTR expects HOLDOVER, new TestTBCProcessDownEventTT expects FREERUN.