### PR TITLE
[release-4.22] OCPBUGS-88703: Fix E1-aware E3 guard race in T-BC profiles

### DIFF
--- a/plugins/ptp_operator/metrics/metrics.go
+++ b/plugins/ptp_operator/metrics/metrics.go
@@ -271,15 +271,13 @@ func (p *PTPEventManager) ExtractMetrics(msg string) {
 				// phc2sys is the single publisher — but if the upstream PHC is not
 				// traceable (E1 != LOCKED), E3 cannot be LOCKED even when
 				// phc2sys offset is within threshold.
-				// Skip for T-GM profiles (masterOffsetSource == ts2phc): T-GM uses
-				// the lastOverallGMState mechanism above instead.
-				if masterOffsetSource != ts2phcProcessName {
-					mainClockKey := ptpStats.GetMainClockName()
-					if e1Stat, ok := ptpStats[mainClockKey]; ok {
-						e1State := e1Stat.LastSyncState()
-						if e1State == ptp.FREERUN || e1State == ptp.HOLDOVER {
-							syncState = OverallState(syncState, e1State)
-						}
+				// GetMainClockName() returns the correct key per profile type:
+				//   T-BC → "T-BC", T-GM → "GM", OC/BC → "master"
+				mainClockKey := ptpStats.GetMainClockName()
+				if e1Stat, ok := ptpStats[mainClockKey]; ok {
+					e1State := e1Stat.LastSyncState()
+					if e1State == ptp.FREERUN || e1State == ptp.HOLDOVER {
+						syncState = OverallState(syncState, e1State)
 					}
 				}
 				//  for HA we can not rely on master ;since there will be 2 or more leaders; this condition will be skipped

--- a/plugins/ptp_operator/metrics/metrics_test.go
+++ b/plugins/ptp_operator/metrics/metrics_test.go
@@ -699,6 +699,8 @@ func Test_ExtractMetrics(t *testing.T) {
 
 	// lastOverallGMState (see ParseGMLogs): when master offset source is ts2phc, ExtractMetrics
 	// forces non-ts2phc downstream sync to FREERUN only if last GM snapshot was FREERUN.
+	// The E1 check (worst_of(phc2sys_state, E1_state)) also fires for T-GM profiles
+	// via the "GM" key in ptpStats, providing HOLDOVER handling per O-RAN Table 37.
 	t.Run("lastOverallGMState_holdover_vs_freerun", func(t *testing.T) {
 		const logPhcLocked = "phc2sys[1000000900]: [ptp4l.0.config] CLOCK_REALTIME phc offset       -62 s2 freq  -78368 delay   1100"
 		assert := assert.New(t)
@@ -718,16 +720,20 @@ func Test_ExtractMetrics(t *testing.T) {
 				"when last GM state is FREERUN, downstream phc2sys sync state must be forced to FREERUN")
 		})
 
-		t.Run("HOLDOVER_GM_preserves_LOCKED_from_log_s2", func(t *testing.T) {
+		t.Run("HOLDOVER_GM_gives_E3_HOLDOVER_per_ORAN_Table37", func(t *testing.T) {
 			metrics.SyncState.With(map[string]string{"process": "phc2sys", "node": MYNODE, "iface": metrics.ClockRealTime}).Set(CLEANUP)
 			setLastSyncState(metrics.ClockRealTime, ptp.FREERUN, logPtp4lConfig.Name)
 			ptpEventManager.SetLastOverallGMStateForTesting(ptp.HOLDOVER)
+
+			gmStats := ptpEventManager.GetStatsForInterface(types.ConfigName(logPtp4lConfig.Name), types.IFace(stats.GMMainClockName))
+			gmStats.SetLastSyncState(ptp.HOLDOVER)
+
 			ptpEventManager.ResetMockEvent()
 			ptpEventManager.ExtractMetrics(logPhcLocked)
 
 			ss := metrics.SyncState.With(map[string]string{"process": "phc2sys", "node": MYNODE, "iface": metrics.ClockRealTime})
-			assert.Equal(float64(types.LOCKED), testutil.ToFloat64(ss),
-				"when last GM state is HOLDOVER, phc2sys must keep LOCKED from the s2 log line")
+			assert.Equal(float64(types.HOLDOVER), testutil.ToFloat64(ss),
+				"when GM E1 is HOLDOVER, E3 must be HOLDOVER per O-RAN Table 37 row 2")
 		})
 	})
 }

--- a/plugins/ptp_operator/metrics/tbc_test.go
+++ b/plugins/ptp_operator/metrics/tbc_test.go
@@ -538,6 +538,64 @@ func TestE3DerivationORANTable37(t *testing.T) {
 	}
 }
 
+// TestE1CheckFiresRegardlessOfMasterOffsetSource verifies that the E1-aware E3
+// derivation works even when masterOffsetSource is "ts2phc". In T-BC profiles,
+// both ptp4l and ts2phc write to ptpStats["master"].ProcessName, causing
+// masterOffsetSource to toggle. The E1 check must fire regardless of this value.
+func TestE1CheckFiresRegardlessOfMasterOffsetSource(t *testing.T) {
+	eventManager := metrics.NewPTPEventManager("", initPubSubTypes(), "testnode", &common.SCConfiguration{StorePath: "/tmp/store"})
+	eventManager.MockTest(true)
+
+	cfgName := "ptp4l.0.config"
+	tbcProfile := "tbc-race-test"
+
+	eventManager.PtpConfigMapUpdates.TBCProfiles = []string{tbcProfile}
+
+	ptp4lCfg := &ptp4lconf.PTP4lConfig{
+		Name:        cfgName,
+		Profile:     tbcProfile,
+		ProfileType: ptp4lconf.TBC,
+		Interfaces: []*ptp4lconf.PTPInterface{
+			{
+				Name:     "ens2f0",
+				PortID:   1,
+				PortName: "port 1",
+				Role:     types.SLAVE,
+			},
+		},
+	}
+	eventManager.AddPTPConfig(types.ConfigName(cfgName), ptp4lCfg)
+
+	ptpStats := eventManager.GetStats(types.ConfigName(cfgName))
+	ptpStats[metrics.MasterClockType] = &stats.Stats{}
+	ptpStats[metrics.MasterClockType].SetAlias("ens2f0")
+	ptpStats[metrics.MasterClockType].SetRole(types.SLAVE)
+
+	replacer := strings.NewReplacer("[", " ", "]", " ", ":", " ")
+	tbcInit := fmt.Sprintf("T-BC[1743005894]:[%s] ens2f0 offset 5 T-BC-STATUS s2", cfgName)
+	eventManager.ParseTBCLogs("T-BC", cfgName, replacer.Replace(tbcInit), strings.Fields(replacer.Replace(tbcInit)), ptpStats)
+
+	// Baseline: phc2sys LOCKED
+	phc2sysBaseline := fmt.Sprintf("phc2sys[3263.065]: [%s] CLOCK_REALTIME phc offset 3 s2 freq -20217 delay 536", cfgName)
+	eventManager.ExtractMetrics(phc2sysBaseline)
+
+	// Set T-BC to HOLDOVER (upstream lost)
+	tbcKey := types.IFace(stats.TBCMainClockName)
+	ptpStats[tbcKey].SetLastSyncState(ptp.HOLDOVER)
+
+	// Simulate the race: force masterOffsetSource to "ts2phc" (as ts2phc would)
+	metrics.SetMasterOffsetSource("ts2phc")
+
+	eventManager.ResetMockEvent()
+	phc2sysAfter := fmt.Sprintf("phc2sys[3264.065]: [%s] CLOCK_REALTIME phc offset 5 s2 freq -20217 delay 536", cfgName)
+	eventManager.ExtractMetrics(phc2sysAfter)
+
+	cStat := ptpStats[metrics.ClockRealTime]
+	assert.Equal(t, ptp.HOLDOVER, cStat.LastSyncState(),
+		"E3 must be HOLDOVER even when masterOffsetSource is ts2phc — "+
+			"the E1 check must not be gated by masterOffsetSource")
+}
+
 // TestTBCOffsetMetricUpdatedEveryLog tests that T-BC offset metric is updated on every log
 func TestTBCOffsetMetricUpdatedEveryLog(t *testing.T) {
 	eventManager := metrics.NewPTPEventManager("", initPubSubTypes(), "testnode", &common.SCConfiguration{StorePath: "/tmp/store"})


### PR DESCRIPTION
The masterOffsetSource guard (`masterOffsetSource != ts2phcProcessName`) used to gate the E1 check was unstable: in T-BC profiles, both ptp4l and ts2phc write to ptpStats["master"].ProcessName, causing masterOffsetSource to toggle between "ptp4l" and "ts2phc" on every log line. When it happened to be "ts2phc", the E1 check was skipped entirely, producing incorrect LOCKED E3 events while the upstream PHC was in HOLDOVER or FREERUN.

Remove the guard. GetMainClockName() already returns the correct stats key per profile type (T-BC→"T-BC", T-GM→"GM", OC/BC→"master"), so the E1 check works correctly for all profiles without needing to inspect masterOffsetSource.

This also extends E1-aware E3 derivation to T-GM profiles: when the GM is in HOLDOVER, E3 is now correctly reported as HOLDOVER per O-RAN O-Cloud API v04.00 Table 37 row 2 (previously only FREERUN was handled via the lastOverallGMState mechanism).