### PR TITLE
CNF-22693: Support dynamic namespace in default transport host

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -114,7 +114,13 @@ func main() {
 	flag.StringVar(&metricsAddr, "metrics-addr", ":9091", "The address the metric endpoint binds to.")
 	flag.StringVar(&storePath, "store-path", ".", "The path to store publisher and subscription info.")
 	// TODO: Rename transportHost to apiHost, which requires changes in PTP Operator.
-	flag.StringVar(&transportHost, "transport-host", "http://ptp-event-publisher-service-NODE_NAME.openshift-ptp.svc.cluster.local:9043", "The transport bus hostname or service name.")
+	defaultTransportNS := os.Getenv("NAME_SPACE")
+	if defaultTransportNS == "" {
+		defaultTransportNS = "openshift-ptp"
+	}
+	flag.StringVar(&transportHost, "transport-host",
+		"http://ptp-event-publisher-service-NODE_NAME."+defaultTransportNS+".svc.cluster.local:9043",
+		"The transport bus hostname or service name.")
 	flag.IntVar(&apiPort, "api-port", 9043, "The address the rest api endpoint binds to.")
 	flag.StringVar(&apiVersion, "api-version", "2.0", "The address the rest api endpoint binds to.")
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -107,6 +107,16 @@ func isV1Api(version string) bool {
 	return true
 }
 
+// defaultTransportHost returns the default transport host URL using the
+// NAME_SPACE env var for the namespace, falling back to "openshift-ptp".
+func defaultTransportHost() string {
+	ns := os.Getenv("NAME_SPACE")
+	if ns == "" {
+		ns = "openshift-ptp"
+	}
+	return "http://ptp-event-publisher-service-NODE_NAME." + ns + ".svc.cluster.local:9043"
+}
+
 func main() {
 	fmt.Printf("Git commit: %s\n", GitCommit)
 	// init
@@ -114,12 +124,8 @@ func main() {
 	flag.StringVar(&metricsAddr, "metrics-addr", ":9091", "The address the metric endpoint binds to.")
 	flag.StringVar(&storePath, "store-path", ".", "The path to store publisher and subscription info.")
 	// TODO: Rename transportHost to apiHost, which requires changes in PTP Operator.
-	defaultTransportNS := os.Getenv("NAME_SPACE")
-	if defaultTransportNS == "" {
-		defaultTransportNS = "openshift-ptp"
-	}
 	flag.StringVar(&transportHost, "transport-host",
-		"http://ptp-event-publisher-service-NODE_NAME."+defaultTransportNS+".svc.cluster.local:9043",
+		defaultTransportHost(),
 		"The transport bus hostname or service name.")
 	flag.IntVar(&apiPort, "api-port", 9043, "The address the rest api endpoint binds to.")
 	flag.StringVar(&apiVersion, "api-version", "2.0", "The address the rest api endpoint binds to.")

--- a/cmd/transport_host_test.go
+++ b/cmd/transport_host_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultTransportHost_Default(t *testing.T) {
+	origEnv, envWasSet := os.LookupEnv("NAME_SPACE")
+	defer func() {
+		if envWasSet {
+			os.Setenv("NAME_SPACE", origEnv)
+		} else {
+			os.Unsetenv("NAME_SPACE")
+		}
+	}()
+
+	os.Unsetenv("NAME_SPACE")
+	host := defaultTransportHost()
+	assert.Equal(t,
+		"http://ptp-event-publisher-service-NODE_NAME.openshift-ptp.svc.cluster.local:9043",
+		host, "should use openshift-ptp when NAME_SPACE is not set")
+}
+
+func TestDefaultTransportHost_CustomNamespace(t *testing.T) {
+	origEnv, envWasSet := os.LookupEnv("NAME_SPACE")
+	defer func() {
+		if envWasSet {
+			os.Setenv("NAME_SPACE", origEnv)
+		} else {
+			os.Unsetenv("NAME_SPACE")
+		}
+	}()
+
+	os.Setenv("NAME_SPACE", "custom-ns")
+	host := defaultTransportHost()
+	assert.Equal(t,
+		"http://ptp-event-publisher-service-NODE_NAME.custom-ns.svc.cluster.local:9043",
+		host, "should use custom namespace from NAME_SPACE env var")
+	assert.NotContains(t, host, "openshift-ptp",
+		"should not contain default namespace when overridden")
+}
+
+func TestDefaultTransportHost_EmptyEnvKeepsDefault(t *testing.T) {
+	origEnv, envWasSet := os.LookupEnv("NAME_SPACE")
+	defer func() {
+		if envWasSet {
+			os.Setenv("NAME_SPACE", origEnv)
+		} else {
+			os.Unsetenv("NAME_SPACE")
+		}
+	}()
+
+	os.Setenv("NAME_SPACE", "")
+	host := defaultTransportHost()
+	assert.Equal(t,
+		"http://ptp-event-publisher-service-NODE_NAME.openshift-ptp.svc.cluster.local:9043",
+		host, "empty NAME_SPACE should fall back to openshift-ptp")
+}


### PR DESCRIPTION
## Summary
Use `NAME_SPACE` env var to construct the default `--transport-host` URL, falling back to `openshift-ptp`. This ensures event consumer URLs resolve correctly when the PTP operator runs in a different namespace via OLMv1 AllNamespaces install mode.

## Changes
- `cmd/main.go`: Read `NAME_SPACE` env var for default transport host URL construction instead of hardcoding `openshift-ptp`

The `NAME_SPACE` env var is already set by the PTP operator DaemonSet template and already read at line 134 for other purposes. This change only affects the default fallback — when the PTP operator explicitly passes `--transport-host`, this default is unused.

## Related PRs
- ptp-operator: [k8snetworkplumbingwg/ptp-operator#262](https://github.com/k8snetworkplumbingwg/ptp-operator/pull/262)
- linuxptp-daemon: [k8snetworkplumbingwg/linuxptp-daemon#231](https://github.com/k8snetworkplumbingwg/linuxptp-daemon/pull/231)

Fixes: [CNF-22693](https://redhat.atlassian.net/browse/CNF-22693)

🤖 Generated with [Claude Code](https://claude.com/claude-code)