### PR TITLE
OCPBUGS-90708: fix CurrentState aggregation

### DIFF
--- a/plugins/ptp_operator/config/config.go
+++ b/plugins/ptp_operator/config/config.go
@@ -272,9 +272,11 @@ func (l *LinuxPTPConfigMapUpdate) UpdatePTPProcessOptions() {
 	l.PtpProcessOpts = make(map[string]*PtpProcessOpts)
 	for _, profile := range l.NodeProfiles {
 		l.PtpProcessOpts[*profile.Name] = &PtpProcessOpts{
-			Ptp4lOpts:  profile.Ptp4lOpts,
-			Phc2Opts:   profile.Phc2sysOpts,
-			TS2PhcOpts: profile.TS2PhcOpts}
+			Ptp4lOpts:   profile.Ptp4lOpts,
+			Phc2Opts:    profile.Phc2sysOpts,
+			TS2PhcOpts:  profile.TS2PhcOpts,
+			ChronydOpts: profile.ChronydOpts,
+		}
 		// ts2phcOpts are empty by default
 		if profile.TS2PhcConf != nil && (profile.TS2PhcOpts == nil || *profile.TS2PhcOpts == "") {
 			l.PtpProcessOpts[*profile.Name].TS2PhcOpts = pointer.String("-m")

--- a/plugins/ptp_operator/config/config_test.go
+++ b/plugins/ptp_operator/config/config_test.go
@@ -167,3 +167,86 @@ func Test_Config(t *testing.T) {
 	}
 	closeCh <- struct{}{}
 }
+
+func TestUpdatePTPProcessOptions_PopulatesChronydOpts(t *testing.T) {
+	chronydOpts := "-f /etc/chrony.conf"
+	phc2sysOpts := "-a -r -r -n 24"
+	ptp4lOpts := "-2 -s"
+	ts2phcOpts := "-m"
+	profileName := "ntp-failover"
+
+	l := &ptpConfig.LinuxPTPConfigMapUpdate{
+		NodeProfiles: []ptpConfig.PtpProfile{
+			{
+				Name:        &profileName,
+				Ptp4lOpts:   &ptp4lOpts,
+				Phc2sysOpts: &phc2sysOpts,
+				TS2PhcOpts:  &ts2phcOpts,
+				ChronydOpts: &chronydOpts,
+			},
+		},
+		PtpProcessOpts: make(map[string]*ptpConfig.PtpProcessOpts),
+		PtpSettings:    make(map[string]map[string]string),
+	}
+
+	l.UpdatePTPProcessOptions()
+
+	opts, ok := l.PtpProcessOpts[profileName]
+	assert.True(t, ok, "profile must be present in PtpProcessOpts")
+	assert.True(t, opts.ChronydEnabled(), "ChronydEnabled() must return true when profile has chronydOpts")
+	assert.Equal(t, chronydOpts, *opts.ChronydOpts)
+	assert.True(t, opts.Ptp4lEnabled())
+	assert.True(t, opts.Phc2SysEnabled())
+	assert.True(t, opts.TS2PhcEnabled())
+}
+
+func TestUpdatePTPProcessOptions_NilChronydOpts(t *testing.T) {
+	phc2sysOpts := "-a -r -r -n 24"
+	ptp4lOpts := "-2 -s"
+	profileName := "ptp-oc"
+
+	l := &ptpConfig.LinuxPTPConfigMapUpdate{
+		NodeProfiles: []ptpConfig.PtpProfile{
+			{
+				Name:        &profileName,
+				Ptp4lOpts:   &ptp4lOpts,
+				Phc2sysOpts: &phc2sysOpts,
+				ChronydOpts: nil,
+			},
+		},
+		PtpProcessOpts: make(map[string]*ptpConfig.PtpProcessOpts),
+		PtpSettings:    make(map[string]map[string]string),
+	}
+
+	l.UpdatePTPProcessOptions()
+
+	opts, ok := l.PtpProcessOpts[profileName]
+	assert.True(t, ok, "profile must be present in PtpProcessOpts")
+	assert.False(t, opts.ChronydEnabled(), "ChronydEnabled() must return false when profile has no chronydOpts")
+	assert.True(t, opts.Ptp4lEnabled())
+	assert.True(t, opts.Phc2SysEnabled())
+}
+
+func TestUpdatePTPProcessOptions_TS2PhcConfSetsDefaultOpts(t *testing.T) {
+	ptp4lOpts := "-2 -s"
+	profileName := "ts2phc-profile"
+	ts2phcConf := "[global]\n"
+
+	l := &ptpConfig.LinuxPTPConfigMapUpdate{
+		NodeProfiles: []ptpConfig.PtpProfile{
+			{
+				Name:       &profileName,
+				Ptp4lOpts:  &ptp4lOpts,
+				TS2PhcConf: &ts2phcConf,
+			},
+		},
+		PtpProcessOpts: make(map[string]*ptpConfig.PtpProcessOpts),
+		PtpSettings:    make(map[string]map[string]string),
+	}
+
+	l.UpdatePTPProcessOptions()
+
+	opts := l.PtpProcessOpts[profileName]
+	assert.True(t, opts.TS2PhcEnabled(), "TS2PhcOpts should default to '-m' when TS2PhcConf is set but TS2PhcOpts is nil")
+	assert.Equal(t, "-m", *opts.TS2PhcOpts)
+}

--- a/plugins/ptp_operator/metrics/manager.go
+++ b/plugins/ptp_operator/metrics/manager.go
@@ -685,6 +685,7 @@ func (p *PTPEventManager) ListHAProfilesWith(currentProfile string) (profile str
 // GetNodeSyncState evaluates the node-level sync state based on FREERUN, HOLDOVER, and LOCKED.
 // It returns the worst state among the available MasterClock and ClockRealTime stats.
 // For T-BC profiles, ptp4l master offset (iface master) is excluded since T-BC-STATUS is authoritative.
+// When chronyd is actively reporting CLOCK_REALTIME, stale phc2sys CLOCK_REALTIME entries are excluded.
 func (p *PTPEventManager) GetNodeSyncState(currentState ptp.SyncState) ptp.SyncState {
 	if currentState == "" {
 		currentState = ptp.FREERUN
@@ -692,6 +693,7 @@ func (p *PTPEventManager) GetNodeSyncState(currentState ptp.SyncState) ptp.SyncS
 
 	var finalState ptp.SyncState = ""
 	found := false
+	chronydActive := p.ChronydActiveAsE3()
 
 	p.lock.RLock()
 	defer p.lock.RUnlock()
@@ -703,6 +705,9 @@ func (p *PTPEventManager) GetNodeSyncState(currentState ptp.SyncState) ptp.SyncS
 				if iface != MasterClockType || mainClockName == types.IFace(stats.TBCMainClockName) {
 					continue
 				}
+			}
+			if iface == ClockRealTime && chronydActive && stat.ProcessName() != chronydProcessName {
+				continue
 			}
 			s := stat.LastSyncState()
 			if s != ptp.FREERUN && s != ptp.HOLDOVER && s != ptp.LOCKED {
@@ -742,6 +747,23 @@ func OverallState(current, updated ptp.SyncState) ptp.SyncState {
 		log.Warnf("last sync state is unknown: %s", updated)
 	}
 	return ""
+}
+
+// ChronydActiveAsE3 returns true if chronyd is currently the active E3
+// publisher — i.e., it has reported a CLOCK_REALTIME state. When chronyd
+// has not reported (e.g. GNSS mode, chronyd is offline), phc2sys remains
+// the E3 authority even if chronyd is configured in the profile.
+func (p *PTPEventManager) ChronydActiveAsE3() bool {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	for _, ptpStats := range p.Stats {
+		if cr, ok := ptpStats[ClockRealTime]; ok {
+			if cr.ProcessName() == chronydProcessName && cr.LastSyncState() != "" {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 type SavedMetrics struct {

--- a/plugins/ptp_operator/ptp_operator_plugin.go
+++ b/plugins/ptp_operator/ptp_operator_plugin.go
@@ -328,6 +328,7 @@ func getCurrentStatOverrideFn() func(e v2.Event, d *channel.DataChan) error {
 		}
 
 		var overallSyncState ptp.SyncState
+		chronydIsE3 := chronydActiveAsE3(eventManager)
 		for config := range eventManager.Stats { // configname->PTPStats
 			mainClockName := eventManager.Stats[config].GetMainClockName()
 			for ptpInterface, s := range eventManager.GetStats(config) { // iface->stats
@@ -352,6 +353,11 @@ func getCurrentStatOverrideFn() func(e v2.Event, d *channel.DataChan) error {
 						overallSyncState = getOverallState(overallSyncState, s.SyncState())
 					}
 				case ptpMetrics.ClockRealTime:
+					if s.ProcessName() != chronydProcessName {
+						if chronydIsE3 {
+							break
+						}
+					}
 					switch eventType {
 					case ptp.OsClockSyncStateChange:
 						data = processDataFn(data, eventManager.GetPTPEventsData(s.SyncState(), s.LastOffset(), string(ptpInterface), eventType))
@@ -446,6 +452,12 @@ func getCurrentStatOverrideFn() func(e v2.Event, d *channel.DataChan) error {
 // return worst of FREERUN, HOLDOVER or LOCKED
 func getOverallState(current, updated ptp.SyncState) ptp.SyncState {
 	return ptpMetrics.OverallState(current, updated)
+}
+
+// chronydActiveAsE3 delegates to the PTPEventManager method that checks
+// whether chronyd has reported a valid CLOCK_REALTIME state.
+func chronydActiveAsE3(em *ptpMetrics.PTPEventManager) bool {
+	return em.ChronydActiveAsE3()
 }
 
 func createPublisher(address string) (pub pubsub.PubSub, err error) {

--- a/plugins/ptp_operator/ptp_operator_plugin_config_test.go
+++ b/plugins/ptp_operator/ptp_operator_plugin_config_test.go
@@ -118,8 +118,8 @@ func TestProcessConfigCreate_InterfaceRoles(t *testing.T) {
 			},
 		},
 		{
-			name:    "no global section defaults to SLAVE",
-			profile: "oc-minimal",
+			name:      "no global section defaults to SLAVE",
+			profile:   "oc-minimal",
 			ptp4lConf: "[ens1f0]\n",
 			expectedIfaces: []struct {
 				name string

--- a/plugins/ptp_operator/ptp_operator_plugin_test.go
+++ b/plugins/ptp_operator/ptp_operator_plugin_test.go
@@ -32,8 +32,10 @@ import (
 
 	v2 "github.com/cloudevents/sdk-go/v2"
 	"github.com/google/uuid"
+	ptpConfig "github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/config"
 	event2 "github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/event"
 	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/metrics"
+	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/ptp4lconf"
 	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/stats"
 	"github.com/redhat-cne/sdk-go/pkg/event"
 	"github.com/redhat-cne/sdk-go/pkg/types"
@@ -567,6 +569,125 @@ func TestLiveStartCommand_ConstantValue(t *testing.T) {
 		"LIVE_START and RESTART must be distinct commands")
 	assert.True(t, strings.HasPrefix(liveStartCommand, "CMD "),
 		"control commands should use CMD prefix to distinguish from log lines")
+}
+
+// TestCurrentState_ChronydSkipsStalePhc2sysClockRealtime verifies that
+// the CurrentState handler only returns the chronyd-managed CLOCK_REALTIME
+// when chronyd is enabled, ignoring the stale phc2sys FREERUN entry.
+func TestCurrentState_ChronydSkipsStalePhc2sysClockRealtime(t *testing.T) {
+	profileName := "ntp-failover"
+	ptp4lCfgName := "ptp4l.0.config"
+	chronydCfgName := "chronyd.0.config"
+
+	eventManager = metrics.NewPTPEventManager("/cluster/node", pubsubTypes, nodeName, scConfig)
+	eventManager.MockTest(true)
+
+	// Register ptp4l config with the profile
+	eventManager.AddPTPConfig(ptpTypes.ConfigName(ptp4lCfgName), &ptp4lconf.PTP4lConfig{
+		Name:    ptp4lCfgName,
+		Profile: profileName,
+		Interfaces: []*ptp4lconf.PTPInterface{
+			{Name: "ens3f0", PortID: 1, PortName: "port 1", Role: ptpTypes.SLAVE},
+		},
+	})
+
+	// Register chronyd config with the same profile
+	eventManager.AddPTPConfig(ptpTypes.ConfigName(chronydCfgName), &ptp4lconf.PTP4lConfig{
+		Name:    chronydCfgName,
+		Profile: profileName,
+	})
+
+	// Set up PtpProcessOpts with chronyd enabled (simulating the production path)
+	phc2sysOpts := "-a -r -r -n 24"
+	chronydOpts := "-f /etc/chrony.conf"
+	eventManager.PtpConfigMapUpdates.PtpProcessOpts = map[string]*ptpConfig.PtpProcessOpts{
+		profileName: {
+			Phc2Opts:    &phc2sysOpts,
+			ChronydOpts: &chronydOpts,
+		},
+	}
+
+	// Set up stats: ptp4l config has stale phc2sys FREERUN for CLOCK_REALTIME
+	ptp4lStats := eventManager.GetStats(ptpTypes.ConfigName(ptp4lCfgName))
+	ptp4lStats.CheckSource(metrics.ClockRealTime, ptp4lCfgName, "phc2sys")
+	ptp4lStats[metrics.ClockRealTime].SetLastSyncState(ptpEvent.FREERUN)
+	ptp4lStats[metrics.ClockRealTime].SetProcessName("phc2sys")
+
+	// Set up stats: chronyd config has authoritative LOCKED for CLOCK_REALTIME
+	chronydStats := eventManager.GetStats(ptpTypes.ConfigName(chronydCfgName))
+	chronydStats.CheckSource(metrics.ClockRealTime, chronydCfgName, "chronyd")
+	chronydStats[metrics.ClockRealTime].SetLastSyncState(ptpEvent.LOCKED)
+	chronydStats[metrics.ClockRealTime].SetProcessName("chronyd")
+
+	// Request OsClockSyncState CurrentState
+	ev := buildEvent(nodeName, ptpEvent.OsClockSyncState, ptpEvent.OsClockSyncStateChange)
+	mockDataChan := &channel.DataChan{
+		ClientID: uuid.MustParse("123e4567-e89b-12d3-a456-426614174000"),
+	}
+	overrideFn := getCurrentStatOverrideFn()
+	err := overrideFn(ev, mockDataChan)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, mockDataChan.Data)
+
+	eventReceived, err2 := v1event.GetCloudNativeEvents(*mockDataChan.Data)
+	assert.Nil(t, err2)
+
+	// Should have values from only ONE CLOCK_REALTIME source (chronyd, LOCKED).
+	// GetPTPEventsData adds 2 DataValues per source (NOTIFICATION + METRIC).
+	assert.Equal(t, 2, len(eventReceived.Data.Values),
+		"Should have exactly 2 DataValues (one source: chronyd only)")
+	assert.Equal(t, string(ptpEvent.LOCKED), eventReceived.Data.Values[0].Value,
+		"CLOCK_REALTIME state should be LOCKED (from chronyd, not stale phc2sys FREERUN)")
+}
+
+// TestCurrentState_NoChronydIncludesPhc2sysClockRealtime verifies that
+// when chronyd is NOT enabled, the standard phc2sys CLOCK_REALTIME is returned.
+func TestCurrentState_NoChronydIncludesPhc2sysClockRealtime(t *testing.T) {
+	profileName := "ptp-oc"
+	ptp4lCfgName := "ptp4l.0.config"
+
+	eventManager = metrics.NewPTPEventManager("/cluster/node", pubsubTypes, nodeName, scConfig)
+	eventManager.MockTest(true)
+
+	eventManager.AddPTPConfig(ptpTypes.ConfigName(ptp4lCfgName), &ptp4lconf.PTP4lConfig{
+		Name:    ptp4lCfgName,
+		Profile: profileName,
+		Interfaces: []*ptp4lconf.PTPInterface{
+			{Name: "ens3f0", PortID: 1, PortName: "port 1", Role: ptpTypes.SLAVE},
+		},
+	})
+
+	phc2sysOpts := "-a -r -r -n 24"
+	eventManager.PtpConfigMapUpdates.PtpProcessOpts = map[string]*ptpConfig.PtpProcessOpts{
+		profileName: {
+			Phc2Opts: &phc2sysOpts,
+		},
+	}
+
+	ptp4lStats := eventManager.GetStats(ptpTypes.ConfigName(ptp4lCfgName))
+	ptp4lStats.CheckSource(metrics.ClockRealTime, ptp4lCfgName, "phc2sys")
+	ptp4lStats[metrics.ClockRealTime].SetLastSyncState(ptpEvent.LOCKED)
+	ptp4lStats[metrics.ClockRealTime].SetProcessName("phc2sys")
+
+	ev := buildEvent(nodeName, ptpEvent.OsClockSyncState, ptpEvent.OsClockSyncStateChange)
+	mockDataChan := &channel.DataChan{
+		ClientID: uuid.MustParse("123e4567-e89b-12d3-a456-426614174000"),
+	}
+	overrideFn := getCurrentStatOverrideFn()
+	err := overrideFn(ev, mockDataChan)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, mockDataChan.Data)
+
+	eventReceived, err2 := v1event.GetCloudNativeEvents(*mockDataChan.Data)
+	assert.Nil(t, err2)
+
+	// GetPTPEventsData adds 2 DataValues per source (NOTIFICATION + METRIC).
+	assert.Equal(t, 2, len(eventReceived.Data.Values),
+		"Should have exactly 2 DataValues (one source: phc2sys)")
+	assert.Equal(t, string(ptpEvent.LOCKED), eventReceived.Data.Values[0].Value,
+		"CLOCK_REALTIME state should be LOCKED from phc2sys")
 }
 
 func getMockOverrideFn() func(e v2.Event, d *channel.DataChan) error {


### PR DESCRIPTION
Fix CurrentState API handler producing duplicate entries with conflicting states (FREERUN from stale phc2sys + LOCKED from chronyd). Now, when chronyd is active for a profile, non-chronyd entries are excluded from the response and vice-versa.