### PR TITLE
Update golangci-lint to v2 and migrate lint config.

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,8 +13,9 @@ jobs:
       - name: tidy
         run: go mod tidy
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.64
+          version: v2.12
+          only-new-issues: true
           args: --timeout 3m0s

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,3 +1,5 @@
+version: "2"
+
 run:
   concurrency: 8
   timeout: 3m
@@ -5,59 +7,62 @@ run:
   tests: true
 output:
   formats:
-    - format: colored-line-number
-  print-issued-lines: true
-  print-linter-name: true
+    text:
+      path: stdout
+      colors: true
+      print-issued-lines: true
+      print-linter-name: true
 issues:
-  exclude:
-    - 'ST1000: at least one file in a package should have a package comment'
-    - 'package-comments: should have a package comment'
-  exclude-dirs:
-    - vendor
-  exclude-dirs-use-default: false
-  exclude-files:
-    - test/cne/test_suite_test.go
-  exclude-use-default: false
-linters-settings:
-  govet:
-    # Enable all analyzers.
-    # Default: false
-    enable-all: true
-    # Disable analyzers by name.
-    # Run `go tool vet help` to see all analyzers.
-    # Default: []
-    disable:
-      - fieldalignment # too strict
-    # Settings per analyzer.
-    settings:
-      shadow:
-        # Whether to be strict about shadowing; can be noisy.
-        # Default: false
-        strict: true
-  gocyclo:
-    # minimal code complexity to report, 30 by default (but we recommend 10-20)
-    min-complexity: 75
-  goconst:
-    min-len: 3
-    min-occurrences: 4
-  decorder:
-    # Required order of `type`, `const`, `var` and `func` declarations inside a file.
-    # Default: types before constants before variables before functions.
-    dec-order:
-      - type
-      - const
-      - var
-      - func
-  revive:
-    rules:
-      - name: dot-imports
-        arguments:
-          - allowedPackages:
-              - "github.com/onsi/ginkgo"
-              - "github.com/onsi/ginkgo/v2"
-              - "github.com/onsi/gomega"
+  new-from-rev: 4b49778d9ec5abe5584861d34d90d31c73e39a24
 linters:
-  disable-all: true
+  exclusions:
+    rules:
+      - path: ".*"
+        text: 'ST1000: at least one file in a package should have a package comment'
+      - path: ".*"
+        text: 'package-comments: should have a package comment'
+    paths:
+      - vendor
+      - test/cne/test_suite_test.go
+  settings:
+    govet:
+      # Enable all analyzers.
+      # Default: false
+      enable-all: true
+      # Disable analyzers by name.
+      # Run `go tool vet help` to see all analyzers.
+      # Default: []
+      disable:
+        - fieldalignment # too strict
+      # Settings per analyzer.
+      settings:
+        shadow:
+          # Whether to be strict about shadowing; can be noisy.
+          # Default: false
+          strict: true
+    gocyclo:
+      # minimal code complexity to report, 30 by default (but we recommend 10-20)
+      min-complexity: 75
+    goconst:
+      min-len: 3
+      min-occurrences: 4
+    decorder:
+      # Required order of `type`, `const`, `var` and `func` declarations inside a file.
+      # Default: types before constants before variables before functions.
+      dec-order:
+        - type
+        - const
+        - var
+        - func
+    revive:
+      rules:
+        - name: dot-imports
+          arguments:
+            - allowedPackages:
+                - "github.com/onsi/ginkgo"
+                - "github.com/onsi/ginkgo/v2"
+                - "github.com/onsi/gomega"
+  default: none
   enable: # NOTE: please keep this list alphabetically sorted
     - bodyclose
     - decorder
@@ -65,18 +70,16 @@ linters:
     #- errcheck
     - goconst
     - gocyclo
-    - goimports
     #- gosec
-    - gosimple
     - govet
     - ineffassign
     - misspell
     - revive
-    - stylecheck
     - staticcheck # is a go vet on steroids, applying a ton of static analysis checks
-    - typecheck
     - unconvert
     - unparam
     - unused
     - whitespace
-  fast: false
+formatters:
+  enable:
+    - goimports

--- a/plugins/mock/mock_plugin.go
+++ b/plugins/mock/mock_plugin.go
@@ -46,7 +46,7 @@ var (
 )
 
 // Start mock plugin to process events,metrics and status, expects rest api available to create publisher and subscriptions
-func Start(wg *sync.WaitGroup, configuration *common.SCConfiguration, _ func(e interface{}) error) error { //nolint:deadcode,unused
+func Start(wg *sync.WaitGroup, configuration *common.SCConfiguration, _ func(e interface{}) error) error { //nolint:unused
 	config = configuration
 	nodeName := os.Getenv("NODE_NAME")
 	if nodeName == "" {

--- a/plugins/ptp_operator/ptp_operator_plugin.go
+++ b/plugins/ptp_operator/ptp_operator_plugin.go
@@ -217,7 +217,7 @@ func startPtpConfigSync(timeout time.Duration, nodeName string, configuration *c
 }
 
 // Start ptp plugin to process events,metrics and status, expects rest api available to create publisher and subscriptions
-func Start(wg *sync.WaitGroup, configuration *common.SCConfiguration, _ func(e interface{}) error) error { //nolint:deadcode,unused
+func Start(wg *sync.WaitGroup, configuration *common.SCConfiguration, _ func(e interface{}) error) error { //nolint:unused
 	// The name of NodePtpDevice CR for this node is equal to the node name
 	nodeName := os.Getenv("NODE_NAME")
 	if nodeName == "" {


### PR DESCRIPTION
Align CI and local lint baselines so new issues are reported while existing findings stay ignored, and remove deprecated deadcode nolint tags.

Generated-by: Cursor