### PR TITLE
OCPBUGS-87883: Cleanup clock_class metrics on ptpconfig deletion

### DIFF
--- a/plugins/ptp_operator/metrics/registry.go
+++ b/plugins/ptp_operator/metrics/registry.go
@@ -205,6 +205,20 @@ func DeletedPTPMetrics(clockType, processName, eventResourceName string) {
 		"process": processName, "node": ptpNodeName, "iface": eventResourceName})
 }
 
+// DeleteClockClassMetricsForConfig removes clock class metrics for a deleted config.
+func DeleteClockClassMetricsForConfig(process, configName string) {
+	ClockClassMetrics.Delete(prometheus.Labels{
+		"process": process,
+		"config":  configName,
+		"node":    ptpNodeName,
+	})
+}
+
+// DeleteAllClockClassMetricsForNode removes all clock class metrics for the current node.
+func DeleteAllClockClassMetricsForNode() {
+	ClockClassMetrics.DeletePartialMatch(prometheus.Labels{"node": ptpNodeName})
+}
+
 // DeleteThresholdMetrics ... delete threshold metrics
 func DeleteThresholdMetrics(profile string) {
 	Threshold.Delete(prometheus.Labels{
@@ -218,11 +232,12 @@ func DeleteThresholdMetrics(profile string) {
 // UpdateSyncStateMetrics ... update sync state metrics
 func UpdateSyncStateMetrics(process, iface string, state ptp.SyncState) {
 	var clockState float64
-	if state == ptp.LOCKED {
+	switch state {
+	case ptp.LOCKED:
 		clockState = float64(types.LOCKED)
-	} else if state == ptp.FREERUN {
+	case ptp.FREERUN:
 		clockState = float64(types.FREERUN)
-	} else if state == ptp.HOLDOVER {
+	case ptp.HOLDOVER:
 		clockState = float64(types.HOLDOVER)
 	}
 	// prevent reporting wrong metrics

--- a/plugins/ptp_operator/metrics/registry_test.go
+++ b/plugins/ptp_operator/metrics/registry_test.go
@@ -1,0 +1,95 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func clockClassLabels(config string) prometheus.Labels {
+	return prometheus.Labels{
+		"process": ptp4lProcessName,
+		"config":  config,
+		"node":    ptpNodeName,
+	}
+}
+
+func setClockClass(config string, value float64) {
+	ClockClassMetrics.With(clockClassLabels(config)).Set(value)
+}
+
+func clockClassValue(t *testing.T, config string) float64 {
+	t.Helper()
+	return testutil.ToFloat64(ClockClassMetrics.With(clockClassLabels(config)))
+}
+
+func assertClockClassAbsent(t *testing.T, config string) {
+	t.Helper()
+	assert.False(t, ClockClassMetrics.Delete(clockClassLabels(config)),
+		"clock class metric still present for config %s", config)
+}
+
+func TestDeleteClockClassMetricsForConfig(t *testing.T) {
+	ensureTestNode(t)
+
+	t.Run("single_delete", func(t *testing.T) {
+		config := "ptp4l.0.config"
+		setClockClass(config, 6)
+
+		DeleteClockClassMetricsForConfig(ptp4lProcessName, config)
+
+		assertClockClassAbsent(t, config)
+	})
+
+	t.Run("partial_delete_preserves_other_config", func(t *testing.T) {
+		config0 := "ptp4l.0.config"
+		config1 := "ptp4l.1.config"
+		setClockClass(config0, 6)
+		setClockClass(config1, 7)
+
+		DeleteClockClassMetricsForConfig(ptp4lProcessName, config0)
+
+		assertClockClassAbsent(t, config0)
+		assert.Equal(t, 7.0, clockClassValue(t, config1))
+
+		DeleteClockClassMetricsForConfig(ptp4lProcessName, config1)
+	})
+
+	t.Run("idempotent_double_delete", func(t *testing.T) {
+		config := "ptp4l.2.config"
+		setClockClass(config, 248)
+
+		DeleteClockClassMetricsForConfig(ptp4lProcessName, config)
+		DeleteClockClassMetricsForConfig(ptp4lProcessName, config)
+
+		assertClockClassAbsent(t, config)
+	})
+
+	t.Run("delete_then_recreate_same_config", func(t *testing.T) {
+		config := "ptp4l.3.config"
+		setClockClass(config, 6)
+
+		DeleteClockClassMetricsForConfig(ptp4lProcessName, config)
+		assertClockClassAbsent(t, config)
+
+		setClockClass(config, 248)
+		assert.Equal(t, 248.0, clockClassValue(t, config))
+
+		DeleteClockClassMetricsForConfig(ptp4lProcessName, config)
+		assertClockClassAbsent(t, config)
+	})
+
+	t.Run("delete_all_for_node", func(t *testing.T) {
+		config0 := "ptp4l.4.config"
+		config1 := "ptp4l.5.config"
+		setClockClass(config0, 6)
+		setClockClass(config1, 7)
+
+		DeleteAllClockClassMetricsForNode()
+
+		assertClockClassAbsent(t, config0)
+		assertClockClassAbsent(t, config1)
+	})
+}

--- a/plugins/ptp_operator/ptp_operator_plugin.go
+++ b/plugins/ptp_operator/ptp_operator_plugin.go
@@ -144,6 +144,7 @@ func Start(wg *sync.WaitGroup, configuration *common.SCConfiguration, _ func(e i
 					}
 					// delete all metrics related to process
 					ptpMetrics.DeleteProcessStatusMetricsForConfig(nodeName, "", "")
+					ptpMetrics.DeleteAllClockClassMetricsForNode()
 					// delete all metrics related to ptp ha if haProfile is deleted
 					if _, haProfiles := eventManager.HAProfiles(); len(haProfiles) > 0 {
 						for _, p := range haProfiles {
@@ -533,6 +534,7 @@ func processPtp4lConfigFileUpdates() {
 				ptpConfigFileName := ptpTypes.ConfigName(*ptpConfigEvent.Name)
 				ptp4lConfig := eventManager.GetPTPConfig(ptpConfigFileName)
 				log.Infof("deleting config %s with profile %s\n", *ptpConfigEvent.Name, ptp4lConfig.Profile)
+				ptpMetrics.DeleteClockClassMetricsForConfig(ptp4lProcessName, string(ptpConfigFileName))
 				ptpStats := eventManager.GetStats(ptpConfigFileName)
 				// to avoid new one getting created , make a copy of this stats
 				ptpStats.SetConfigAsDeleted(true)
@@ -602,10 +604,6 @@ func processPtp4lConfigFileUpdates() {
 									masterResource := fmt.Sprintf("%s/%s", p.Alias(), MasterClockType)
 									eventManager.PublishEvent(ptp.FREERUN, ptpMetrics.FreeRunOffsetValue, masterResource, ptp.GnssStateChange)
 								}
-							}
-							if ptpMetrics.ClockClassMetrics != nil {
-								ptpMetrics.ClockClassMetrics.Delete(prometheus.Labels{
-									"process": ptp4lProcessName, "config": string(ptpConfigFileName), "node": eventManager.NodeName()})
 							}
 							ptpMetrics.DeletedPTPMetrics(MasterClockType, ts2PhcProcessName, p.Alias())
 							p.DeleteAllMetrics([]*prometheus.GaugeVec{ptpMetrics.PtpOffset, ptpMetrics.SyncState})


### PR DESCRIPTION
Delete openshift_ptp_clock_class series when boundary-clock configs are removed via file watcher or zero-profile config map update.