### PR TITLE
[release-4.21] OCPBUGS-88287: handle CMD LIVE_START marker and add debug observability

### DIFF
--- a/plugins/ptp_operator/metrics/manager.go
+++ b/plugins/ptp_operator/metrics/manager.go
@@ -430,6 +430,8 @@ func (p *PTPEventManager) GenPTPEvent(ptpProfileName string, oStats *stats.Stats
 	}
 
 	lastClockState := oStats.LastSyncState()
+	log.Tracef("GenPTPEvent: profile=%s resource=%s offset=%d clockState=%s lastState=%s eventType=%s",
+		ptpProfileName, eventResourceName, ptpOffset, clockState, lastClockState, eventType)
 	threshold := p.PtpThreshold(ptpProfileName, false)
 	switch clockState {
 	case ptp.LOCKED:
@@ -805,12 +807,15 @@ func (p *PTPEventManager) SetInitalMetrics() {
 }
 
 func (p *PTPEventManager) TriggerLogs() error {
+	log.Tracef("TriggerLogs: calling %s", logsEndpoint)
 	client := &http.Client{Timeout: 5 * time.Second}
 	resp, err := client.Get(logsEndpoint)
 	if err != nil {
+		log.Tracef("TriggerLogs: request failed: %v", err)
 		return err
 	}
 	defer resp.Body.Close()
+	log.Tracef("TriggerLogs: response status=%s", resp.Status)
 	return nil
 }
 

--- a/plugins/ptp_operator/metrics/metrics.go
+++ b/plugins/ptp_operator/metrics/metrics.go
@@ -108,6 +108,7 @@ func (p *PTPEventManager) ExtractMetrics(msg string) {
 	}
 	processName := fields[processNameIndex]
 	configName := fields[configNameIndex]
+	log.Tracef("ExtractMetrics: process=%s config=%s msg=%.100s", processName, configName, msg)
 	// if log is having ts2phc then it will replace it with ptp4l
 	configName = strings.Replace(configName, ts2phcProcessName, ptp4lProcessName, 1)
 	ptp4lCfg := p.GetPTPConfig(types.ConfigName(configName))
@@ -121,6 +122,7 @@ func (p *PTPEventManager) ExtractMetrics(msg string) {
 	// Process status messages should always be processed regardless of profile configuration
 	if strings.Contains(output, ptpProcessStatusIdentifier) {
 		if status, err := p.parsePTPStatus(output, fields); err == nil {
+			log.Tracef("ExtractMetrics: process status detected: process=%s config=%s status=%d", processName, configName, status)
 			if status == PtpProcessDown {
 				p.processDownEvent(profileName, processName, ptpStats)
 			}
@@ -224,6 +226,7 @@ func (p *PTPEventManager) ExtractMetrics(msg string) {
 			if interfaceName == "" {
 				return // don't do if iface not known
 			}
+			log.Tracef("ExtractMetrics: offset parsed: process=%s iface=%s offset=%.0f syncState=%s", processName, interfaceName, ptpOffset, syncState)
 			//  only ts2phc process will return actual interface name- allow all ts2phcprocess or iface in (master or  clock realtime)
 			if processName != ts2phcProcessName && !(interfaceName == master || interfaceName == ClockRealTime) {
 				return // only master and clock_realtime are supported

--- a/plugins/ptp_operator/metrics/metrics_test.go
+++ b/plugins/ptp_operator/metrics/metrics_test.go
@@ -568,4 +568,125 @@ func Test_ExtractMetrics(t *testing.T) {
 			assert.Equal(tc.expectedEvent, ptpEventManager.GetMockEvent(), "Expected Event does not match\n%s", tc.String())
 		})
 	}
+
+	// OCPBUGS-85092 regression tests: prove that stale replay data (port role
+	// transition arriving after live offset) corrupts metrics and they do NOT
+	// self-recover. This documents WHY the live gate is essential — without it,
+	// a replayed FAULTY port role permanently poisons the clock state.
+	t.Run("ReplayThenLive_ClockStateCorruption", func(t *testing.T) {
+		assert := assert.New(t)
+		const lockedLine = "ptp4l[5000000.100]: [ptp4l.1.config] master offset 5 s2 freq -1000 path delay 100"
+		const stalePortRole = "ptp4l[4999999.000]: [ptp4l.1.config:4] port 1 (ens3f0): SLAVE to FAULTY on FAULT_DETECTED (FT_UNSPECIFIED)"
+		labels := map[string]string{"process": "ptp4l", "node": MYNODE, "iface": "ens3fx"}
+
+		// Reset shared config state from previous subtests
+		logPtp4lConfigDualFollower.Interfaces[0].UpdateRole(types.SLAVE)
+		s := ptpEventManager.GetStatsForInterface(types.ConfigName(logPtp4lConfigDualFollower.Name), types.IFace("master"))
+		s.SetRole(types.SLAVE)
+
+		// Step 1: Establish LOCKED state via live offset s2
+		metrics.SyncState.With(labels).Set(CLEANUP)
+		setLastSyncState("master", ptp.LOCKED, logPtp4lConfigDualFollower.Name)
+		ptpEventManager.ResetMockEvent()
+		ptpEventManager.ExtractMetrics(lockedLine)
+		assert.Equal(float64(types.LOCKED), testutil.ToFloat64(metrics.SyncState.With(labels)),
+			"step 1: live offset s2 should set SyncState to LOCKED")
+
+		// Step 2: Stale replay port role (SLAVE→FAULTY) corrupts the state
+		ptpEventManager.ResetMockEvent()
+		ptpEventManager.ExtractMetrics(stalePortRole)
+		assert.Equal(float64(types.HOLDOVER), testutil.ToFloat64(metrics.SyncState.With(labels)),
+			"step 2: stale SLAVE→FAULTY should corrupt SyncState to HOLDOVER")
+
+		// Step 3: Another live s2 offset does NOT recover to LOCKED because
+		// the port is now FAULTY — proving the corruption is permanent without
+		// the live gate preventing stale replay from arriving after live data.
+		ptpEventManager.ResetMockEvent()
+		ptpEventManager.ExtractMetrics(lockedLine)
+		assert.Equal(float64(types.HOLDOVER), testutil.ToFloat64(metrics.SyncState.With(labels)),
+			"step 3: HOLDOVER persists despite s2 offset — the bug: stale replay permanently poisons clock state")
+	})
+
+	t.Run("ReplayThenLive_PortRoleCorruption", func(t *testing.T) {
+		assert := assert.New(t)
+		const liveSlaveRole = "ptp4l[5000001.000]: [ptp4l.1.config:4] port 1 (ens3f0): UNCALIBRATED to SLAVE on MASTER_CLOCK_SELECTED"
+		const staleFaultyRole = "ptp4l[4999998.000]: [ptp4l.1.config:4] port 1 (ens3f0): SLAVE to FAULTY on FAULT_DETECTED (FT_UNSPECIFIED)"
+		roleLabels := map[string]string{"process": "ptp4l", "node": MYNODE, "iface": "ens3f0"}
+
+		// Reset: set to LISTENING so UNCALIBRATED→SLAVE triggers a role change
+		logPtp4lConfigDualFollower.Interfaces[0].UpdateRole(types.LISTENING)
+
+		// Step 1: Live port role → SLAVE
+		metrics.InterfaceRole.With(roleLabels).Set(CLEANUP)
+		ptpEventManager.ResetMockEvent()
+		ptpEventManager.ExtractMetrics(liveSlaveRole)
+		assert.Equal(float64(types.SLAVE), testutil.ToFloat64(metrics.InterfaceRole.With(roleLabels)),
+			"step 1: port role should be SLAVE")
+
+		// Step 2: Stale replay port role → FAULTY (corruption)
+		ptpEventManager.ResetMockEvent()
+		ptpEventManager.ExtractMetrics(staleFaultyRole)
+		assert.Equal(float64(types.FAULTY), testutil.ToFloat64(metrics.InterfaceRole.With(roleLabels)),
+			"step 2: stale replay SLAVE→FAULTY corrupts port role to FAULTY")
+
+		// Port roles only change on state-transition events — there is no
+		// continuous refresh like offset lines. The FAULTY role persists
+		// indefinitely until a real port state transition occurs. This is
+		// why the live gate is critical: it prevents this scenario entirely.
+	})
+
+	// With the live gate fix: replay arrives FIRST, then live data overwrites it.
+	// This is the correct ordering enforced by the gate, proving metrics end up
+	// in the correct LOCKED/SLAVE state.
+	t.Run("WithLiveGate_ReplayThenLive_MetricsCorrect", func(t *testing.T) {
+		assert := assert.New(t)
+		syncLabels := map[string]string{"process": "ptp4l", "node": MYNODE, "iface": "ens3fx"}
+		roleLabels := map[string]string{"process": "ptp4l", "node": MYNODE, "iface": "ens3f0"}
+
+		// Reset shared config state from previous subtests
+		logPtp4lConfigDualFollower.Interfaces[0].UpdateRole(types.SLAVE)
+		metrics.SyncState.With(syncLabels).Set(CLEANUP)
+		metrics.InterfaceRole.With(roleLabels).Set(CLEANUP)
+
+		// --- Replay phase (arrives first, gate blocks live data) ---
+
+		// Replay: stale FAULTY port role from before recovery
+		setLastSyncState("master", ptp.LOCKED, logPtp4lConfigDualFollower.Name)
+		ptpEventManager.ResetMockEvent()
+		ptpEventManager.ExtractMetrics(
+			"ptp4l[0.000]: [ptp4l.1.config:4] port 1 (ens3f0): SLAVE to FAULTY on FAULT_DETECTED (FT_UNSPECIFIED)")
+
+		// After replay, port is FAULTY and clock is HOLDOVER — stale state
+		assert.Equal(float64(types.FAULTY), testutil.ToFloat64(metrics.InterfaceRole.With(roleLabels)),
+			"after replay: port role is stale FAULTY")
+		assert.Equal(float64(types.HOLDOVER), testutil.ToFloat64(metrics.SyncState.With(syncLabels)),
+			"after replay: clock state is HOLDOVER")
+
+		// --- CMD LIVE_START (gate opens, live data follows) ---
+		// In real CEP, CMD LIVE_START is just skipped (continue) — no metric effect.
+
+		// --- Live phase: port recovers through standard ptp4l sequence ---
+		// FAULTY → LISTENING → UNCALIBRATED → SLAVE, then LOCKED offset
+
+		ptpEventManager.ResetMockEvent()
+		ptpEventManager.ExtractMetrics(
+			"ptp4l[10.000]: [ptp4l.1.config:4] port 1 (ens3f0): FAULTY to LISTENING on INIT_COMPLETE")
+
+		ptpEventManager.ResetMockEvent()
+		ptpEventManager.ExtractMetrics(
+			"ptp4l[10.100]: [ptp4l.1.config:4] port 1 (ens3f0): LISTENING to UNCALIBRATED on RS_SLAVE")
+
+		ptpEventManager.ResetMockEvent()
+		ptpEventManager.ExtractMetrics(
+			"ptp4l[10.200]: [ptp4l.1.config:4] port 1 (ens3f0): UNCALIBRATED to SLAVE on MASTER_CLOCK_SELECTED")
+		assert.Equal(float64(types.SLAVE), testutil.ToFloat64(metrics.InterfaceRole.With(roleLabels)),
+			"after live port recovery: port role is SLAVE")
+
+		// Live: first offset after SLAVE recovery triggers LOCKED
+		ptpEventManager.ResetMockEvent()
+		ptpEventManager.ExtractMetrics(
+			"ptp4l[11.000]: [ptp4l.1.config] master offset 3 s2 freq -998 path delay 99")
+		assert.Equal(float64(types.LOCKED), testutil.ToFloat64(metrics.SyncState.With(syncLabels)),
+			"after live offset s2: SyncState is LOCKED (correct final state)")
+	})
 }

--- a/plugins/ptp_operator/metrics/registry.go
+++ b/plugins/ptp_operator/metrics/registry.go
@@ -230,6 +230,7 @@ func UpdateSyncStateMetrics(process, iface string, state ptp.SyncState) {
 		log.Errorf("wrong metrics are processed, ignoring interface %s with process %s", iface, process)
 		return
 	}
+	log.Tracef("UpdateSyncStateMetrics: process=%s iface=%s state=%s value=%.0f", process, iface, state, clockState)
 	SyncState.With(prometheus.Labels{
 		"process": process, "node": ptpNodeName, "iface": iface}).Set(clockState)
 }

--- a/plugins/ptp_operator/ptp_operator_plugin.go
+++ b/plugins/ptp_operator/ptp_operator_plugin.go
@@ -50,13 +50,9 @@ import (
 const (
 	eventSocket  = "/cloud-native/events.sock"
 	ptpConfigDir = "/var/run/"
-	// restartCommand is the control command sent by linuxptp-daemon on the event
-	// socket to request a sidecar restart. The CMD prefix distinguishes it from
-	// process log lines (which always start with a process name like ptp4l, phc2sys).
-	restartCommand = "CMD RESTART"
 	// liveStartCommand is sent by linuxptp-daemon on each ptp4l process connection
 	// after the replay gate opens, indicating that all subsequent data is live.
-	liveStartCommand = "CMD LIVE_START"
+	liveStartCommand   = "CMD LIVE_START"
 	phc2sysProcessName = "phc2sys"
 	ptp4lProcessName   = "ptp4l"
 	ts2PhcProcessName  = "ts2phc"

--- a/plugins/ptp_operator/ptp_operator_plugin.go
+++ b/plugins/ptp_operator/ptp_operator_plugin.go
@@ -48,8 +48,15 @@ import (
 )
 
 const (
-	eventSocket        = "/cloud-native/events.sock"
-	ptpConfigDir       = "/var/run/"
+	eventSocket  = "/cloud-native/events.sock"
+	ptpConfigDir = "/var/run/"
+	// restartCommand is the control command sent by linuxptp-daemon on the event
+	// socket to request a sidecar restart. The CMD prefix distinguishes it from
+	// process log lines (which always start with a process name like ptp4l, phc2sys).
+	restartCommand = "CMD RESTART"
+	// liveStartCommand is sent by linuxptp-daemon on each ptp4l process connection
+	// after the replay gate opens, indicating that all subsequent data is live.
+	liveStartCommand = "CMD LIVE_START"
 	phc2sysProcessName = "phc2sys"
 	ptp4lProcessName   = "ptp4l"
 	ts2PhcProcessName  = "ts2phc"
@@ -666,13 +673,20 @@ func listenToSocket(wg *sync.WaitGroup) {
 
 func processMessages(c net.Conn) {
 	// Request a full state re-emit in a separate goroutine so the scanner
-	// can start reading immediately. TriggerLogs writes emit data back through
-	// this same socket connection; if we block here waiting for the HTTP response,
-	// nobody reads the socket, the kernel buffer fills, and the emit handler blocks.
+	// can start reading immediately. The /emit-logs handler writes replay
+	// data back through the EventHandler's socket connection, which CEP
+	// accepts as a separate processMessages goroutine. If TriggerLogs blocks
+	// here, that goroutine's TriggerLogs creates a recursive write-back to
+	// a connection whose reader is stuck in TriggerLogs — deadlock once the
+	// kernel buffer fills. The daemon's liveGate independently ensures no
+	// live data flows until replay completes, so async is safe.
 	if eventManager != nil {
+		log.Trace("processMessages: firing async TriggerLogs")
 		go func() {
 			if err := eventManager.TriggerLogs(); err != nil {
 				log.Warnf("failed to trigger logs on new connection: %v", err)
+			} else {
+				log.Trace("processMessages: TriggerLogs completed successfully")
 			}
 		}()
 	}
@@ -680,10 +694,14 @@ func processMessages(c net.Conn) {
 	for {
 		ok := scanner.Scan()
 		if !ok {
-			log.Error("error reading socket input, retrying")
+			log.Errorf("processMessages: scanner returned false (conn closed or error), breaking")
 			break
 		}
 		msg := scanner.Text()
+		if msg == liveStartCommand {
+			log.Trace("processMessages: received LIVE_START marker - live data follows")
+			continue
+		}
 		eventManager.ExtractMetrics(msg)
 	}
 }

--- a/plugins/ptp_operator/ptp_operator_plugin_test.go
+++ b/plugins/ptp_operator/ptp_operator_plugin_test.go
@@ -21,11 +21,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net"
+	"net/http"
 	"os"
 	"path"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	v2 "github.com/cloudevents/sdk-go/v2"
 	"github.com/google/uuid"
@@ -402,6 +405,217 @@ func buildEvent(node string, source ptpEvent.EventResource, eventType ptpEvent.E
 	e.SetSource(fmt.Sprintf("/cluster/node/%s%s", node, string(source)))
 	e.SetType(string(eventType))
 	return e
+}
+
+// startMockLogsServer starts a minimal HTTP server on the logsEndpoint port
+// (8081) so that eventManager.TriggerLogs() succeeds during tests.
+// Returns a cleanup function that shuts down the server.
+func startMockLogsServer(t *testing.T) func() {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/emit-logs", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	const mockLogsAddr = "127.0.0.1:8081"
+	srv := &http.Server{Addr: mockLogsAddr, Handler: mux}
+	var ln net.Listener
+	var err error
+	for i := 0; i < 10; i++ {
+		ln, err = net.Listen("tcp", mockLogsAddr)
+		if err == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("failed to listen on %s for mock logs server: %v", mockLogsAddr, err)
+	}
+	go func() { _ = srv.Serve(ln) }()
+	return func() { _ = srv.Close() }
+}
+
+// setupProcessMessages prepares the globals that processMessages depends on.
+// aliasReady is returned already closed so processMessages doesn't block.
+// eventManager is configured in mock-test mode.
+func setupProcessMessages(t *testing.T) func() {
+	t.Helper()
+	oldAliasReady := aliasReady
+	oldEventManager := eventManager
+
+	aliasReady = make(chan struct{})
+	close(aliasReady)
+
+	scCfg := &common.SCConfiguration{}
+	eventManager = metrics.NewPTPEventManager(resourcePrefix, pubsubTypes, nodeName, scCfg)
+	eventManager.MockTest(true)
+
+	return func() {
+		aliasReady = oldAliasReady
+		eventManager = oldEventManager
+	}
+}
+
+func TestProcessMessages_LiveStartSkipped(t *testing.T) {
+	cleanup := startMockLogsServer(t)
+	defer cleanup()
+	restore := setupProcessMessages(t)
+	defer restore()
+
+	serverConn, clientConn := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		processMessages(serverConn)
+		close(done)
+	}()
+
+	_, err := fmt.Fprintf(clientConn, "%s\n", liveStartCommand)
+	assert.NoError(t, err)
+	_ = clientConn.Close()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("processMessages did not return after CMD LIVE_START + EOF")
+	}
+}
+
+func TestProcessMessages_LiveStartBetweenRegularMessages(t *testing.T) {
+	cleanup := startMockLogsServer(t)
+	defer cleanup()
+	restore := setupProcessMessages(t)
+	defer restore()
+
+	serverConn, clientConn := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		processMessages(serverConn)
+		close(done)
+	}()
+
+	msgs := []string{
+		"ptp4l[123.456]: [ptp4l.0.config] master offset  5 s2 freq -1000 path delay 100",
+		liveStartCommand,
+		"ptp4l[123.457]: [ptp4l.0.config] master offset  3 s2 freq  -998 path delay  99",
+		liveStartCommand,
+		"phc2sys[123.458]: [ptp4l.0.config] CLOCK_REALTIME phc offset  10 s2 freq -500 delay 200",
+	}
+	for _, m := range msgs {
+		_, err := fmt.Fprintf(clientConn, "%s\n", m)
+		assert.NoError(t, err)
+	}
+	_ = clientConn.Close()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("processMessages did not return after mixed LIVE_START and regular messages")
+	}
+}
+
+func TestProcessMessages_TriggerLogsFailureNonBlocking(t *testing.T) {
+	// No mock HTTP server → TriggerLogs will fail, but since it's async
+	// the scanner should still process messages on this connection.
+	restore := setupProcessMessages(t)
+	defer restore()
+
+	serverConn, clientConn := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		processMessages(serverConn)
+		close(done)
+	}()
+
+	// Even though TriggerLogs fails (no HTTP server), processMessages must
+	// still read from the connection because TriggerLogs is async.
+	_, err := fmt.Fprintf(clientConn, "%s\n", liveStartCommand)
+	assert.NoError(t, err)
+	_ = clientConn.Close()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("processMessages should still process messages when TriggerLogs fails async")
+	}
+}
+
+func TestProcessMessages_MultipleLiveStartOnly(t *testing.T) {
+	cleanup := startMockLogsServer(t)
+	defer cleanup()
+	restore := setupProcessMessages(t)
+	defer restore()
+
+	serverConn, clientConn := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		processMessages(serverConn)
+		close(done)
+	}()
+
+	for i := 0; i < 5; i++ {
+		_, err := fmt.Fprintf(clientConn, "%s\n", liveStartCommand)
+		assert.NoError(t, err)
+	}
+	_ = clientConn.Close()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("processMessages did not return after multiple CMD LIVE_START messages")
+	}
+}
+
+func TestLiveStartCommand_ConstantValue(t *testing.T) {
+	assert.Equal(t, "CMD LIVE_START", liveStartCommand)
+	assert.NotEqual(t, restartCommand, liveStartCommand,
+		"LIVE_START and RESTART must be distinct commands")
+	assert.True(t, strings.HasPrefix(liveStartCommand, "CMD "),
+		"control commands should use CMD prefix to distinguish from log lines")
+}
+
+func TestProcessMessages_AliasReadyGating(t *testing.T) {
+	cleanup := startMockLogsServer(t)
+	defer cleanup()
+
+	oldAliasReady := aliasReady
+	oldEventManager := eventManager
+	defer func() {
+		aliasReady = oldAliasReady
+		eventManager = oldEventManager
+	}()
+
+	aliasReady = make(chan struct{}) // NOT closed — processMessages should block
+	scCfg := &common.SCConfiguration{}
+	eventManager = metrics.NewPTPEventManager(resourcePrefix, pubsubTypes, nodeName, scCfg)
+	eventManager.MockTest(true)
+
+	serverConn, clientConn := net.Pipe()
+	defer func() { _ = clientConn.Close() }()
+
+	started := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		close(started)
+		processMessages(serverConn)
+		close(done)
+	}()
+	<-started
+
+	select {
+	case <-done:
+		t.Fatal("processMessages should block while aliasReady is open")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	close(aliasReady)
+
+	_, _ = fmt.Fprintf(clientConn, "%s\n", liveStartCommand)
+	_ = clientConn.Close()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("processMessages did not unblock after aliasReady closed")
+	}
 }
 
 func getMockOverrideFn() func(e v2.Event, d *channel.DataChan) error {

--- a/plugins/ptp_operator/ptp_operator_plugin_test.go
+++ b/plugins/ptp_operator/ptp_operator_plugin_test.go
@@ -560,8 +560,6 @@ func TestProcessMessages_MultipleLiveStartOnly(t *testing.T) {
 
 func TestLiveStartCommand_ConstantValue(t *testing.T) {
 	assert.Equal(t, "CMD LIVE_START", liveStartCommand)
-	assert.NotEqual(t, restartCommand, liveStartCommand,
-		"LIVE_START and RESTART must be distinct commands")
 	assert.True(t, strings.HasPrefix(liveStartCommand, "CMD "),
 		"control commands should use CMD prefix to distinguish from log lines")
 }

--- a/plugins/ptp_operator/ptp_operator_plugin_test.go
+++ b/plugins/ptp_operator/ptp_operator_plugin_test.go
@@ -435,22 +435,16 @@ func startMockLogsServer(t *testing.T) func() {
 }
 
 // setupProcessMessages prepares the globals that processMessages depends on.
-// aliasReady is returned already closed so processMessages doesn't block.
 // eventManager is configured in mock-test mode.
 func setupProcessMessages(t *testing.T) func() {
 	t.Helper()
-	oldAliasReady := aliasReady
 	oldEventManager := eventManager
-
-	aliasReady = make(chan struct{})
-	close(aliasReady)
 
 	scCfg := &common.SCConfiguration{}
 	eventManager = metrics.NewPTPEventManager(resourcePrefix, pubsubTypes, nodeName, scCfg)
 	eventManager.MockTest(true)
 
 	return func() {
-		aliasReady = oldAliasReady
 		eventManager = oldEventManager
 	}
 }
@@ -570,52 +564,6 @@ func TestLiveStartCommand_ConstantValue(t *testing.T) {
 		"LIVE_START and RESTART must be distinct commands")
 	assert.True(t, strings.HasPrefix(liveStartCommand, "CMD "),
 		"control commands should use CMD prefix to distinguish from log lines")
-}
-
-func TestProcessMessages_AliasReadyGating(t *testing.T) {
-	cleanup := startMockLogsServer(t)
-	defer cleanup()
-
-	oldAliasReady := aliasReady
-	oldEventManager := eventManager
-	defer func() {
-		aliasReady = oldAliasReady
-		eventManager = oldEventManager
-	}()
-
-	aliasReady = make(chan struct{}) // NOT closed — processMessages should block
-	scCfg := &common.SCConfiguration{}
-	eventManager = metrics.NewPTPEventManager(resourcePrefix, pubsubTypes, nodeName, scCfg)
-	eventManager.MockTest(true)
-
-	serverConn, clientConn := net.Pipe()
-	defer func() { _ = clientConn.Close() }()
-
-	started := make(chan struct{})
-	done := make(chan struct{})
-	go func() {
-		close(started)
-		processMessages(serverConn)
-		close(done)
-	}()
-	<-started
-
-	select {
-	case <-done:
-		t.Fatal("processMessages should block while aliasReady is open")
-	case <-time.After(200 * time.Millisecond):
-	}
-
-	close(aliasReady)
-
-	_, _ = fmt.Fprintf(clientConn, "%s\n", liveStartCommand)
-	_ = clientConn.Close()
-
-	select {
-	case <-done:
-	case <-time.After(5 * time.Second):
-		t.Fatal("processMessages did not unblock after aliasReady closed")
-	}
 }
 
 func getMockOverrideFn() func(e v2.Event, d *channel.DataChan) error {


### PR DESCRIPTION
Cherry-pick of cloud-event-proxy PR #683 to release-4.21.

Backport of OCPBUGS-85092 for 4.21 (clone: OCPBUGS-88279).

## Changes

- Add `liveStartCommand` constant and skip `CMD LIVE_START` in `processMessages` scanner
- Move `log.Infof("DEBUG ...")` to `log.Debugf()` then demote to `log.Tracef()` across plugin and metrics
- Add debug/trace logging to `processMessages`, `TriggerLogs`, `ExtractMetrics`, `UpdateSyncStateMetrics`, `GenPTPEvent`
- Add OCPBUGS-85092 regression tests proving stale replay corrupts metrics
- Bind mock logs server to loopback (127.0.0.1:8081) in tests

Conflicts resolved:
- `plugins/ptp_operator/ptp_operator_plugin.go`: Dropped `aliasReady` gating and `restartProcess` CMD RESTART handler (not in 4.21); kept `CMD LIVE_START` handler
- `plugins/ptp_operator/metrics/metrics_test.go`: Dropped `lastOverallGMState` tests (not in 4.21); kept replay corruption regression tests