### PR TITLE
CNF-25885: Widen PTP clock thresholds when NTP failover is enabled

### DIFF
--- a/plugins/ptp_operator/_testprofile/ntpfailover
+++ b/plugins/ptp_operator/_testprofile/ntpfailover
@@ -1,0 +1,1 @@
+[{"name":"profile0","interface":"ens5f1","ptp4lOpts":"-2 -s --summary_interval -4","phc2sysOpts":"-a -r -m -n 24 -N 8 -R 16","plugins":{"ntpfailover":{"gnssFailover":true}}}]

--- a/plugins/ptp_operator/config/config.go
+++ b/plugins/ptp_operator/config/config.go
@@ -28,6 +28,8 @@ import (
 
 	"k8s.io/utils/pointer"
 
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
 	"github.com/redhat-cne/cloud-event-proxy/pkg/common"
 	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/filesystem"
 	log "github.com/sirupsen/logrus"
@@ -54,17 +56,18 @@ const (
 
 // PtpProfile ... ptp profile
 type PtpProfile struct {
-	Name              *string            `json:"name"`
-	Interface         *string            `json:"interface"`
-	PtpClockThreshold *PtpClockThreshold `json:"ptpClockThreshold,omitempty"`
-	Ptp4lOpts         *string            `json:"ptp4lOpts,omitempty"`
-	Phc2sysOpts       *string            `json:"phc2sysOpts,omitempty"`
-	TS2PhcOpts        *string            `json:"ts2PhcOpts,omitempty"`
-	ChronydOpts       *string            `json:"chronydOpts,omitempty"`
-	Ptp4lConf         *string            `json:"ptp4lConf,omitempty"`
-	TS2PhcConf        *string            `json:"ts2PhcConf,omitempty"`
-	ChronydConf       *string            `json:"chronydConf,omitempty"`
-	PtpSettings       map[string]string  `json:"ptpSettings,omitempty"`
+	Name              *string                        `json:"name"`
+	Interface         *string                        `json:"interface"`
+	PtpClockThreshold *PtpClockThreshold             `json:"ptpClockThreshold,omitempty"`
+	Ptp4lOpts         *string                        `json:"ptp4lOpts,omitempty"`
+	Phc2sysOpts       *string                        `json:"phc2sysOpts,omitempty"`
+	TS2PhcOpts        *string                        `json:"ts2PhcOpts,omitempty"`
+	ChronydOpts       *string                        `json:"chronydOpts,omitempty"`
+	Ptp4lConf         *string                        `json:"ptp4lConf,omitempty"`
+	TS2PhcConf        *string                        `json:"ts2PhcConf,omitempty"`
+	ChronydConf       *string                        `json:"chronydConf,omitempty"`
+	PtpSettings       map[string]string              `json:"ptpSettings,omitempty"`
+	Plugins           map[string]*apiextensions.JSON `json:"plugins,omitempty"`
 	Interfaces        []*string
 }
 
@@ -290,10 +293,9 @@ func (l *LinuxPTPConfigMapUpdate) UpdatePTPProcessOptions() {
 func (l *LinuxPTPConfigMapUpdate) UpdatePTPThreshold() {
 	var maxOffsetTh, minOffsetTh, holdOverTh int64
 	for _, profile := range l.NodeProfiles {
-		holdOverTh = holdoverTimeout
-		maxOffsetTh = maxOffsetThreshold
-		minOffsetTh = minOffsetThreshold
 		if profile.PtpClockThreshold != nil {
+			holdOverTh = holdoverTimeout
+			maxOffsetTh = maxOffsetThreshold
 			if profile.PtpClockThreshold.MaxOffsetThreshold > 0 { // has to be greater than 0 nano secs
 				maxOffsetTh = profile.PtpClockThreshold.MaxOffsetThreshold
 			} else {
@@ -311,6 +313,14 @@ func (l *LinuxPTPConfigMapUpdate) UpdatePTPThreshold() {
 			} else {
 				log.Infof("invalid holdOverTimeout %d in secs, setting to default %d holdOverTimeout", profile.PtpClockThreshold.HoldOverTimeout, holdOverTh)
 			}
+		} else if isNtpFailoverEnabled(&profile) {
+			holdOverTh = holdoverTimeout
+			maxOffsetTh = 1000
+			minOffsetTh = -1000
+		} else {
+			holdOverTh = holdoverTimeout
+			maxOffsetTh = maxOffsetThreshold
+			minOffsetTh = minOffsetThreshold
 		}
 
 		l.EventThreshold[*profile.Name] = &PtpClockThreshold{
@@ -323,6 +333,21 @@ func (l *LinuxPTPConfigMapUpdate) UpdatePTPThreshold() {
 		log.Infof("update ptp threshold values for %s\n holdoverTimeout: %d\n maxThreshold: %d\n minThreshold: %d\n",
 			*profile.Name, holdOverTh, maxOffsetTh, minOffsetTh)
 	}
+}
+
+func isNtpFailoverEnabled(profile *PtpProfile) bool {
+	pluginOpts, ok := profile.Plugins["ntpfailover"]
+	if !ok || pluginOpts == nil {
+		return false
+	}
+	var opts struct {
+		GnssFailover bool `json:"gnssFailover"`
+	}
+	if err := json.Unmarshal(pluginOpts.Raw, &opts); err != nil {
+		log.Errorf("failed to unmarshal ntpfailover plugin options: %v", err)
+		return false
+	}
+	return opts.GnssFailover
 }
 
 // UpdatePTPSetting ... ptp settings

--- a/plugins/ptp_operator/config/config_test.go
+++ b/plugins/ptp_operator/config/config_test.go
@@ -6,7 +6,10 @@ import (
 
 	ptpConfig "github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/config"
 	"github.com/stretchr/testify/assert"
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
+
+const ntpFailoverPlugin = "ntpfailover"
 
 var (
 	profile0  = "profile0"
@@ -122,6 +125,21 @@ func Test_Config(t *testing.T) {
 			nodeName:    "ptpha",
 			len:         1,
 		},
+		ntpFailoverPlugin: {
+			wantProfile: []*ptpConfig.PtpProfile{{
+				Name:      &profile0,
+				Interface: &inface1,
+				PtpClockThreshold: &ptpConfig.PtpClockThreshold{
+					HoldOverTimeout:    5,
+					MaxOffsetThreshold: 1000,
+					MinOffsetThreshold: -1000,
+					Close:              make(chan struct{}),
+				},
+			}},
+			profilePath: "../_testprofile",
+			nodeName:    "ntpfailover",
+			len:         1,
+		},
 	}
 
 	closeCh := make(chan struct{})
@@ -156,8 +174,10 @@ func Test_Config(t *testing.T) {
 				}
 			} else {
 				for i, p := range ptpUpdate.NodeProfiles {
-					tc.wantProfile[i].PtpClockThreshold.Close = p.PtpClockThreshold.Close
-					assert.Equal(t, tc.wantProfile[i].PtpClockThreshold, p.PtpClockThreshold)
+					if p.PtpClockThreshold != nil {
+						tc.wantProfile[i].PtpClockThreshold.Close = p.PtpClockThreshold.Close
+						assert.Equal(t, tc.wantProfile[i].PtpClockThreshold, p.PtpClockThreshold)
+					}
 					tc.wantProfile[i].PtpClockThreshold.Close = ptpUpdate.EventThreshold[*p.Name].Close
 					assert.Equal(t, tc.wantProfile[i].PtpClockThreshold, ptpUpdate.EventThreshold[*p.Name])
 					assert.Equal(t, *tc.wantProfile[i].Name, *p.Name)
@@ -225,6 +245,78 @@ func TestUpdatePTPProcessOptions_NilChronydOpts(t *testing.T) {
 	assert.False(t, opts.ChronydEnabled(), "ChronydEnabled() must return false when profile has no chronydOpts")
 	assert.True(t, opts.Ptp4lEnabled())
 	assert.True(t, opts.Phc2SysEnabled())
+}
+
+func TestUpdatePTPThreshold_NtpFailover(t *testing.T) {
+	profileName := "test-profile"
+
+	tests := []struct {
+		name        string
+		profile     ptpConfig.PtpProfile
+		expectedMax int64
+		expectedMin int64
+	}{
+		{
+			name: "default threshold without ntpfailover",
+			profile: ptpConfig.PtpProfile{
+				Name: &profileName,
+			},
+			expectedMax: 100,
+			expectedMin: -100,
+		},
+		{
+			name: "ntpfailover with gnssFailover enabled uses looser threshold",
+			profile: ptpConfig.PtpProfile{
+				Name: &profileName,
+				Plugins: map[string]*apiextensions.JSON{
+					ntpFailoverPlugin: {Raw: []byte(`{"gnssFailover": true}`)},
+				},
+			},
+			expectedMax: 1000,
+			expectedMin: -1000,
+		},
+		{
+			name: "ntpfailover with gnssFailover disabled uses standard threshold",
+			profile: ptpConfig.PtpProfile{
+				Name: &profileName,
+				Plugins: map[string]*apiextensions.JSON{
+					ntpFailoverPlugin: {Raw: []byte(`{"gnssFailover": false}`)},
+				},
+			},
+			expectedMax: 100,
+			expectedMin: -100,
+		},
+		{
+			name: "explicit PtpClockThreshold takes precedence over ntpfailover",
+			profile: ptpConfig.PtpProfile{
+				Name: &profileName,
+				PtpClockThreshold: &ptpConfig.PtpClockThreshold{
+					HoldOverTimeout:    10,
+					MaxOffsetThreshold: 500,
+					MinOffsetThreshold: -500,
+				},
+				Plugins: map[string]*apiextensions.JSON{
+					ntpFailoverPlugin: {Raw: []byte(`{"gnssFailover": true}`)},
+				},
+			},
+			expectedMax: 500,
+			expectedMin: -500,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := &ptpConfig.LinuxPTPConfigMapUpdate{
+				NodeProfiles:   []ptpConfig.PtpProfile{tt.profile},
+				EventThreshold: make(map[string]*ptpConfig.PtpClockThreshold),
+			}
+			l.UpdatePTPThreshold()
+			th := l.EventThreshold[profileName]
+			assert.NotNil(t, th)
+			assert.Equal(t, tt.expectedMax, th.MaxOffsetThreshold)
+			assert.Equal(t, tt.expectedMin, th.MinOffsetThreshold)
+		})
+	}
 }
 
 func TestUpdatePTPProcessOptions_TS2PhcConfSetsDefaultOpts(t *testing.T) {


### PR DESCRIPTION
When a profile has the ntpfailover plugin with gnssFailover: true, the user has accepted NTP-level accuracy as a fallback. The default +/-100ns offset threshold is too strict for that tolerance — it would declare FREERUN on minor drift that the user considers acceptable.

Widen the default threshold to +/-1000ns when NTP failover is enabled. Explicit PtpClockThreshold on the profile still takes precedence.