### PR TITLE
Demote replay-fix debug logs to trace level

### DIFF
--- a/plugins/ptp_operator/metrics/manager.go
+++ b/plugins/ptp_operator/metrics/manager.go
@@ -431,7 +431,7 @@ func (p *PTPEventManager) GenPTPEvent(ptpProfileName string, oStats *stats.Stats
 	}
 
 	lastClockState := oStats.LastSyncState()
-	log.Debugf("GenPTPEvent: profile=%s resource=%s offset=%d clockState=%s lastState=%s eventType=%s",
+	log.Tracef("GenPTPEvent: profile=%s resource=%s offset=%d clockState=%s lastState=%s eventType=%s",
 		ptpProfileName, eventResourceName, ptpOffset, clockState, lastClockState, eventType)
 	threshold := p.PtpThreshold(ptpProfileName, false)
 	switch clockState {
@@ -829,15 +829,15 @@ func (p *PTPEventManager) SetInitalMetrics() {
 }
 
 func (p *PTPEventManager) TriggerLogs() error {
-	log.Debugf("TriggerLogs: calling %s", logsEndpoint)
+	log.Tracef("TriggerLogs: calling %s", logsEndpoint)
 	client := &http.Client{Timeout: 5 * time.Second}
 	resp, err := client.Get(logsEndpoint)
 	if err != nil {
-		log.Debugf("TriggerLogs: request failed: %v", err)
+		log.Tracef("TriggerLogs: request failed: %v", err)
 		return err
 	}
 	defer resp.Body.Close()
-	log.Debugf("TriggerLogs: response status=%s", resp.Status)
+	log.Tracef("TriggerLogs: response status=%s", resp.Status)
 	return nil
 }
 

--- a/plugins/ptp_operator/metrics/metrics.go
+++ b/plugins/ptp_operator/metrics/metrics.go
@@ -107,7 +107,7 @@ func (p *PTPEventManager) ExtractMetrics(msg string) {
 	}
 	processName := fields[processNameIndex]
 	configName := fields[configNameIndex]
-	log.Debugf("ExtractMetrics: process=%s config=%s msg=%.100s", processName, configName, msg)
+	log.Tracef("ExtractMetrics: process=%s config=%s msg=%.100s", processName, configName, msg)
 	// if log is having ts2phc then it will replace it with ptp4l
 	configName = strings.Replace(configName, ts2phcProcessName, ptp4lProcessName, 1)
 	ptp4lCfg := p.GetPTPConfig(types.ConfigName(configName))
@@ -121,7 +121,7 @@ func (p *PTPEventManager) ExtractMetrics(msg string) {
 	// Process status messages should always be processed regardless of profile configuration
 	if strings.Contains(output, ptpProcessStatusIdentifier) {
 		if status, err := p.parsePTPStatus(output, fields); err == nil {
-			log.Debugf("ExtractMetrics: process status detected: process=%s config=%s status=%d", processName, configName, status)
+			log.Tracef("ExtractMetrics: process status detected: process=%s config=%s status=%d", processName, configName, status)
 			if status == PtpProcessDown {
 				p.processDownEvent(profileName, processName, ptpStats, ptp4lCfg.ProfileType)
 			}
@@ -225,7 +225,7 @@ func (p *PTPEventManager) ExtractMetrics(msg string) {
 			if interfaceName == "" {
 				return // don't do if iface not known
 			}
-			log.Debugf("ExtractMetrics: offset parsed: process=%s iface=%s offset=%.0f syncState=%s", processName, interfaceName, ptpOffset, syncState)
+			log.Tracef("ExtractMetrics: offset parsed: process=%s iface=%s offset=%.0f syncState=%s", processName, interfaceName, ptpOffset, syncState)
 			//  only ts2phc process will return actual interface name- allow all ts2phcprocess or iface in (master or  clock realtime)
 			if processName != ts2phcProcessName && !(interfaceName == master || interfaceName == ClockRealTime) {
 				return // only master and clock_realtime are supported

--- a/plugins/ptp_operator/metrics/registry.go
+++ b/plugins/ptp_operator/metrics/registry.go
@@ -242,7 +242,7 @@ func UpdateSyncStateMetrics(process, iface string, state ptp.SyncState) {
 		log.Errorf("wrong metrics are processed, ignoring interface %s with process %s", iface, process)
 		return
 	}
-	log.Debugf("UpdateSyncStateMetrics: process=%s iface=%s state=%s value=%.0f", process, iface, state, clockState)
+	log.Tracef("UpdateSyncStateMetrics: process=%s iface=%s state=%s value=%.0f", process, iface, state, clockState)
 	SyncState.With(prometheus.Labels{
 		"process": process, "node": ptpNodeName, "iface": iface}).Set(clockState)
 }

--- a/plugins/ptp_operator/ptp_operator_plugin.go
+++ b/plugins/ptp_operator/ptp_operator_plugin.go
@@ -518,9 +518,9 @@ func listenToSocket(wg *sync.WaitGroup) {
 }
 
 func processMessages(c net.Conn) {
-	log.Debugf("processMessages: new connection accepted from %v", c.RemoteAddr())
+	log.Tracef("processMessages: new connection accepted from %v", c.RemoteAddr())
 	<-aliasReady // wait until alias found and this is closed
-	log.Debug("processMessages: aliasReady unblocked, processing can begin")
+	log.Info("processMessages: aliasReady unblocked, processing can begin")
 	// Request a full state re-emit in a separate goroutine so the scanner
 	// can start reading immediately. The /emit-logs handler writes replay
 	// data back through the EventHandler's socket connection, which CEP
@@ -530,12 +530,12 @@ func processMessages(c net.Conn) {
 	// kernel buffer fills. The daemon's liveGate independently ensures no
 	// live data flows until replay completes, so async is safe.
 	if eventManager != nil {
-		log.Debug("processMessages: firing async TriggerLogs")
+		log.Trace("processMessages: firing async TriggerLogs")
 		go func() {
 			if err := eventManager.TriggerLogs(); err != nil {
 				log.Warnf("failed to trigger logs on new connection: %v", err)
 			} else {
-				log.Debug("processMessages: TriggerLogs completed successfully")
+				log.Trace("processMessages: TriggerLogs completed successfully")
 			}
 		}()
 	}
@@ -543,20 +543,20 @@ func processMessages(c net.Conn) {
 	for {
 		ok := scanner.Scan()
 		if !ok {
-			log.Debugf("processMessages: scanner returned false (conn closed or error), breaking")
+			log.Errorf("processMessages: scanner returned false (conn closed or error), breaking")
 			break
 		}
 		msg := scanner.Text()
 		if msg == restartCommand {
-			log.Debug("processMessages: received CMD RESTART")
+			log.Trace("processMessages: received CMD RESTART")
 			restartProcess("restart requested by daemon via socket")
 			return // unreachable after exec
 		}
 		if msg == liveStartCommand {
-			log.Debug("processMessages: received LIVE_START marker - live data follows")
+			log.Trace("processMessages: received LIVE_START marker - live data follows")
 			continue
 		}
-		log.Debugf("processMessages: dispatching to ExtractMetrics: %.120s", msg)
+		log.Tracef("processMessages: dispatching to ExtractMetrics: %.120s", msg)
 		eventManager.ExtractMetrics(msg)
 	}
 }


### PR DESCRIPTION
The observability logs introduced by the LIVE_START/replay-fix (PR #683)
use log.Debug, which fires at the default LOG_LEVEL=debug configured in
InitLogger(). This creates excessive log noise in normal operation.

Demote all new replay-fix debug logs from Debug to Trace so they remain
silent at the default debug level but are still available for deep
troubleshooting with LOG_LEVEL=trace.

Pre-existing logs that were inadvertently downgraded during the refactoring
are restored to their original levels (Info/Error).