### PR TITLE
[release-4.22] OCPBUGS-88703: T-BC CLOCK_REALTIME stuck at FREERUN due to dual-publisher conflict in ParseTBCLogs and extractRegularMetrics

### DIFF
--- a/plugins/ptp_operator/metrics/logparser.go
+++ b/plugins/ptp_operator/metrics/logparser.go
@@ -501,24 +501,16 @@ func (p *PTPEventManager) ParseTBCLogs(processName, configName, output string, f
 	// when ptp4l updates it in the T-BC mode
 	UpdateSyncStateMetrics(ts2phcProcessName, aliasValue, ptpSyncState)
 
-	// if there is phc2sys ooptions enabled then when the clock is FREERUN annouce OSCLOCK as FREERUN
-	if clockState.State == ptp.FREERUN {
-		// loop thourgh eventManager.PtpConfigMapUpdates.TBCProfiles
-		// message tag for ptp4l.1.config with T-BC-Profile but T-BC is reporting from ts2phc.0.conifg
-		// so clock_realtime is not assigned to same config ?
-		cStats, osStatsOK := ptpStats[ClockRealTime]
-		if !osStatsOK || cStats.LastSyncState() == ptp.FREERUN {
-			// ClockRealTime stats not available, nothing to publish or already  in FREERUN
-			return
-		}
-		if p.mock {
-			p.mockEvent = []ptp.EventType{ptp.OsClockSyncStateChange}
-			log.Infof("PublishEvent state=%s, ptpOffset=%d, source=%s, eventType=%s", ptp.FREERUN, FreeRunOffsetValue, ClockRealTime, ptp.OsClockSyncStateChange)
-			return
-		}
-		p.GenPTPEvent(configName, cStats, ClockRealTime, FreeRunOffsetValue, ptp.FREERUN, ptp.OsClockSyncStateChange)
-		UpdateSyncStateMetrics(phc2sysProcessName, ClockRealTime, ptp.FREERUN)
-	}
+	// CLOCK_REALTIME state is managed exclusively by phc2sys log processing.
+	// When the T-BC chain loses its upstream source (FREERUN), the PHC will
+	// eventually drift, phc2sys will detect the growing offset, and
+	// CLOCK_REALTIME will transition to FREERUN naturally through the
+	// threshold-based mechanism in extractRegularMetrics.
+	//
+	// Forcing CLOCK_REALTIME to FREERUN here based on the T-BC state creates
+	// a dual-publisher conflict: ParseTBCLogs overrides CLOCK_REALTIME to
+	// FREERUN while phc2sys reports LOCKED, causing rapid oscillation and
+	// incorrect state visible to event consumers.
 }
 
 // ParseDPLLLogs ... parse logs for various events

--- a/plugins/ptp_operator/metrics/logparser.go
+++ b/plugins/ptp_operator/metrics/logparser.go
@@ -501,16 +501,12 @@ func (p *PTPEventManager) ParseTBCLogs(processName, configName, output string, f
 	// when ptp4l updates it in the T-BC mode
 	UpdateSyncStateMetrics(ts2phcProcessName, aliasValue, ptpSyncState)
 
-	// CLOCK_REALTIME state is managed exclusively by phc2sys log processing.
-	// When the T-BC chain loses its upstream source (FREERUN), the PHC will
-	// eventually drift, phc2sys will detect the growing offset, and
-	// CLOCK_REALTIME will transition to FREERUN naturally through the
-	// threshold-based mechanism in extractRegularMetrics.
-	//
-	// Forcing CLOCK_REALTIME to FREERUN here based on the T-BC state creates
-	// a dual-publisher conflict: ParseTBCLogs overrides CLOCK_REALTIME to
-	// FREERUN while phc2sys reports LOCKED, causing rapid oscillation and
-	// incorrect state visible to event consumers.
+	// Do not set CLOCK_REALTIME / emit E3 (OsClockSyncStateChange) here.
+	// E3 is published exclusively from the phc2sys log path in ExtractMetrics,
+	// where it is derived as worst_of(phc2sys_state, E1_state) per O-RAN
+	// O-Cloud API v04.00 Table 37. When T-BC enters FREERUN, the E1 state
+	// change is picked up on the next phc2sys sample and E3 is downgraded
+	// accordingly.
 }
 
 // ParseDPLLLogs ... parse logs for various events

--- a/plugins/ptp_operator/metrics/manager.go
+++ b/plugins/ptp_operator/metrics/manager.go
@@ -499,7 +499,12 @@ func (p *PTPEventManager) GenPTPEvent(ptpProfileName string, oStats *stats.Stats
 		return
 	case ptp.FREERUN:
 		oStats.SetLastSyncState(clockState)
-		if lastClockState != ptp.HOLDOVER {
+		// For E1 (PtpStateChange), HOLDOVER→FREERUN is handled by the holdover
+		// timer's direct PublishEvent call, so skip here to avoid double-publish.
+		// For E3 (OsClockSyncStateChange), the holdover timer no longer publishes
+		// E3 directly — the phc2sys path is the single E3 publisher — so allow
+		// the HOLDOVER→FREERUN transition through.
+		if lastClockState != ptp.HOLDOVER || eventType == ptp.OsClockSyncStateChange {
 			if lastClockState != ptp.FREERUN { // don't send event if last event was freerun
 				log.Infof("publishing event for (profile %s) %s with last state %s and current clock state %s and offset %d for ( Max/Min Threshold %d/%d )",
 					ptpProfileName, eventResourceName, lastClockState, clockState, ptpOffset, threshold.MaxOffsetThreshold, threshold.MinOffsetThreshold)

--- a/plugins/ptp_operator/metrics/metrics.go
+++ b/plugins/ptp_operator/metrics/metrics.go
@@ -267,14 +267,10 @@ func (p *PTPEventManager) ExtractMetrics(msg string) {
 			// TODO: understand if the config is GM /BC /OC
 			switch interfaceName { //note: this is not  interface type
 			case ClockRealTime: // CLOCK_REALTIME is active slave interface
-				// T-BC-STATUS is authoritative for overall sync state. When T-BC
-				// reports FREERUN, suppress phc2sys LOCKED reports to prevent
-				// os-clock-sync-state-change event flip-flop during startup.
-				if ptp4lCfg.ProfileType == ptp4lconf.TBC {
-					if tbcStats, ok := ptpStats[stats.TBCMainClockName]; ok && tbcStats.LastSyncState() == ptp.FREERUN {
-						syncState = ptp.FREERUN
-					}
-				}
+				// CLOCK_REALTIME state is determined solely by phc2sys offset vs
+				// threshold. Do not override syncState based on T-BC FSM state;
+				// doing so creates a dual-publisher conflict where phc2sys reports
+				// LOCKED while T-BC forces FREERUN, causing event oscillation.
 				//  for HA we can not rely on master ;since there will be 2 or more leaders; this condition will be skipped
 				// ptpStats clock realtime has its own stats objects
 				//TODO: NEED TO VISIT THIS LOGIC FOR UNASSISTED BOUNDARY CLOCK

--- a/plugins/ptp_operator/metrics/metrics.go
+++ b/plugins/ptp_operator/metrics/metrics.go
@@ -267,13 +267,23 @@ func (p *PTPEventManager) ExtractMetrics(msg string) {
 			// TODO: understand if the config is GM /BC /OC
 			switch interfaceName { //note: this is not  interface type
 			case ClockRealTime: // CLOCK_REALTIME is active slave interface
-				// CLOCK_REALTIME state is determined solely by phc2sys offset vs
-				// threshold. Do not override syncState based on T-BC FSM state;
-				// doing so creates a dual-publisher conflict where phc2sys reports
-				// LOCKED while T-BC forces FREERUN, causing event oscillation.
+				// O-RAN O-Cloud API v04.00 Table 37: E3 = worst_of(phc2sys_state, E1_state).
+				// phc2sys is the single publisher — but if the upstream PHC is not
+				// traceable (E1 != LOCKED), E3 cannot be LOCKED even when
+				// phc2sys offset is within threshold.
+				// Skip for T-GM profiles (masterOffsetSource == ts2phc): T-GM uses
+				// the lastOverallGMState mechanism above instead.
+				if masterOffsetSource != ts2phcProcessName {
+					mainClockKey := ptpStats.GetMainClockName()
+					if e1Stat, ok := ptpStats[mainClockKey]; ok {
+						e1State := e1Stat.LastSyncState()
+						if e1State == ptp.FREERUN || e1State == ptp.HOLDOVER {
+							syncState = OverallState(syncState, e1State)
+						}
+					}
+				}
 				//  for HA we can not rely on master ;since there will be 2 or more leaders; this condition will be skipped
 				// ptpStats clock realtime has its own stats objects
-				//TODO: NEED TO VISIT THIS LOGIC FOR UNASSISTED BOUNDARY CLOCK
 				if r, ok := ptpStats[master]; ok && r.Role() == types.SLAVE { // publish event only if the master role is active
 					// when related slave is faulty the holdover will make clock clear time as FREERUN
 					p.GenPTPEvent(profileName, ptpStats[ClockRealTime], interfaceName, int64(ptpOffset), syncState, ptp.OsClockSyncStateChange)

--- a/plugins/ptp_operator/metrics/ptp4lParse.go
+++ b/plugins/ptp_operator/metrics/ptp4lParse.go
@@ -154,9 +154,7 @@ func (p *PTPEventManager) ParsePTP4l(processName, configName, profileName, outpu
 
 func (p *PTPEventManager) startHoldoverTimer(
 	ptpOpts *ptpConfig.PtpProcessOpts, configName, profileName, alias string) {
-	if ptpOpts != nil {
-		p.maybePublishOSClockSyncStateChangeEvent(ptpOpts, configName, profileName)
-	} else {
+	if ptpOpts == nil {
 		log.Warnf("holdover timer: PtpProcessOpts missing for profile=%s config=%s (available=%v), continuing with default threshold",
 			profileName, configName, p.PtpConfigMapUpdates.PtpProcessOpts)
 	}
@@ -167,11 +165,11 @@ func (p *PTPEventManager) startHoldoverTimer(
 	threshold := p.PtpThreshold(profileName, true)
 	log.Infof("starting holdover timer: profile=%s config=%s alias=%s timeout=%ds",
 		profileName, configName, alias, threshold.HoldOverTimeout)
-	go handleHoldOverState(p, ptpOpts, configName, profileName, threshold.HoldOverTimeout, alias, threshold.Close)
+	go handleHoldOverState(p, configName, profileName, threshold.HoldOverTimeout, alias, threshold.Close)
 }
 
 func handleHoldOverState(ptpManager *PTPEventManager,
-	ptpOpts *ptpConfig.PtpProcessOpts, configName,
+	configName,
 	ptpProfileName string, holdoverTimeout int64,
 	ptpIFace string, c chan struct{}) {
 	defer func() {
@@ -208,71 +206,5 @@ func handleHoldOverState(ptpManager *PTPEventManager,
 		mStats.SetLastSyncState(ptp.FREERUN)
 		ptpManager.PublishEvent(ptp.FREERUN, mStats.LastOffset(), masterResource, ptp.PtpStateChange)
 		UpdateSyncStateMetrics(mStats.ProcessName(), alias, ptp.FREERUN)
-		// don't check of os clock sync state if phc2 not enabled
-		ptpManager.maybePublishOSClockSyncStateChangeEvent(ptpOpts, configName, ptpProfileName)
-	}
-}
-
-func (p *PTPEventManager) maybePublishOSClockSyncStateChangeEvent(
-	ptpOpts *ptpConfig.PtpProcessOpts, configName, ptpProfileName string) {
-	if ptpOpts == nil {
-		log.Error("No profile found in configuration; OS clock sync state change event not published.")
-		return
-	}
-
-	// Already in a synced state, check if we need to emit FREERUN event
-	publish := false
-	haProfile, haProfiles := p.ListHAProfilesWith(ptpProfileName)
-
-	if ptpOpts.Phc2SysEnabled() {
-		publish = true
-	} else if len(haProfiles) > 0 { // Check if we are in a HA profile
-		haConfigName := p.GetPTPConfigByProfile(haProfile)
-
-		// Proceed only if we were able to retrieve the system clock config
-		if len(haConfigName) > 0 {
-			configName = haConfigName // change to phc2sys config name
-			for _, hProfile := range haProfiles {
-				if hProfile == ptpProfileName {
-					continue // Skip current (already known to be faulty)
-				}
-				checkConfig := p.GetPTPConfigByProfile(hProfile)
-				if len(checkConfig) == 0 {
-					continue
-				}
-
-				if haStats, exists := p.GetStats(types.ConfigName(checkConfig))[master]; exists && haStats.Role() == types.SLAVE {
-					log.Infof("HA profile %s is still in SLAVE state, not setting CLOCK_REALTIME to FREERUN", hProfile)
-					return
-				}
-			}
-			// If all other HA profiles are non-SLAVE or missing, we can publish
-			publish = true
-			// set to the one that is in the HA profile
-			ptpProfileName = haProfile
-		} else {
-			return // No HA profile found, nothing to publish
-		}
-	}
-
-	ptpStats := p.GetStats(types.ConfigName(configName))
-	cStats, ok := ptpStats[ClockRealTime]
-	if !ok {
-		// ClockRealTime stats not available, nothing to publish
-		return
-	}
-	if cStats.LastSyncState() == ptp.FREERUN {
-		// Already in FREERUN, no need to publish again
-		return
-	}
-
-	if publish {
-		if p.mock {
-			p.mockEvent = []ptp.EventType{ptp.OsClockSyncStateChange}
-			log.Infof("PublishEvent state=%s, ptpOffset=%d, source=%s, eventType=%s", ptp.FREERUN, FreeRunOffsetValue, ClockRealTime, ptp.OsClockSyncStateChange)
-			return
-		}
-		p.GenPTPEvent(ptpProfileName, cStats, ClockRealTime, FreeRunOffsetValue, ptp.FREERUN, ptp.OsClockSyncStateChange)
-		UpdateSyncStateMetrics(phc2sysProcessName, ClockRealTime, ptp.FREERUN)
 	}
 }

--- a/plugins/ptp_operator/metrics/ptp4lParse_test.go
+++ b/plugins/ptp_operator/metrics/ptp4lParse_test.go
@@ -41,7 +41,7 @@ func TestHandleHoldOverStateExpiryTransitionsToFreerun(t *testing.T) {
 	ptpStats[master].SetLastSyncState(ptp.HOLDOVER)
 
 	closeCh := make(chan struct{})
-	go handleHoldOverState(mgr, nil, configName, profileName, 1, "ens5fx", closeCh)
+	go handleHoldOverState(mgr, configName, profileName, 1, "ens5fx", closeCh)
 	time.Sleep(1500 * time.Millisecond)
 
 	assert.Equal(t, ptp.FREERUN, ptpStats[master].LastSyncState())
@@ -69,7 +69,7 @@ func TestHandleHoldOverStateFaultHoldoverExpiry(t *testing.T) {
 	ptpStats[master].SetLastSyncState(ptp.HOLDOVER)
 
 	closeCh := make(chan struct{})
-	go handleHoldOverState(mgr, nil, configName, profileName, 1, "ens3fx", closeCh)
+	go handleHoldOverState(mgr, configName, profileName, 1, "ens3fx", closeCh)
 	time.Sleep(1500 * time.Millisecond)
 
 	assert.Equal(t, ptp.FREERUN, ptpStats[master].LastSyncState())
@@ -90,7 +90,7 @@ func TestHandleHoldOverStateCancelled(t *testing.T) {
 
 	closeCh := make(chan struct{})
 	close(closeCh)
-	go handleHoldOverState(mgr, nil, configName, testProfileName, 1, "ens5fx", closeCh)
+	go handleHoldOverState(mgr, configName, testProfileName, 1, "ens5fx", closeCh)
 	time.Sleep(200 * time.Millisecond)
 
 	assert.Equal(t, ptp.HOLDOVER, ptpStats[master].LastSyncState())
@@ -110,7 +110,7 @@ func TestHandleHoldOverStateExpiryNoOpWhenNotHoldover(t *testing.T) {
 	ptpStats[master].SetLastSyncState(ptp.LOCKED)
 
 	closeCh := make(chan struct{})
-	go handleHoldOverState(mgr, nil, configName, testProfileName, 1, "ens5fx", closeCh)
+	go handleHoldOverState(mgr, configName, testProfileName, 1, "ens5fx", closeCh)
 	time.Sleep(1500 * time.Millisecond)
 
 	assert.Equal(t, ptp.LOCKED, ptpStats[master].LastSyncState())
@@ -172,7 +172,7 @@ func TestSlaveToMasterHoldoverTimerRecovery(t *testing.T) {
 	assert.Equal(t, ptp.HOLDOVER, ptpStats[master].LastSyncState())
 
 	closeCh := make(chan struct{})
-	go handleHoldOverState(mgr, nil, configName, profileName, 1, "ens5fx", closeCh)
+	go handleHoldOverState(mgr, configName, profileName, 1, "ens5fx", closeCh)
 	time.Sleep(1500 * time.Millisecond)
 	assert.Equal(t, ptp.FREERUN, ptpStats[master].LastSyncState())
 }

--- a/plugins/ptp_operator/metrics/tbc_test.go
+++ b/plugins/ptp_operator/metrics/tbc_test.go
@@ -345,6 +345,88 @@ func TestTBCFaultyPortSpuriousFreerun(t *testing.T) {
 			"because the TBC profile was not detected due to startup ordering")
 }
 
+// TestTBCFreerunDoesNotOverrideClockRealtime verifies that when T-BC-STATUS
+// reports FREERUN, ParseTBCLogs does NOT force CLOCK_REALTIME to FREERUN.
+// CLOCK_REALTIME state must be managed exclusively by phc2sys processing.
+func TestTBCFreerunDoesNotOverrideClockRealtime(t *testing.T) {
+	eventManager := metrics.NewPTPEventManager("", initPubSubTypes(), "testnode", &common.SCConfiguration{StorePath: "/tmp/store"})
+	eventManager.MockTest(true)
+
+	configName = "ptp4l.0.config"
+	tbcProfile := "tbc-test-profile"
+
+	eventManager.PtpConfigMapUpdates.TBCProfiles = []string{tbcProfile}
+
+	ptp4lCfg := &ptp4lconf.PTP4lConfig{
+		Name:        configName,
+		Profile:     tbcProfile,
+		ProfileType: ptp4lconf.TBC,
+		Interfaces: []*ptp4lconf.PTPInterface{
+			{
+				Name:     "ens2f0",
+				PortID:   1,
+				PortName: "port 1",
+				Role:     types.SLAVE,
+			},
+		},
+	}
+	eventManager.AddPTPConfig(types.ConfigName(configName), ptp4lCfg)
+
+	ptpStats := eventManager.GetStats(types.ConfigName(configName))
+	ptpStats[metrics.MasterClockType] = &stats.Stats{}
+	ptpStats[metrics.MasterClockType].SetAlias("ens2f0")
+
+	// Step 1: T-BC-STATUS s2 (LOCKED) — establish TBC state
+	replacer := strings.NewReplacer("[", " ", "]", " ", ":", " ")
+	tbcLockedLog := fmt.Sprintf("T-BC[1743005894]:[%s] ens2f0 offset 5 T-BC-STATUS s2", configName)
+	output := replacer.Replace(tbcLockedLog)
+	fields := strings.Fields(output)
+	eventManager.ParseTBCLogs("T-BC", configName, output, fields, ptpStats)
+
+	// Step 2: phc2sys CLOCK_REALTIME s2 (LOCKED) — establish OS clock state
+	phc2sysLocked := fmt.Sprintf("phc2sys[3263.065]: [%s] CLOCK_REALTIME phc offset 3 s2 freq -20217 delay 536", configName)
+	eventManager.ExtractMetrics(phc2sysLocked)
+
+	cStat, ok := ptpStats[metrics.ClockRealTime]
+	assert.True(t, ok, "CLOCK_REALTIME stats should exist after phc2sys line")
+	assert.Equal(t, ptp.LOCKED, cStat.LastSyncState(), "CLOCK_REALTIME should be LOCKED from phc2sys")
+
+	// Step 3: T-BC-STATUS s0 (FREERUN) — upstream lost, but phc2sys still locked
+	eventManager.ResetMockEvent()
+	tbcFreerunLog := fmt.Sprintf("T-BC[1743005900]:[%s] ens2f0 offset 123 T-BC-STATUS s0", configName)
+	output = replacer.Replace(tbcFreerunLog)
+	fields = strings.Fields(output)
+	eventManager.ParseTBCLogs("T-BC", configName, output, fields, ptpStats)
+
+	// Verify T-BC master resource is FREERUN (the T-BC event itself should fire)
+	tbcKey := types.IFace(stats.TBCMainClockName)
+	assert.Equal(t, ptp.FREERUN, ptpStats[tbcKey].LastSyncState(),
+		"T-BC master resource should be FREERUN")
+
+	// Verify CLOCK_REALTIME was NOT overridden — it must stay LOCKED
+	assert.Equal(t, ptp.LOCKED, cStat.LastSyncState(),
+		"CLOCK_REALTIME must remain LOCKED; ParseTBCLogs should not override phc2sys")
+
+	// Verify no OsClockSyncStateChange was emitted
+	assert.NotContains(t, eventManager.GetMockEvent(), ptp.OsClockSyncStateChange,
+		"ParseTBCLogs must not emit OsClockSyncStateChange when T-BC goes FREERUN")
+
+	// Step 4: Next phc2sys sample must also remain LOCKED — verify the
+	// phc2sys processing path (extractRegularMetrics) does not rewrite
+	// CLOCK_REALTIME to FREERUN based on T-BC state.
+	eventManager.ResetMockEvent()
+	phc2sysStillLocked := fmt.Sprintf(
+		"phc2sys[3264.065]: [%s] CLOCK_REALTIME phc offset 3 s2 freq -20217 delay 536",
+		configName,
+	)
+	eventManager.ExtractMetrics(phc2sysStillLocked)
+
+	assert.Equal(t, ptp.LOCKED, cStat.LastSyncState(),
+		"CLOCK_REALTIME must remain LOCKED after the next phc2sys sample")
+	assert.NotContains(t, eventManager.GetMockEvent(), ptp.OsClockSyncStateChange,
+		"T-BC FREERUN must not rewrite the phc2sys CLOCK_REALTIME path")
+}
+
 // TestTBCOffsetMetricUpdatedEveryLog tests that T-BC offset metric is updated on every log
 func TestTBCOffsetMetricUpdatedEveryLog(t *testing.T) {
 	eventManager := metrics.NewPTPEventManager("", initPubSubTypes(), "testnode", &common.SCConfiguration{StorePath: "/tmp/store"})

--- a/plugins/ptp_operator/metrics/tbc_test.go
+++ b/plugins/ptp_operator/metrics/tbc_test.go
@@ -312,7 +312,7 @@ func TestTBCFaultyPortSpuriousFreerun(t *testing.T) {
 	eventManager.ResetMockEvent()
 	t.Logf("--- STEP 3: SLAVE to FAULTY ---")
 
-	// Step 3: SLAVE to FAULTY — triggers the bug
+	// Step 3: SLAVE to FAULTY — would have triggered the bug before the fix
 	ptp4lFaulty := "ptp4l[3263.061]: [ptp4l.0.config:5] port 1 (ens3f2): SLAVE to FAULTY on FAULT_DETECTED (FT_UNSPECIFIED)"
 	t.Logf("Input: %s", ptp4lFaulty)
 	t.Logf("ProfileType at time of parsing: %v (should be TBC but is NONE due to race)",

--- a/plugins/ptp_operator/metrics/tbc_test.go
+++ b/plugins/ptp_operator/metrics/tbc_test.go
@@ -236,10 +236,11 @@ func TestTBCProfileTypeSetBeforeTBCProfilesPopulated(t *testing.T) {
 		"BUG REPRODUCED: stored ProfileType remains NONE even after TBCProfiles is populated")
 }
 
-// TestTBCFaultyPortSpuriousFreerun reproduces the end-to-end bug: when a ptp4l port
-// goes SLAVE to FAULTY on a TBC profile that wasn't detected as TBC (due to the startup
-// race), a spurious FREERUN event is published for CLOCK_REALTIME even though phc2sys
-// is still locked.
+// TestTBCFaultyPortSpuriousFreerun verifies that when a ptp4l port goes
+// SLAVE to FAULTY on a TBC profile that wasn't detected as TBC (due to a
+// startup race), no spurious OsClockSyncStateChange FREERUN event is emitted.
+// This was a known bug when maybePublishOSClockSyncStateChangeEvent existed;
+// now that E3 is published exclusively from the phc2sys path, the bug is fixed.
 func TestTBCFaultyPortSpuriousFreerun(t *testing.T) {
 	profileName := "tsc-holdover"
 
@@ -340,15 +341,16 @@ func TestTBCFaultyPortSpuriousFreerun(t *testing.T) {
 	t.Logf("--- RESULT ---")
 	t.Logf("Spurious OsClockSyncStateChange emitted: %v", hasOsClockFreerun)
 
-	assert.True(t, hasOsClockFreerun,
-		"BUG REPRODUCED: spurious OsClockSyncStateChange FREERUN event emitted on FAULTY "+
-			"because the TBC profile was not detected due to startup ordering")
+	assert.False(t, hasOsClockFreerun,
+		"No spurious OsClockSyncStateChange should be emitted: E3 is published "+
+			"exclusively from the phc2sys path, not from the holdover timer")
 }
 
-// TestTBCFreerunDoesNotOverrideClockRealtime verifies that when T-BC-STATUS
-// reports FREERUN, ParseTBCLogs does NOT force CLOCK_REALTIME to FREERUN.
-// CLOCK_REALTIME state must be managed exclusively by phc2sys processing.
-func TestTBCFreerunDoesNotOverrideClockRealtime(t *testing.T) {
+// TestE3IncorporatesE1State verifies that E3 (CLOCK_REALTIME) incorporates
+// E1 (PTP Lock State / upstream traceability) per O-RAN O-Cloud API v04.00
+// Table 37. ParseTBCLogs does NOT publish E3 directly; only the phc2sys path
+// publishes E3, applying worst_of(phc2sys_state, E1_state).
+func TestE3IncorporatesE1State(t *testing.T) {
 	eventManager := metrics.NewPTPEventManager("", initPubSubTypes(), "testnode", &common.SCConfiguration{StorePath: "/tmp/store"})
 	eventManager.MockTest(true)
 
@@ -411,20 +413,131 @@ func TestTBCFreerunDoesNotOverrideClockRealtime(t *testing.T) {
 	assert.NotContains(t, eventManager.GetMockEvent(), ptp.OsClockSyncStateChange,
 		"ParseTBCLogs must not emit OsClockSyncStateChange when T-BC goes FREERUN")
 
-	// Step 4: Next phc2sys sample must also remain LOCKED — verify the
-	// phc2sys processing path (extractRegularMetrics) does not rewrite
-	// CLOCK_REALTIME to FREERUN based on T-BC state.
+	// Step 4: Next phc2sys sample — E1 is FREERUN, phc2sys reports s2 with
+	// small offset. Per O-RAN Table 37 row 3, E3 = worst_of(LOCKED, FREERUN) = FREERUN.
 	eventManager.ResetMockEvent()
-	phc2sysStillLocked := fmt.Sprintf(
+	phc2sysAfterE1Freerun := fmt.Sprintf(
 		"phc2sys[3264.065]: [%s] CLOCK_REALTIME phc offset 3 s2 freq -20217 delay 536",
 		configName,
 	)
-	eventManager.ExtractMetrics(phc2sysStillLocked)
+	eventManager.ExtractMetrics(phc2sysAfterE1Freerun)
 
-	assert.Equal(t, ptp.LOCKED, cStat.LastSyncState(),
-		"CLOCK_REALTIME must remain LOCKED after the next phc2sys sample")
-	assert.NotContains(t, eventManager.GetMockEvent(), ptp.OsClockSyncStateChange,
-		"T-BC FREERUN must not rewrite the phc2sys CLOCK_REALTIME path")
+	assert.Equal(t, ptp.FREERUN, cStat.LastSyncState(),
+		"CLOCK_REALTIME must be FREERUN because E1 is FREERUN (O-RAN Table 37 row 3)")
+	assert.Contains(t, eventManager.GetMockEvent(), ptp.OsClockSyncStateChange,
+		"phc2sys path must emit OsClockSyncStateChange when E3 transitions to FREERUN")
+}
+
+// TestE3DerivationORANTable37 is a table-driven test covering all 5 rows
+// of O-RAN O-Cloud Notification API v04.00 Table 37 for E3 (CLOCK_REALTIME).
+//
+// | Row | E1 (PTP Lock State) | phc2sys offset | phc2sys servo | Expected E3         |
+// |-----|---------------------|----------------|---------------|---------------------|
+// |  1  | LOCKED              | within range   | s2            | LOCKED              |
+// |  2  | HOLDOVER            | within range   | s2            | HOLDOVER            |
+// |  3  | FREERUN             | within range   | s2            | FREERUN             |
+// |  4  | LOCKED              | outside range  | s2            | FREERUN             |
+// |  5  | LOCKED              | n/a (phc2sys)  | s0            | FREERUN             |
+func TestE3DerivationORANTable37(t *testing.T) {
+	tests := []struct {
+		name        string
+		e1State     ptp.SyncState
+		phc2sys     string // phc2sys log line suffix: "offset <N> <servo> freq <F> delay <D>"
+		expectedE3  ptp.SyncState
+		expectEvent bool
+	}{
+		{
+			name:        "Row1: E1=LOCKED offset_in_range s2 → E3=LOCKED",
+			e1State:     ptp.LOCKED,
+			phc2sys:     "CLOCK_REALTIME phc offset 3 s2 freq -20217 delay 536",
+			expectedE3:  ptp.LOCKED,
+			expectEvent: true, // FREERUN→LOCKED transition
+		},
+		{
+			name:        "Row2: E1=HOLDOVER offset_in_range s2 → E3=HOLDOVER",
+			e1State:     ptp.HOLDOVER,
+			phc2sys:     "CLOCK_REALTIME phc offset 5 s2 freq -20217 delay 536",
+			expectedE3:  ptp.HOLDOVER,
+			expectEvent: true, // LOCKED→HOLDOVER transition
+		},
+		{
+			name:        "Row3: E1=FREERUN offset_in_range s2 → E3=FREERUN",
+			e1State:     ptp.FREERUN,
+			phc2sys:     "CLOCK_REALTIME phc offset 3 s2 freq -20217 delay 536",
+			expectedE3:  ptp.FREERUN,
+			expectEvent: true, // HOLDOVER→FREERUN transition
+		},
+		{
+			name:        "Row4: E1=LOCKED offset_out_of_range s2 → E3=FREERUN",
+			e1State:     ptp.LOCKED,
+			phc2sys:     "CLOCK_REALTIME phc offset 999999 s2 freq -20217 delay 536",
+			expectedE3:  ptp.FREERUN,
+			expectEvent: false, // FREERUN→FREERUN, no event
+		},
+		{
+			name:        "Row5: E1=LOCKED servo=s0 → E3=FREERUN",
+			e1State:     ptp.LOCKED,
+			phc2sys:     "CLOCK_REALTIME phc offset 3 s0 freq -20217 delay 536",
+			expectedE3:  ptp.FREERUN,
+			expectEvent: false, // FREERUN→FREERUN, no event
+		},
+	}
+
+	cfgName := "ptp4l.0.config"
+	tbcProfile := "tbc-e3-test"
+
+	eventManager := metrics.NewPTPEventManager("", initPubSubTypes(), "testnode", &common.SCConfiguration{StorePath: "/tmp/store"})
+	eventManager.MockTest(true)
+
+	eventManager.PtpConfigMapUpdates.TBCProfiles = []string{tbcProfile}
+
+	ptp4lCfg := &ptp4lconf.PTP4lConfig{
+		Name:        cfgName,
+		Profile:     tbcProfile,
+		ProfileType: ptp4lconf.TBC,
+		Interfaces: []*ptp4lconf.PTPInterface{
+			{
+				Name:     "ens2f0",
+				PortID:   1,
+				PortName: "port 1",
+				Role:     types.SLAVE,
+			},
+		},
+	}
+	eventManager.AddPTPConfig(types.ConfigName(cfgName), ptp4lCfg)
+
+	ptpStats := eventManager.GetStats(types.ConfigName(cfgName))
+	ptpStats[metrics.MasterClockType] = &stats.Stats{}
+	ptpStats[metrics.MasterClockType].SetAlias("ens2f0")
+	ptpStats[metrics.MasterClockType].SetRole(types.SLAVE)
+
+	// Initialize T-BC key and CLOCK_REALTIME via a T-BC LOCKED + phc2sys LOCKED baseline.
+	// This ensures GetMainClockName() finds the T-BC key.
+	replacer := strings.NewReplacer("[", " ", "]", " ", ":", " ")
+	tbcInit := fmt.Sprintf("T-BC[1743005894]:[%s] ens2f0 offset 5 T-BC-STATUS s2", cfgName)
+	eventManager.ParseTBCLogs("T-BC", cfgName, replacer.Replace(tbcInit), strings.Fields(replacer.Replace(tbcInit)), ptpStats)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set E1 state on the T-BC main clock key
+			tbcKey := types.IFace(stats.TBCMainClockName)
+			ptpStats[tbcKey].SetLastSyncState(tt.e1State)
+
+			eventManager.ResetMockEvent()
+			phc2sysLog := fmt.Sprintf("phc2sys[3263.065]: [%s] %s", cfgName, tt.phc2sys)
+			eventManager.ExtractMetrics(phc2sysLog)
+
+			cStat := ptpStats[metrics.ClockRealTime]
+			assert.Equal(t, tt.expectedE3, cStat.LastSyncState(),
+				"E3 (CLOCK_REALTIME) state mismatch")
+
+			mockEvents := eventManager.GetMockEvent()
+			if tt.expectEvent {
+				assert.Contains(t, mockEvents, ptp.OsClockSyncStateChange,
+					"expected OsClockSyncStateChange event")
+			}
+		})
+	}
 }
 
 // TestTBCOffsetMetricUpdatedEveryLog tests that T-BC offset metric is updated on every log

--- a/plugins/ptp_operator/metrics/tbc_test.go
+++ b/plugins/ptp_operator/metrics/tbc_test.go
@@ -123,7 +123,7 @@ func TestTBCPtp4lMasterOffsetNoHoldover(t *testing.T) {
 	eventManager := metrics.NewPTPEventManager("", initPubSubTypes(), "testnode", &common.SCConfiguration{StorePath: "/tmp/store"})
 	eventManager.MockTest(true)
 
-	configName = "ptp4l.0.config"
+	configName = cfgName
 	tbcProfile := "tbc-test-profile"
 
 	// Setup TBC profile
@@ -185,7 +185,6 @@ func TestTBCPtp4lMasterOffsetNoHoldover(t *testing.T) {
 // has rh_external_pps in ts2phcOpts.
 func TestTBCProfileTypeSetBeforeTBCProfilesPopulated(t *testing.T) {
 	profileName := "tsc-holdover"
-	cfgName := "ptp4l.0.config"
 
 	eventManager := metrics.NewPTPEventManager("", initPubSubTypes(), "testnode", &common.SCConfiguration{StorePath: "/tmp/store"})
 
@@ -354,7 +353,7 @@ func TestE3IncorporatesE1State(t *testing.T) {
 	eventManager := metrics.NewPTPEventManager("", initPubSubTypes(), "testnode", &common.SCConfiguration{StorePath: "/tmp/store"})
 	eventManager.MockTest(true)
 
-	configName = "ptp4l.0.config"
+	configName = cfgName
 	tbcProfile := "tbc-test-profile"
 
 	eventManager.PtpConfigMapUpdates.TBCProfiles = []string{tbcProfile}
@@ -483,7 +482,6 @@ func TestE3DerivationORANTable37(t *testing.T) {
 		},
 	}
 
-	cfgName := "ptp4l.0.config"
 	tbcProfile := "tbc-e3-test"
 
 	eventManager := metrics.NewPTPEventManager("", initPubSubTypes(), "testnode", &common.SCConfiguration{StorePath: "/tmp/store"})


### PR DESCRIPTION
Cherry-pick of #701 to release-4.22.

## Summary

### Commit 1: Fix CLOCK_REALTIME dual-publisher conflict in ParseTBCLogs

- Removes the CLOCK_REALTIME override from `ParseTBCLogs` that was forcing FREERUN with a sentinel offset, overriding phc2sys which may still report LOCKED.
- `CLOCK_REALTIME` is now managed exclusively by `phc2sys`.
- Adds regression test `TestTBCFreerunDoesNotOverrideClockRealtime`.

### Commit 2: E1-aware E3 derivation per O-RAN O-Cloud API v04.00 Table 37

- Adds E1-aware syncState downgrade in `ExtractMetrics`: E3 = `worst_of(phc2sys_state, E1_state)`. T-GM profiles skipped.
- Removes redundant `maybePublishOSClockSyncStateChangeEvent` and unused `ptpOpts` parameter from `handleHoldOverState`.
- Fixes `GenPTPEvent` to allow HOLDOVER-to-FREERUN transitions for E3.
- Adds `TestE3DerivationORANTable37` covering all 5 rows of O-RAN Table 37.

## E3 derivation (O-RAN Table 37)

| E1 (PTP State) | phc2sys status | E3 (OS Clock) |
| :--- | :--- | :--- |
| LOCKED | offset < threshold | **LOCKED** |
| HOLDOVER | offset < threshold | **HOLDOVER** |
| FREERUN | offset < threshold | **FREERUN** |
| any | offset > threshold | **FREERUN** |
| any | phc2sys down | **FREERUN** |

## Test plan

- [x] Full `go test ./plugins/ptp_operator/metrics/...` passes

/assign edcdavid

Assisted-By: Cursor