### PR TITLE
OCPBUGS-82519: Fix NTP-failover dual-publisher for CLOCK_REALTIME

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -42,7 +42,7 @@ func storeCleanUp() {
 
 func TestSidecar_Main(t *testing.T) {
 	apiPort = 8990
-	
+
 	// Create a unique temporary directory for this test run to avoid conflicts
 	tempDir, err := os.MkdirTemp("", "sidecar-test-*")
 	assert.NoError(t, err)
@@ -50,7 +50,7 @@ func TestSidecar_Main(t *testing.T) {
 		storeCleanUp()
 		os.RemoveAll(tempDir) // Clean up temp directory
 	}()
-	
+
 	wg := &sync.WaitGroup{}
 	var storePath = tempDir
 	if sPath, ok := os.LookupEnv("STORE_PATH"); ok && sPath != "" {
@@ -73,10 +73,10 @@ func TestSidecar_Main(t *testing.T) {
 			Err:  nil,
 		},
 	}
-	
+
 	// Clean up any existing state before starting the test
 	storeCleanUp()
-	
+
 	log.Infof("Configuration set to %#v", scConfig)
 
 	//start rest service

--- a/plugins/ptp_operator/config/config.go
+++ b/plugins/ptp_operator/config/config.go
@@ -284,9 +284,11 @@ func (l *LinuxPTPConfigMapUpdate) UpdatePTPProcessOptions() {
 	l.PtpProcessOpts = make(map[string]*PtpProcessOpts)
 	for _, profile := range l.NodeProfiles {
 		l.PtpProcessOpts[*profile.Name] = &PtpProcessOpts{
-			Ptp4lOpts:  profile.Ptp4lOpts,
-			Phc2Opts:   profile.Phc2sysOpts,
-			TS2PhcOpts: profile.TS2PhcOpts}
+			Ptp4lOpts:   profile.Ptp4lOpts,
+			Phc2Opts:    profile.Phc2sysOpts,
+			TS2PhcOpts:  profile.TS2PhcOpts,
+			ChronydOpts: profile.ChronydOpts,
+		}
 		// ts2phcOpts are empty by default
 		if profile.TS2PhcConf != nil && (profile.TS2PhcOpts == nil || *profile.TS2PhcOpts == "") {
 			l.PtpProcessOpts[*profile.Name].TS2PhcOpts = pointer.String("-m")

--- a/plugins/ptp_operator/config/config_test.go
+++ b/plugins/ptp_operator/config/config_test.go
@@ -167,3 +167,86 @@ func Test_Config(t *testing.T) {
 	}
 	closeCh <- struct{}{}
 }
+
+func TestUpdatePTPProcessOptions_PopulatesChronydOpts(t *testing.T) {
+	chronydOpts := "-f /etc/chrony.conf"
+	phc2sysOpts := "-a -r -r -n 24"
+	ptp4lOpts := "-2 -s"
+	ts2phcOpts := "-m"
+	profileName := "ntp-failover"
+
+	l := &ptpConfig.LinuxPTPConfigMapUpdate{
+		NodeProfiles: []ptpConfig.PtpProfile{
+			{
+				Name:        &profileName,
+				Ptp4lOpts:   &ptp4lOpts,
+				Phc2sysOpts: &phc2sysOpts,
+				TS2PhcOpts:  &ts2phcOpts,
+				ChronydOpts: &chronydOpts,
+			},
+		},
+		PtpProcessOpts: make(map[string]*ptpConfig.PtpProcessOpts),
+		PtpSettings:    make(map[string]map[string]string),
+	}
+
+	l.UpdatePTPProcessOptions()
+
+	opts, ok := l.PtpProcessOpts[profileName]
+	assert.True(t, ok, "profile must be present in PtpProcessOpts")
+	assert.True(t, opts.ChronydEnabled(), "ChronydEnabled() must return true when profile has chronydOpts")
+	assert.Equal(t, chronydOpts, *opts.ChronydOpts)
+	assert.True(t, opts.Ptp4lEnabled())
+	assert.True(t, opts.Phc2SysEnabled())
+	assert.True(t, opts.TS2PhcEnabled())
+}
+
+func TestUpdatePTPProcessOptions_NilChronydOpts(t *testing.T) {
+	phc2sysOpts := "-a -r -r -n 24"
+	ptp4lOpts := "-2 -s"
+	profileName := "ptp-oc"
+
+	l := &ptpConfig.LinuxPTPConfigMapUpdate{
+		NodeProfiles: []ptpConfig.PtpProfile{
+			{
+				Name:        &profileName,
+				Ptp4lOpts:   &ptp4lOpts,
+				Phc2sysOpts: &phc2sysOpts,
+				ChronydOpts: nil,
+			},
+		},
+		PtpProcessOpts: make(map[string]*ptpConfig.PtpProcessOpts),
+		PtpSettings:    make(map[string]map[string]string),
+	}
+
+	l.UpdatePTPProcessOptions()
+
+	opts, ok := l.PtpProcessOpts[profileName]
+	assert.True(t, ok, "profile must be present in PtpProcessOpts")
+	assert.False(t, opts.ChronydEnabled(), "ChronydEnabled() must return false when profile has no chronydOpts")
+	assert.True(t, opts.Ptp4lEnabled())
+	assert.True(t, opts.Phc2SysEnabled())
+}
+
+func TestUpdatePTPProcessOptions_TS2PhcConfSetsDefaultOpts(t *testing.T) {
+	ptp4lOpts := "-2 -s"
+	profileName := "ts2phc-profile"
+	ts2phcConf := "[global]\n"
+
+	l := &ptpConfig.LinuxPTPConfigMapUpdate{
+		NodeProfiles: []ptpConfig.PtpProfile{
+			{
+				Name:       &profileName,
+				Ptp4lOpts:  &ptp4lOpts,
+				TS2PhcConf: &ts2phcConf,
+			},
+		},
+		PtpProcessOpts: make(map[string]*ptpConfig.PtpProcessOpts),
+		PtpSettings:    make(map[string]map[string]string),
+	}
+
+	l.UpdatePTPProcessOptions()
+
+	opts := l.PtpProcessOpts[profileName]
+	assert.True(t, opts.TS2PhcEnabled(), "TS2PhcOpts should default to '-m' when TS2PhcConf is set but TS2PhcOpts is nil")
+	assert.Equal(t, "-m", *opts.TS2PhcOpts)
+}

--- a/plugins/ptp_operator/metrics/manager.go
+++ b/plugins/ptp_operator/metrics/manager.go
@@ -639,6 +639,7 @@ func (p *PTPEventManager) ListHAProfilesWith(currentProfile string) (profile str
 
 // GetNodeSyncState evaluates the node-level sync state based on FREERUN, HOLDOVER, and LOCKED.
 // It returns the worst state among the available MasterClock and ClockRealTime stats.
+// When chronyd is actively reporting CLOCK_REALTIME, stale phc2sys CLOCK_REALTIME entries are excluded.
 func (p *PTPEventManager) GetNodeSyncState(currentState ptp.SyncState) ptp.SyncState {
 	if currentState == "" {
 		currentState = ptp.FREERUN
@@ -646,6 +647,7 @@ func (p *PTPEventManager) GetNodeSyncState(currentState ptp.SyncState) ptp.SyncS
 
 	var finalState ptp.SyncState = ""
 	found := false
+	chronydActive := p.ChronydActiveAsE3()
 
 	p.lock.RLock()
 	defer p.lock.RUnlock()
@@ -654,6 +656,9 @@ func (p *PTPEventManager) GetNodeSyncState(currentState ptp.SyncState) ptp.SyncS
 		mainClockName := ptpStats.GetMainClockName()
 		for iface, stat := range ptpStats {
 			if iface != MasterClockType && iface != ClockRealTime && iface != mainClockName {
+				continue
+			}
+			if iface == ClockRealTime && chronydActive && stat.ProcessName() != chronydProcessName {
 				continue
 			}
 			s := stat.LastSyncState()
@@ -694,6 +699,23 @@ func OverallState(current, updated ptp.SyncState) ptp.SyncState {
 		log.Warnf("last sync state is unknown: %s", updated)
 	}
 	return ""
+}
+
+// ChronydActiveAsE3 returns true if chronyd is currently the active E3
+// publisher — i.e., it has reported a CLOCK_REALTIME state. When chronyd
+// has not reported (e.g. GNSS mode, chronyd is offline), phc2sys remains
+// the E3 authority even if chronyd is configured in the profile.
+func (p *PTPEventManager) ChronydActiveAsE3() bool {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	for _, ptpStats := range p.Stats {
+		if cr, ok := ptpStats[ClockRealTime]; ok {
+			if cr.ProcessName() == chronydProcessName && cr.LastSyncState() != "" {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 const logsEndpoint = "http://localhost:8081/emit-logs"

--- a/plugins/ptp_operator/metrics/manager_test.go
+++ b/plugins/ptp_operator/metrics/manager_test.go
@@ -411,61 +411,61 @@ func TestOverallState(t *testing.T) {
 }
 
 func TestPublishEvent_UsesAggregatedNodeStateAndDedupes(t *testing.T) {
-    // Arrange
-    metrics.Filesystem = &metrics.MockFileSystem{}
-    pubTypes := map[ptp.EventType]*types.EventPublisherType{
-        ptp.PtpStateChange: {
-            EventType: ptp.PtpStateChange,
-            Resource:  ptp.PtpLockState,
-            PubID:     "pub1",
-        },
-        ptp.OsClockSyncStateChange: {
-            EventType: ptp.OsClockSyncStateChange,
-            Resource:  ptp.OsClockSyncState,
-            PubID:     "pub2",
-        },
-        ptp.SyncStateChange: {
-            EventType: ptp.SyncStateChange,
-            Resource:  ptp.SyncStatusState,
-            PubID:     "pub3",
-        },
-    }
-    sc := &common.SCConfiguration{
-        EventOutCh:    make(chan *channel.DataChan, 10),
-        PubSubAPI:     v1pubsub.GetAPIInstance("/tmp/store"),
-        SubscriberAPI: nil,
-        StorePath:     "/tmp/store",
-    }
-    mgr := metrics.NewPTPEventManager("/cluster/node", pubTypes, "testnode", sc)
+	// Arrange
+	metrics.Filesystem = &metrics.MockFileSystem{}
+	pubTypes := map[ptp.EventType]*types.EventPublisherType{
+		ptp.PtpStateChange: {
+			EventType: ptp.PtpStateChange,
+			Resource:  ptp.PtpLockState,
+			PubID:     "pub1",
+		},
+		ptp.OsClockSyncStateChange: {
+			EventType: ptp.OsClockSyncStateChange,
+			Resource:  ptp.OsClockSyncState,
+			PubID:     "pub2",
+		},
+		ptp.SyncStateChange: {
+			EventType: ptp.SyncStateChange,
+			Resource:  ptp.SyncStatusState,
+			PubID:     "pub3",
+		},
+	}
+	sc := &common.SCConfiguration{
+		EventOutCh:    make(chan *channel.DataChan, 10),
+		PubSubAPI:     v1pubsub.GetAPIInstance("/tmp/store"),
+		SubscriberAPI: nil,
+		StorePath:     "/tmp/store",
+	}
+	mgr := metrics.NewPTPEventManager("/cluster/node", pubTypes, "testnode", sc)
 
-    // Build stats across configs to force aggregated state decisions
-    cfg1 := types.ConfigName("ptp4l.0.config")
-    cfg2 := types.ConfigName("phc2sys.0.config")
-    s1 := stats.NewStats(string(cfg1))
-    s2 := stats.NewStats(string(cfg2))
+	// Build stats across configs to force aggregated state decisions
+	cfg1 := types.ConfigName("ptp4l.0.config")
+	cfg2 := types.ConfigName("phc2sys.0.config")
+	s1 := stats.NewStats(string(cfg1))
+	s2 := stats.NewStats(string(cfg2))
 
-    // Scenario A: Master LOCKED, OS FREERUN -> aggregated should be FREERUN
-    s1.SetLastSyncState(ptp.LOCKED)
-    s2.SetLastSyncState(ptp.FREERUN)
-    mgr.SetStats(cfg1, stats.PTPStats{metrics.MasterClockType: s1})
-    mgr.SetStats(cfg2, stats.PTPStats{metrics.ClockRealTime: s2})
+	// Scenario A: Master LOCKED, OS FREERUN -> aggregated should be FREERUN
+	s1.SetLastSyncState(ptp.LOCKED)
+	s2.SetLastSyncState(ptp.FREERUN)
+	mgr.SetStats(cfg1, stats.PTPStats{metrics.MasterClockType: s1})
+	mgr.SetStats(cfg2, stats.PTPStats{metrics.ClockRealTime: s2})
 
-    mockFS := metrics.Filesystem.(*metrics.MockFileSystem)
-    mockFS.Clear()
+	mockFS := metrics.Filesystem.(*metrics.MockFileSystem)
+	mockFS.Clear()
 
-    // Act: Publish master state change; should compute node FREERUN and persist once
-    mgr.MockTest(true)
-    mgr.PublishEvent(ptp.LOCKED, 0, "ens1f0/master", ptp.PtpStateChange)
-    assert.Equal(t, 1, mockFS.WriteCount, "expected a single persist when node state changes to FREERUN")
+	// Act: Publish master state change; should compute node FREERUN and persist once
+	mgr.MockTest(true)
+	mgr.PublishEvent(ptp.LOCKED, 0, "ens1f0/master", ptp.PtpStateChange)
+	assert.Equal(t, 1, mockFS.WriteCount, "expected a single persist when node state changes to FREERUN")
 
-    // Act again with same overall state; should not persist again (dedup)
-    mgr.PublishEvent(ptp.LOCKED, 0, "ens1f0/master", ptp.PtpStateChange)
-    assert.Equal(t, 1, mockFS.WriteCount, "no additional persist expected when node state unchanged")
+	// Act again with same overall state; should not persist again (dedup)
+	mgr.PublishEvent(ptp.LOCKED, 0, "ens1f0/master", ptp.PtpStateChange)
+	assert.Equal(t, 1, mockFS.WriteCount, "no additional persist expected when node state unchanged")
 
-    // Scenario B: Now both LOCKED -> aggregated should move to LOCKED; expect another persist
-    s2.SetLastSyncState(ptp.LOCKED)
-    mgr.SetStats(cfg2, stats.PTPStats{metrics.ClockRealTime: s2})
-    mockFS.WriteCount = 1 // Reset to account for the SetStats write, keeping the previous PublishEvent write
-    mgr.PublishEvent(ptp.LOCKED, 0, metrics.ClockRealTime, ptp.OsClockSyncStateChange)
-    assert.Equal(t, 2, mockFS.WriteCount, "expected persist when node state changes to LOCKED")
+	// Scenario B: Now both LOCKED -> aggregated should move to LOCKED; expect another persist
+	s2.SetLastSyncState(ptp.LOCKED)
+	mgr.SetStats(cfg2, stats.PTPStats{metrics.ClockRealTime: s2})
+	mockFS.WriteCount = 1 // Reset to account for the SetStats write, keeping the previous PublishEvent write
+	mgr.PublishEvent(ptp.LOCKED, 0, metrics.ClockRealTime, ptp.OsClockSyncStateChange)
+	assert.Equal(t, 2, mockFS.WriteCount, "expected persist when node state changes to LOCKED")
 }

--- a/plugins/ptp_operator/metrics/metrics.go
+++ b/plugins/ptp_operator/metrics/metrics.go
@@ -380,8 +380,10 @@ func (p *PTPEventManager) processDownEvent(profileName, processName string, ptpS
 			}
 		}
 		if s, ok := ptpStats[ClockRealTime]; ok {
-			if t := p.PtpConfigMapUpdates.LookupPtpProcessOpts(profileName); t != nil && t.Phc2SysEnabled() {
+			opts := p.PtpConfigMapUpdates.LookupPtpProcessOpts(profileName)
+			if opts != nil && opts.Phc2SysEnabled() && !opts.ChronydEnabled() {
 				p.GenPTPEvent(profileName, s, ClockRealTime, FreeRunOffsetValue, ptp.FREERUN, ptp.OsClockSyncStateChange)
+				UpdateSyncStateMetrics(phc2sysProcessName, ClockRealTime, ptp.FREERUN)
 			}
 		}
 	}

--- a/plugins/ptp_operator/metrics/ntp_test.go
+++ b/plugins/ptp_operator/metrics/ntp_test.go
@@ -1,0 +1,344 @@
+package metrics_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/redhat-cne/cloud-event-proxy/pkg/common"
+	ptpConfig "github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/config"
+	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/metrics"
+	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/ptp4lconf"
+	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/stats"
+	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/types"
+	"github.com/redhat-cne/sdk-go/pkg/event/ptp"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/pointer"
+)
+
+const (
+	ntpFailoverProfile = "ntp-failover"
+	ntpPtp4lCfgName    = "ptp4l.0.config"
+	ntpChronydCfgName  = "chronyd.0.config"
+	ntpPhc2sysOpts     = "-a -r -r -n 24"
+	ntpChronydOpts     = "-f /etc/chrony.conf"
+)
+
+// TestNTPProcessDownDoesNotEmitOsClockSyncStateChange verifies that when
+// phc2sys reports process_status 0 in an NTP-failover configuration (chronyd
+// enabled), no OsClockSyncStateChange event is emitted for CLOCK_REALTIME.
+// Chronyd is the sole E3 publisher in NTP mode.
+func TestNTPProcessDownDoesNotEmitOsClockSyncStateChange(t *testing.T) {
+	eventManager := metrics.NewPTPEventManager("", initPubSubTypes(), "testnode", &common.SCConfiguration{StorePath: "/tmp/store"})
+	eventManager.MockTest(true)
+
+	ptp4lCfg := &ptp4lconf.PTP4lConfig{
+		Name:    ntpPtp4lCfgName,
+		Profile: ntpFailoverProfile,
+		Interfaces: []*ptp4lconf.PTPInterface{
+			{
+				Name:     "ens3f0",
+				PortID:   1,
+				PortName: "port 1",
+				Role:     types.SLAVE,
+			},
+		},
+	}
+	eventManager.AddPTPConfig(types.ConfigName(ntpPtp4lCfgName), ptp4lCfg)
+
+	phc2sysOpts := ntpPhc2sysOpts
+	chronydOpts := ntpChronydOpts
+	eventManager.PtpConfigMapUpdates.PtpProcessOpts = map[string]*ptpConfig.PtpProcessOpts{
+		ntpFailoverProfile: {
+			Phc2Opts:    &phc2sysOpts,
+			ChronydOpts: &chronydOpts,
+		},
+	}
+
+	ptpStats := eventManager.GetStats(types.ConfigName(ntpPtp4lCfgName))
+	ptpStats.CheckSource(metrics.ClockRealTime, ntpPtp4lCfgName, "phc2sys")
+	ptpStats[metrics.ClockRealTime].SetLastSyncState(ptp.LOCKED)
+
+	eventManager.ResetMockEvent()
+
+	phc2sysDown := fmt.Sprintf("phc2sys[1234.567]: [%s] PTP_PROCESS_STATUS 0", ntpPtp4lCfgName)
+	eventManager.ExtractMetrics(phc2sysDown)
+
+	mockEvents := eventManager.GetMockEvent()
+	for _, evt := range mockEvents {
+		assert.NotEqual(t, ptp.OsClockSyncStateChange, evt,
+			"phc2sys process-down must NOT emit OsClockSyncStateChange when chronyd is enabled")
+	}
+
+	assert.Equal(t, ptp.LOCKED, ptpStats[metrics.ClockRealTime].LastSyncState(),
+		"CLOCK_REALTIME internal state must remain LOCKED (chronyd manages it)")
+}
+
+// TestNTPProcessDownEmitsOsClockWhenNoChronyd confirms that the existing
+// behavior is preserved: when phc2sys goes down in a profile WITHOUT chronyd,
+// CLOCK_REALTIME should transition to FREERUN.
+func TestNTPProcessDownEmitsOsClockWhenNoChronyd(t *testing.T) {
+	profileName := "ptp-oc"
+
+	eventManager := metrics.NewPTPEventManager("", initPubSubTypes(), "testnode", &common.SCConfiguration{StorePath: "/tmp/store"})
+	eventManager.MockTest(true)
+
+	ptp4lCfg := &ptp4lconf.PTP4lConfig{
+		Name:    ntpPtp4lCfgName,
+		Profile: profileName,
+		Interfaces: []*ptp4lconf.PTPInterface{
+			{
+				Name:     "ens3f0",
+				PortID:   1,
+				PortName: "port 1",
+				Role:     types.SLAVE,
+			},
+		},
+	}
+	eventManager.AddPTPConfig(types.ConfigName(ntpPtp4lCfgName), ptp4lCfg)
+
+	phc2sysOpts := ntpPhc2sysOpts
+	eventManager.PtpConfigMapUpdates.PtpProcessOpts = map[string]*ptpConfig.PtpProcessOpts{
+		profileName: {
+			Phc2Opts: &phc2sysOpts,
+		},
+	}
+
+	ptpStats := eventManager.GetStats(types.ConfigName(ntpPtp4lCfgName))
+	ptpStats.CheckSource(metrics.ClockRealTime, ntpPtp4lCfgName, "phc2sys")
+	ptpStats[metrics.ClockRealTime].SetLastSyncState(ptp.LOCKED)
+
+	eventManager.ResetMockEvent()
+
+	phc2sysDown := fmt.Sprintf("phc2sys[1234.567]: [%s] PTP_PROCESS_STATUS 0", ntpPtp4lCfgName)
+	eventManager.ExtractMetrics(phc2sysDown)
+
+	mockEvents := eventManager.GetMockEvent()
+	hasOsClockEvent := false
+	for _, evt := range mockEvents {
+		if evt == ptp.OsClockSyncStateChange {
+			hasOsClockEvent = true
+		}
+	}
+	assert.True(t, hasOsClockEvent,
+		"phc2sys process-down MUST emit OsClockSyncStateChange when chronyd is NOT enabled")
+
+	assert.Equal(t, ptp.FREERUN, ptpStats[metrics.ClockRealTime].LastSyncState(),
+		"CLOCK_REALTIME should be FREERUN after phc2sys dies (no chronyd)")
+}
+
+// TestNTPChronydSelectedSourceSetsLocked verifies that chronyd "Selected source"
+// correctly sets CLOCK_REALTIME to LOCKED and is the sole E3 publisher.
+func TestNTPChronydSelectedSourceSetsLocked(t *testing.T) {
+	eventManager := metrics.NewPTPEventManager("", initPubSubTypes(), "testnode", &common.SCConfiguration{StorePath: "/tmp/store"})
+	eventManager.MockTest(true)
+
+	ptp4lCfg := &ptp4lconf.PTP4lConfig{
+		Name:    ntpChronydCfgName,
+		Profile: ntpFailoverProfile,
+	}
+	eventManager.AddPTPConfig(types.ConfigName(ntpChronydCfgName), ptp4lCfg)
+
+	chronydOpts := ntpChronydOpts
+	eventManager.PtpConfigMapUpdates.PtpProcessOpts = map[string]*ptpConfig.PtpProcessOpts{
+		ntpFailoverProfile: {
+			ChronydOpts: &chronydOpts,
+		},
+	}
+
+	eventManager.ResetMockEvent()
+
+	chronydLog := fmt.Sprintf("chronyd[5678.901]: [%s] Selected source 192.168.1.1 (ntp.example.com)", ntpChronydCfgName)
+	eventManager.ExtractMetrics(chronydLog)
+
+	ptpStats := eventManager.GetStats(types.ConfigName(ntpChronydCfgName))
+	cStat, ok := ptpStats[metrics.ClockRealTime]
+	assert.True(t, ok, "CLOCK_REALTIME stats should exist after chronyd Selected source")
+	assert.Equal(t, ptp.LOCKED, cStat.LastSyncState(),
+		"CLOCK_REALTIME should be LOCKED from chronyd Selected source")
+
+	mockEvents := eventManager.GetMockEvent()
+	hasOsClockEvent := false
+	for _, evt := range mockEvents {
+		if evt == ptp.OsClockSyncStateChange {
+			hasOsClockEvent = true
+		}
+	}
+	assert.True(t, hasOsClockEvent,
+		"chronyd Selected source must emit OsClockSyncStateChange")
+}
+
+// TestNTPNodeSyncStateIncludesMasterFreerun verifies that in the STABLE NTP
+// state, the node-level sync-state is FREERUN because ptp4l master (PTP source
+// absent) is in FREERUN. Per the state chart, sync-state = worst(os-clock=LOCKED,
+// ptp-lock=FREERUN) = FREERUN.
+func TestNTPNodeSyncStateIncludesMasterFreerun(t *testing.T) {
+	eventManager := metrics.NewPTPEventManager("", initPubSubTypes(), "testnode", &common.SCConfiguration{StorePath: "/tmp/store"})
+	eventManager.MockTest(true)
+
+	ptp4lCfg := &ptp4lconf.PTP4lConfig{
+		Name:    ntpPtp4lCfgName,
+		Profile: ntpFailoverProfile,
+		Interfaces: []*ptp4lconf.PTPInterface{
+			{
+				Name:     "ens3f0",
+				PortID:   1,
+				PortName: "port 1",
+				Role:     types.SLAVE,
+			},
+		},
+	}
+	eventManager.AddPTPConfig(types.ConfigName(ntpPtp4lCfgName), ptp4lCfg)
+
+	chronydCfg := &ptp4lconf.PTP4lConfig{
+		Name:    ntpChronydCfgName,
+		Profile: ntpFailoverProfile,
+	}
+	eventManager.AddPTPConfig(types.ConfigName(ntpChronydCfgName), chronydCfg)
+
+	phc2sysOpts := ntpPhc2sysOpts
+	chronydOpts := ntpChronydOpts
+	eventManager.PtpConfigMapUpdates.PtpProcessOpts = map[string]*ptpConfig.PtpProcessOpts{
+		ntpFailoverProfile: {
+			Phc2Opts:    &phc2sysOpts,
+			ChronydOpts: &chronydOpts,
+		},
+	}
+
+	ptp4lStats := eventManager.GetStats(types.ConfigName(ntpPtp4lCfgName))
+	ptp4lStats.CheckSource(metrics.MasterClockType, ntpPtp4lCfgName, "ptp4l")
+	ptp4lStats[metrics.MasterClockType].SetLastSyncState(ptp.FREERUN)
+	ptp4lStats[metrics.MasterClockType].SetAlias("ens3f0")
+
+	chronydStats := eventManager.GetStats(types.ConfigName(ntpChronydCfgName))
+	chronydStats.CheckSource(metrics.ClockRealTime, ntpChronydCfgName, "chronyd")
+	chronydStats[metrics.ClockRealTime].SetLastSyncState(ptp.LOCKED)
+
+	nodeState := eventManager.GetNodeSyncState(ptp.LOCKED)
+	assert.Equal(t, ptp.FREERUN, nodeState,
+		"STABLE NTP: sync-state must be FREERUN (ptp4l master FREERUN drags it down per state chart)")
+}
+
+// TestNTPNoDoubleClockRealtime verifies the full NTP-failover scenario:
+// phc2sys goes down but chronyd maintains CLOCK_REALTIME, resulting in a
+// single consistent CLOCK_REALTIME state (LOCKED) without conflicting events.
+func TestNTPNoDoubleClockRealtime(t *testing.T) {
+	eventManager := metrics.NewPTPEventManager("", initPubSubTypes(), "testnode", &common.SCConfiguration{StorePath: "/tmp/store"})
+	eventManager.MockTest(true)
+
+	ptp4lCfg := &ptp4lconf.PTP4lConfig{
+		Name:    ntpPtp4lCfgName,
+		Profile: ntpFailoverProfile,
+		Interfaces: []*ptp4lconf.PTPInterface{
+			{
+				Name:     "ens3f0",
+				PortID:   1,
+				PortName: "port 1",
+				Role:     types.SLAVE,
+			},
+		},
+	}
+	eventManager.AddPTPConfig(types.ConfigName(ntpPtp4lCfgName), ptp4lCfg)
+
+	chronydCfg := &ptp4lconf.PTP4lConfig{
+		Name:    ntpChronydCfgName,
+		Profile: ntpFailoverProfile,
+	}
+	eventManager.AddPTPConfig(types.ConfigName(ntpChronydCfgName), chronydCfg)
+
+	phc2sysOpts := ntpPhc2sysOpts
+	chronydOpts := ntpChronydOpts
+	eventManager.PtpConfigMapUpdates.PtpProcessOpts = map[string]*ptpConfig.PtpProcessOpts{
+		ntpFailoverProfile: {
+			Phc2Opts:    &phc2sysOpts,
+			ChronydOpts: &chronydOpts,
+		},
+	}
+
+	metrics.SetMasterOffsetSource("ptp4l")
+
+	// Step 1: ptp4l reports port SLAVE — initializes ptpStats
+	replacer := strings.NewReplacer("[", " ", "]", " ", ":", " ")
+	_ = replacer
+
+	ptp4lSlave := fmt.Sprintf("ptp4l[1000.000]: [%s] port 1 (ens3f0): LISTENING to SLAVE on RS_SLAVE", ntpPtp4lCfgName)
+	eventManager.ExtractMetrics(ptp4lSlave)
+	t.Log("Step 1: ptp4l port goes SLAVE")
+
+	// Step 2: phc2sys reports process DOWN
+	eventManager.ResetMockEvent()
+	phc2sysDown := fmt.Sprintf("phc2sys[1001.000]: [%s] PTP_PROCESS_STATUS 0", ntpPtp4lCfgName)
+	eventManager.ExtractMetrics(phc2sysDown)
+	t.Log("Step 2: phc2sys process goes DOWN")
+
+	mockEvents := eventManager.GetMockEvent()
+	for _, evt := range mockEvents {
+		assert.NotEqual(t, ptp.OsClockSyncStateChange, evt,
+			"No OsClockSyncStateChange should fire for phc2sys down in NTP mode")
+	}
+
+	// Step 3: chronyd reports Selected source → CLOCK_REALTIME LOCKED
+	eventManager.ResetMockEvent()
+	chronydSelected := fmt.Sprintf("chronyd[1002.000]: [%s] Selected source 192.168.1.1 (ntp.example.com)", ntpChronydCfgName)
+	eventManager.ExtractMetrics(chronydSelected)
+	t.Log("Step 3: chronyd Selected source")
+
+	chronydStats := eventManager.GetStats(types.ConfigName(ntpChronydCfgName))
+	assert.Equal(t, ptp.LOCKED, chronydStats[metrics.ClockRealTime].LastSyncState(),
+		"chronyd CLOCK_REALTIME should be LOCKED")
+
+	// Verify ptp4l's stats for CLOCK_REALTIME were not set to FREERUN
+	ptp4lStats := eventManager.GetStats(types.ConfigName(ntpPtp4lCfgName))
+	if crStat, ok := ptp4lStats[metrics.ClockRealTime]; ok {
+		assert.NotEqual(t, ptp.FREERUN, crStat.LastSyncState(),
+			"ptp4l config CLOCK_REALTIME should NOT be set to FREERUN by processDownEvent in NTP mode")
+	}
+}
+
+// TestNTPNodeSyncStateDuringHoldover verifies that during the "LOST GNSS
+// (IN HOLDOVER SPEC)" state, sync-state is correctly HOLDOVER even when
+// os-clock-sync-state (CLOCK_REALTIME) is LOCKED. Per the state chart,
+// sync-state = worst(os-clock=LOCKED, ptp-lock=HOLDOVER) = HOLDOVER.
+func TestNTPNodeSyncStateDuringHoldover(t *testing.T) {
+	profileName := "gnss-failover"
+
+	eventManager := metrics.NewPTPEventManager("", initPubSubTypes(), "testnode", &common.SCConfiguration{StorePath: "/tmp/store"})
+	eventManager.MockTest(true)
+
+	ptp4lCfg := &ptp4lconf.PTP4lConfig{
+		Name:    ntpPtp4lCfgName,
+		Profile: profileName,
+		Interfaces: []*ptp4lconf.PTPInterface{
+			{
+				Name:     "ens3f0",
+				PortID:   1,
+				PortName: "port 1",
+				Role:     types.SLAVE,
+			},
+		},
+	}
+	eventManager.AddPTPConfig(types.ConfigName(ntpPtp4lCfgName), ptp4lCfg)
+
+	phc2sysOpts := ntpPhc2sysOpts
+	eventManager.PtpConfigMapUpdates.PtpProcessOpts = map[string]*ptpConfig.PtpProcessOpts{
+		profileName: {
+			Phc2Opts: &phc2sysOpts,
+		},
+	}
+
+	ptpStats := eventManager.GetStats(types.ConfigName(ntpPtp4lCfgName))
+	ptpStats.CheckSource(metrics.MasterClockType, ntpPtp4lCfgName, "ptp4l")
+	ptpStats[metrics.MasterClockType].SetLastSyncState(ptp.HOLDOVER)
+	ptpStats[metrics.MasterClockType].SetAlias("ens3f0")
+
+	ptpStats.CheckSource(metrics.ClockRealTime, ntpPtp4lCfgName, "phc2sys")
+	ptpStats[metrics.ClockRealTime].SetLastSyncState(ptp.LOCKED)
+
+	nodeState := eventManager.GetNodeSyncState(ptp.LOCKED)
+	assert.Equal(t, ptp.HOLDOVER, nodeState,
+		"LOST GNSS (HOLDOVER): sync-state must be HOLDOVER even though os-clock is LOCKED")
+}
+
+// Silence unused-import warnings for packages referenced indirectly.
+var _ = pointer.String
+var _ = stats.TBCMainClockName

--- a/plugins/ptp_operator/ptp_operator_plugin.go
+++ b/plugins/ptp_operator/ptp_operator_plugin.go
@@ -48,8 +48,11 @@ import (
 )
 
 const (
-	eventSocket        = "/cloud-native/events.sock"
-	ptpConfigDir       = "/var/run/"
+	eventSocket      = "/cloud-native/events.sock"
+	ptpConfigDir     = "/var/run/"
+	restartCommand   = "CMD RESTART"
+	liveStartCommand = "CMD LIVE_START"
+
 	phc2sysProcessName = "phc2sys"
 	ptp4lProcessName   = "ptp4l"
 	ts2PhcProcessName  = "ts2phc"
@@ -237,6 +240,7 @@ func getCurrentStatOverrideFn() func(e v2.Event, d *channel.DataChan) error {
 		}
 
 		var overallSyncState ptp.SyncState
+		chronydIsE3 := chronydActiveAsE3(eventManager)
 		for config := range eventManager.Stats { // configname->PTPStats
 			mainClockName := eventManager.Stats[config].GetMainClockName()
 			for ptpInterface, s := range eventManager.GetStats(config) { // iface->stats
@@ -261,6 +265,11 @@ func getCurrentStatOverrideFn() func(e v2.Event, d *channel.DataChan) error {
 						overallSyncState = getOverallState(overallSyncState, s.SyncState())
 					}
 				case ptpMetrics.ClockRealTime:
+					if s.ProcessName() != chronydProcessName {
+						if chronydIsE3 {
+							break
+						}
+					}
 					switch eventType {
 					case ptp.OsClockSyncStateChange:
 						data = processDataFn(data, eventManager.GetPTPEventsData(s.SyncState(), s.LastOffset(), string(ptpInterface), eventType))
@@ -627,6 +636,13 @@ func processPtp4lConfigFileUpdates() {
 		}
 	}
 }
+
+// chronydActiveAsE3 delegates to the PTPEventManager method that checks
+// whether chronyd has reported a valid CLOCK_REALTIME state.
+func chronydActiveAsE3(em *ptpMetrics.PTPEventManager) bool {
+	return em.ChronydActiveAsE3()
+}
+
 func createPublisher(address string) (pub pubsub.PubSub, err error) {
 	// this is loop back on server itself. Since current pod does not create any server
 	returnURL := fmt.Sprintf("%s%s", config.BaseURL, "dummy")
@@ -673,10 +689,18 @@ func processMessages(c net.Conn) {
 	for {
 		ok := scanner.Scan()
 		if !ok {
-			log.Error("error reading socket input, retrying")
+			log.Debugf("processMessages: scanner returned false (conn closed or error), breaking")
 			break
 		}
 		msg := scanner.Text()
+		if msg == restartCommand {
+			log.Debug("processMessages: received CMD RESTART")
+			return
+		}
+		if msg == liveStartCommand {
+			log.Debug("processMessages: received LIVE_START marker - live data follows")
+			continue
+		}
 		eventManager.ExtractMetrics(msg)
 	}
 }

--- a/plugins/ptp_operator/ptp_operator_plugin_test.go
+++ b/plugins/ptp_operator/ptp_operator_plugin_test.go
@@ -21,16 +21,21 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net"
+	"net/http"
 	"os"
 	"path"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	v2 "github.com/cloudevents/sdk-go/v2"
 	"github.com/google/uuid"
+	ptpConfig "github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/config"
 	event2 "github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/event"
 	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/metrics"
+	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/ptp4lconf"
 	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/stats"
 	"github.com/redhat-cne/sdk-go/pkg/event"
 	"github.com/redhat-cne/sdk-go/pkg/types"
@@ -402,6 +407,284 @@ func buildEvent(node string, source ptpEvent.EventResource, eventType ptpEvent.E
 	e.SetSource(fmt.Sprintf("/cluster/node/%s%s", node, string(source)))
 	e.SetType(string(eventType))
 	return e
+}
+
+// startMockLogsServer starts a minimal HTTP server on the logsEndpoint port
+// (8081) so that eventManager.TriggerLogs() succeeds during tests.
+// Returns a cleanup function that shuts down the server.
+func startMockLogsServer(t *testing.T) func() {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/emit-logs", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	const mockLogsAddr = "127.0.0.1:8081"
+	srv := &http.Server{Addr: mockLogsAddr, Handler: mux}
+	var ln net.Listener
+	var err error
+	for i := 0; i < 10; i++ {
+		ln, err = net.Listen("tcp", mockLogsAddr)
+		if err == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("failed to listen on %s for mock logs server: %v", mockLogsAddr, err)
+	}
+	go func() { _ = srv.Serve(ln) }()
+	return func() { _ = srv.Close() }
+}
+
+// setupProcessMessages prepares the globals that processMessages depends on.
+// eventManager is configured in mock-test mode.
+func setupProcessMessages(t *testing.T) func() {
+	t.Helper()
+	oldEventManager := eventManager
+
+	scCfg := &common.SCConfiguration{}
+	eventManager = metrics.NewPTPEventManager(resourcePrefix, pubsubTypes, nodeName, scCfg)
+	eventManager.MockTest(true)
+
+	return func() {
+		eventManager = oldEventManager
+	}
+}
+
+func TestProcessMessages_LiveStartSkipped(t *testing.T) {
+	cleanup := startMockLogsServer(t)
+	defer cleanup()
+	restore := setupProcessMessages(t)
+	defer restore()
+
+	serverConn, clientConn := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		processMessages(serverConn)
+		close(done)
+	}()
+
+	_, err := fmt.Fprintf(clientConn, "%s\n", liveStartCommand)
+	assert.NoError(t, err)
+	_ = clientConn.Close()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("processMessages did not return after CMD LIVE_START + EOF")
+	}
+}
+
+func TestProcessMessages_LiveStartBetweenRegularMessages(t *testing.T) {
+	cleanup := startMockLogsServer(t)
+	defer cleanup()
+	restore := setupProcessMessages(t)
+	defer restore()
+
+	serverConn, clientConn := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		processMessages(serverConn)
+		close(done)
+	}()
+
+	msgs := []string{
+		"ptp4l[123.456]: [ptp4l.0.config] master offset  5 s2 freq -1000 path delay 100",
+		liveStartCommand,
+		"ptp4l[123.457]: [ptp4l.0.config] master offset  3 s2 freq  -998 path delay  99",
+		liveStartCommand,
+		"phc2sys[123.458]: [ptp4l.0.config] CLOCK_REALTIME phc offset  10 s2 freq -500 delay 200",
+	}
+	for _, m := range msgs {
+		_, err := fmt.Fprintf(clientConn, "%s\n", m)
+		assert.NoError(t, err)
+	}
+	_ = clientConn.Close()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("processMessages did not return after mixed LIVE_START and regular messages")
+	}
+}
+
+func TestProcessMessages_TriggerLogsFailureNonBlocking(t *testing.T) {
+	// No mock HTTP server → TriggerLogs will fail, but since it's async
+	// the scanner should still process messages on this connection.
+	restore := setupProcessMessages(t)
+	defer restore()
+
+	serverConn, clientConn := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		processMessages(serverConn)
+		close(done)
+	}()
+
+	// Even though TriggerLogs fails (no HTTP server), processMessages must
+	// still read from the connection because TriggerLogs is async.
+	_, err := fmt.Fprintf(clientConn, "%s\n", liveStartCommand)
+	assert.NoError(t, err)
+	_ = clientConn.Close()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("processMessages should still process messages when TriggerLogs fails async")
+	}
+}
+
+func TestProcessMessages_MultipleLiveStartOnly(t *testing.T) {
+	cleanup := startMockLogsServer(t)
+	defer cleanup()
+	restore := setupProcessMessages(t)
+	defer restore()
+
+	serverConn, clientConn := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		processMessages(serverConn)
+		close(done)
+	}()
+
+	for i := 0; i < 5; i++ {
+		_, err := fmt.Fprintf(clientConn, "%s\n", liveStartCommand)
+		assert.NoError(t, err)
+	}
+	_ = clientConn.Close()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("processMessages did not return after multiple CMD LIVE_START messages")
+	}
+}
+
+func TestLiveStartCommand_ConstantValue(t *testing.T) {
+	assert.Equal(t, "CMD LIVE_START", liveStartCommand)
+	assert.NotEqual(t, restartCommand, liveStartCommand,
+		"LIVE_START and RESTART must be distinct commands")
+	assert.True(t, strings.HasPrefix(liveStartCommand, "CMD "),
+		"control commands should use CMD prefix to distinguish from log lines")
+}
+
+// TestCurrentState_ChronydSkipsStalePhc2sysClockRealtime verifies that
+// the CurrentState handler only returns the chronyd-managed CLOCK_REALTIME
+// when chronyd is enabled, ignoring the stale phc2sys FREERUN entry.
+func TestCurrentState_ChronydSkipsStalePhc2sysClockRealtime(t *testing.T) {
+	profileName := "ntp-failover"
+	ptp4lCfgName := "ptp4l.0.config"
+	chronydCfgName := "chronyd.0.config"
+
+	eventManager = metrics.NewPTPEventManager("/cluster/node", pubsubTypes, nodeName, scConfig)
+	eventManager.MockTest(true)
+
+	// Register ptp4l config with the profile
+	eventManager.AddPTPConfig(ptpTypes.ConfigName(ptp4lCfgName), &ptp4lconf.PTP4lConfig{
+		Name:    ptp4lCfgName,
+		Profile: profileName,
+		Interfaces: []*ptp4lconf.PTPInterface{
+			{Name: "ens3f0", PortID: 1, PortName: "port 1", Role: ptpTypes.SLAVE},
+		},
+	})
+
+	// Register chronyd config with the same profile
+	eventManager.AddPTPConfig(ptpTypes.ConfigName(chronydCfgName), &ptp4lconf.PTP4lConfig{
+		Name:    chronydCfgName,
+		Profile: profileName,
+	})
+
+	// Set up PtpProcessOpts with chronyd enabled (simulating the production path)
+	phc2sysOpts := "-a -r -r -n 24"
+	chronydOpts := "-f /etc/chrony.conf"
+	eventManager.PtpConfigMapUpdates.PtpProcessOpts = map[string]*ptpConfig.PtpProcessOpts{
+		profileName: {
+			Phc2Opts:    &phc2sysOpts,
+			ChronydOpts: &chronydOpts,
+		},
+	}
+
+	// Set up stats: ptp4l config has stale phc2sys FREERUN for CLOCK_REALTIME
+	ptp4lStats := eventManager.GetStats(ptpTypes.ConfigName(ptp4lCfgName))
+	ptp4lStats.CheckSource(metrics.ClockRealTime, ptp4lCfgName, "phc2sys")
+	ptp4lStats[metrics.ClockRealTime].SetLastSyncState(ptpEvent.FREERUN)
+	ptp4lStats[metrics.ClockRealTime].SetProcessName("phc2sys")
+
+	// Set up stats: chronyd config has authoritative LOCKED for CLOCK_REALTIME
+	chronydStats := eventManager.GetStats(ptpTypes.ConfigName(chronydCfgName))
+	chronydStats.CheckSource(metrics.ClockRealTime, chronydCfgName, "chronyd")
+	chronydStats[metrics.ClockRealTime].SetLastSyncState(ptpEvent.LOCKED)
+	chronydStats[metrics.ClockRealTime].SetProcessName("chronyd")
+
+	// Request OsClockSyncState CurrentState
+	ev := buildEvent(nodeName, ptpEvent.OsClockSyncState, ptpEvent.OsClockSyncStateChange)
+	mockDataChan := &channel.DataChan{
+		ClientID: uuid.MustParse("123e4567-e89b-12d3-a456-426614174000"),
+	}
+	overrideFn := getCurrentStatOverrideFn()
+	err := overrideFn(ev, mockDataChan)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, mockDataChan.Data)
+
+	eventReceived, err2 := v1event.GetCloudNativeEvents(*mockDataChan.Data)
+	assert.Nil(t, err2)
+
+	// Should have values from only ONE CLOCK_REALTIME source (chronyd, LOCKED).
+	// GetPTPEventsData adds 2 DataValues per source (NOTIFICATION + METRIC).
+	assert.Equal(t, 2, len(eventReceived.Data.Values),
+		"Should have exactly 2 DataValues (one source: chronyd only)")
+	assert.Equal(t, string(ptpEvent.LOCKED), eventReceived.Data.Values[0].Value,
+		"CLOCK_REALTIME state should be LOCKED (from chronyd, not stale phc2sys FREERUN)")
+}
+
+// TestCurrentState_NoChronydIncludesPhc2sysClockRealtime verifies that
+// when chronyd is NOT enabled, the standard phc2sys CLOCK_REALTIME is returned.
+func TestCurrentState_NoChronydIncludesPhc2sysClockRealtime(t *testing.T) {
+	profileName := "ptp-oc"
+	ptp4lCfgName := "ptp4l.0.config"
+
+	eventManager = metrics.NewPTPEventManager("/cluster/node", pubsubTypes, nodeName, scConfig)
+	eventManager.MockTest(true)
+
+	eventManager.AddPTPConfig(ptpTypes.ConfigName(ptp4lCfgName), &ptp4lconf.PTP4lConfig{
+		Name:    ptp4lCfgName,
+		Profile: profileName,
+		Interfaces: []*ptp4lconf.PTPInterface{
+			{Name: "ens3f0", PortID: 1, PortName: "port 1", Role: ptpTypes.SLAVE},
+		},
+	})
+
+	phc2sysOpts := "-a -r -r -n 24"
+	eventManager.PtpConfigMapUpdates.PtpProcessOpts = map[string]*ptpConfig.PtpProcessOpts{
+		profileName: {
+			Phc2Opts: &phc2sysOpts,
+		},
+	}
+
+	ptp4lStats := eventManager.GetStats(ptpTypes.ConfigName(ptp4lCfgName))
+	ptp4lStats.CheckSource(metrics.ClockRealTime, ptp4lCfgName, "phc2sys")
+	ptp4lStats[metrics.ClockRealTime].SetLastSyncState(ptpEvent.LOCKED)
+	ptp4lStats[metrics.ClockRealTime].SetProcessName("phc2sys")
+
+	ev := buildEvent(nodeName, ptpEvent.OsClockSyncState, ptpEvent.OsClockSyncStateChange)
+	mockDataChan := &channel.DataChan{
+		ClientID: uuid.MustParse("123e4567-e89b-12d3-a456-426614174000"),
+	}
+	overrideFn := getCurrentStatOverrideFn()
+	err := overrideFn(ev, mockDataChan)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, mockDataChan.Data)
+
+	eventReceived, err2 := v1event.GetCloudNativeEvents(*mockDataChan.Data)
+	assert.Nil(t, err2)
+
+	// GetPTPEventsData adds 2 DataValues per source (NOTIFICATION + METRIC).
+	assert.Equal(t, 2, len(eventReceived.Data.Values),
+		"Should have exactly 2 DataValues (one source: phc2sys)")
+	assert.Equal(t, string(ptpEvent.LOCKED), eventReceived.Data.Values[0].Value,
+		"CLOCK_REALTIME state should be LOCKED from phc2sys")
 }
 
 func getMockOverrideFn() func(e v2.Event, d *channel.DataChan) error {


### PR DESCRIPTION
In NTP-failover profiles (chronyd + phc2sys configured), phc2sys process-down was emitting a spurious OsClockSyncStateChange FREERUN event for CLOCK_REALTIME, conflicting with chronyd which is the sole E3 authority in NTP mode. This caused:
- Double CLOCK_REALTIME values in os-clock-sync-state events
- Stale openshift_ptp_clock_state{process="phc2sys"} metric

Fix: skip the OsClockSyncStateChange emission in processDownEvent when ChronydEnabled() is true for the profile. Also update the Prometheus gauge on the non-chronyd path to prevent stale metrics.