### PR TITLE
OCPBUGS-98227: Fix phc2sys / chrony stale metric

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.23.0
 	github.com/prometheus/client_golang v1.14.0
+	github.com/prometheus/client_model v0.3.0
 	github.com/redhat-cne/rest-api v1.23.6
 	github.com/redhat-cne/sdk-go v1.23.6
 	github.com/sirupsen/logrus v1.9.3
@@ -52,7 +53,6 @@ require (
 	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.42.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/plugins/ptp_operator/metrics/clear_stale_test.go
+++ b/plugins/ptp_operator/metrics/clear_stale_test.go
@@ -1,0 +1,146 @@
+package metrics
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	ptpConfig "github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/config"
+	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/ptp4lconf"
+	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/types"
+	"github.com/redhat-cne/sdk-go/pkg/event/ptp"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	staleMetricProfile = "ntp-failover"
+	staleMetricPtp4l   = "ptp4l.0.config"
+	staleMetricChronyd = "chronyd.0.config"
+	staleMetricPhcOpts = "-a -r -r -n 24"
+	staleMetricChrOpts = "-f /etc/chrony.conf"
+	labelProcessName   = "process"
+	labelIfaceName     = "iface"
+)
+
+func syncStateExists(process string) bool {
+	ch := make(chan prometheus.Metric, 64)
+	go func() {
+		SyncState.Collect(ch)
+		close(ch)
+	}()
+	for m := range ch {
+		var d dto.Metric
+		if err := m.Write(&d); err != nil {
+			continue
+		}
+		var p, i string
+		for _, lp := range d.Label {
+			switch lp.GetName() {
+			case labelProcessName:
+				p = lp.GetValue()
+			case labelIfaceName:
+				i = lp.GetValue()
+			}
+		}
+		if p == process && i == ClockRealTime {
+			return true
+		}
+	}
+	return false
+}
+
+func newStaleMetricManager(t *testing.T, phcOpts, chronydOpts *string) *PTPEventManager {
+	t.Helper()
+	ensureTestNode(t)
+	mgr := NewPTPEventManager("", nil, testNode, nil)
+	mgr.MockTest(true)
+	mgr.AddPTPConfig(types.ConfigName(staleMetricPtp4l), &ptp4lconf.PTP4lConfig{
+		Name:    staleMetricPtp4l,
+		Profile: staleMetricProfile,
+		Interfaces: []*ptp4lconf.PTPInterface{{
+			Name: "ens3f0", PortID: 1, PortName: "port 1", Role: types.SLAVE,
+		}},
+	})
+	mgr.AddPTPConfig(types.ConfigName(staleMetricChronyd), &ptp4lconf.PTP4lConfig{
+		Name:    staleMetricChronyd,
+		Profile: staleMetricProfile,
+	})
+	mgr.PtpConfigMapUpdates.PtpProcessOpts = map[string]*ptpConfig.PtpProcessOpts{
+		staleMetricProfile: {
+			Phc2Opts:    phcOpts,
+			ChronydOpts: chronydOpts,
+		},
+	}
+	return mgr
+}
+
+func TestClearStaleClockRealTimeMetric_NoOpWithoutFailoverPair(t *testing.T) {
+	phc := staleMetricPhcOpts
+	mgr := newStaleMetricManager(t, &phc, nil) // chronyd disabled
+
+	UpdateSyncStateMetrics(phc2sysProcessName, ClockRealTime, ptp.LOCKED)
+	UpdateSyncStateMetrics(chronydProcessName, ClockRealTime, ptp.LOCKED)
+	assert.True(t, syncStateExists(phc2sysProcessName))
+	assert.True(t, syncStateExists(chronydProcessName))
+
+	mgr.clearStaleClockRealTimeMetric(staleMetricProfile, chronydProcessName)
+	assert.True(t, syncStateExists(phc2sysProcessName), "must not delete when chronyd is not enabled")
+	assert.True(t, syncStateExists(chronydProcessName))
+
+	mgr.clearStaleClockRealTimeMetric("missing-profile", chronydProcessName)
+	assert.True(t, syncStateExists(phc2sysProcessName), "must not delete when profile opts are missing")
+
+	DeleteSyncStateMetrics(phc2sysProcessName, ClockRealTime)
+	DeleteSyncStateMetrics(chronydProcessName, ClockRealTime)
+}
+
+func TestClearStaleClockRealTimeMetric_SwapsOwner(t *testing.T) {
+	phc := staleMetricPhcOpts
+	chr := staleMetricChrOpts
+	mgr := newStaleMetricManager(t, &phc, &chr)
+
+	DeleteSyncStateMetrics(phc2sysProcessName, ClockRealTime)
+	DeleteSyncStateMetrics(chronydProcessName, ClockRealTime)
+
+	UpdateSyncStateMetrics(phc2sysProcessName, ClockRealTime, ptp.LOCKED)
+	assert.True(t, syncStateExists(phc2sysProcessName))
+
+	mgr.clearStaleClockRealTimeMetric(staleMetricProfile, chronydProcessName)
+	assert.False(t, syncStateExists(phc2sysProcessName), "chronyd active must clear phc2sys series")
+
+	UpdateSyncStateMetrics(chronydProcessName, ClockRealTime, ptp.LOCKED)
+	assert.True(t, syncStateExists(chronydProcessName))
+
+	mgr.clearStaleClockRealTimeMetric(staleMetricProfile, phc2sysProcessName)
+	assert.False(t, syncStateExists(chronydProcessName), "phc2sys active must clear chronyd series")
+}
+
+func TestExtractMetrics_ClearsStaleClockRealTimeOnFailover(t *testing.T) {
+	phc := staleMetricPhcOpts
+	chr := staleMetricChrOpts
+	mgr := newStaleMetricManager(t, &phc, &chr)
+
+	DeleteSyncStateMetrics(phc2sysProcessName, ClockRealTime)
+	DeleteSyncStateMetrics(chronydProcessName, ClockRealTime)
+	UpdateSyncStateMetrics(phc2sysProcessName, ClockRealTime, ptp.LOCKED)
+
+	mgr.ExtractMetrics(fmt.Sprintf(
+		"chronyd[1000.000]: [%s] Selected source 192.168.1.1 (ntp.example.com)", staleMetricChronyd))
+	assert.True(t, syncStateExists(chronydProcessName))
+	assert.False(t, syncStateExists(phc2sysProcessName),
+		"Selected source must clear stale phc2sys CLOCK_REALTIME series")
+
+	mgr.ExtractMetrics(fmt.Sprintf(
+		"phc2sys[1001.000]: [%s] CLOCK_REALTIME phc offset       -10 s2 freq  -100 delay   100", staleMetricPtp4l))
+	assert.True(t, syncStateExists(phc2sysProcessName))
+	assert.False(t, syncStateExists(chronydProcessName),
+		"phc2sys CLOCK_REALTIME offset must clear stale chronyd series")
+
+	UpdateSyncStateMetrics(phc2sysProcessName, ClockRealTime, ptp.LOCKED)
+	mgr.ExtractMetrics(fmt.Sprintf(
+		"chronyd[1002.000]: [%s] no selectable sources", staleMetricChronyd))
+	assert.True(t, syncStateExists(chronydProcessName))
+	assert.False(t, syncStateExists(phc2sysProcessName),
+		"no selectable sources must also clear stale phc2sys series")
+}

--- a/plugins/ptp_operator/metrics/metrics.go
+++ b/plugins/ptp_operator/metrics/metrics.go
@@ -162,9 +162,11 @@ func (p *PTPEventManager) ExtractMetrics(msg string) {
 		ptpStats[ClockRealTime].SetProcessName(processName)
 		if chronydValidSource.MatchString(output) {
 			UpdateSyncStateMetrics(chronydProcessName, ClockRealTime, ptp.LOCKED)
+			p.clearStaleClockRealTimeMetric(profileName, chronydProcessName)
 			p.GenPTPEvent(profileName, ptpStats[ClockRealTime], ClockRealTime, int64(0), ptp.LOCKED, ptp.OsClockSyncStateChange)
 		} else if chronydNoValidSource.MatchString(output) {
 			UpdateSyncStateMetrics(chronydProcessName, ClockRealTime, ptp.FREERUN)
+			p.clearStaleClockRealTimeMetric(profileName, chronydProcessName)
 			p.GenPTPEvent(profileName, ptpStats[ClockRealTime], ClockRealTime, int64(0), ptp.FREERUN, ptp.OsClockSyncStateChange)
 		}
 	default:
@@ -227,7 +229,7 @@ func (p *PTPEventManager) ExtractMetrics(msg string) {
 			}
 			log.Debugf("ExtractMetrics: offset parsed: process=%s iface=%s offset=%.0f syncState=%s", processName, interfaceName, ptpOffset, syncState)
 			//  only ts2phc process will return actual interface name- allow all ts2phcprocess or iface in (master or  clock realtime)
-			if processName != ts2phcProcessName && !(interfaceName == master || interfaceName == ClockRealTime) {
+			if processName != ts2phcProcessName && interfaceName != master && interfaceName != ClockRealTime {
 				return // only master and clock_realtime are supported
 			}
 			// Force FREERUN if gnss is FREERUN and ts2phc is the source
@@ -301,6 +303,9 @@ func (p *PTPEventManager) ExtractMetrics(msg string) {
 				}
 				// continue to update metrics regardless and stick to last sync state
 				UpdateSyncStateMetrics(processName, interfaceName, ptpStats[ClockRealTime].LastSyncState())
+				if processName == phc2sysProcessName {
+					p.clearStaleClockRealTimeMetric(profileName, phc2sysProcessName)
+				}
 				UpdatePTPMetrics(offsetSource, processName, interfaceName, ptpOffset, float64(ptpStats[ClockRealTime].MaxAbs()), frequencyAdjustment, delay)
 			case MasterClockType: // this ptp4l[5196819.100]: [ptp4l.0.config] master offset   -2162130 s2 freq +22451884 path delay
 				// Report events for master  by masking the index  number of the slave interface
@@ -366,6 +371,27 @@ func (p *PTPEventManager) ExtractMetrics(msg string) {
 	}
 	p.ParsePTP4l(processName, configName, profileName, output, fields,
 		ptpInterface, ptp4lCfg, ptpStats)
+}
+
+// clearStaleClockRealTimeMetric removes the openshift_ptp_clock_state
+// CLOCK_REALTIME series belonging to the counterpart process (phc2sys <->
+// chronyd) once activeProcessName actively reports its own CLOCK_REALTIME
+// state. This only applies to NTP/GNSS-failover profiles where both phc2sys
+// and chronyd are configured, since in that scenario exactly one of the two
+// processes owns CLOCK_REALTIME at any given time. Without this cleanup, the
+// previously active process' last-known state lingers forever, resulting in
+// two (potentially conflicting) CLOCK_REALTIME time series being exposed at
+// once.
+func (p *PTPEventManager) clearStaleClockRealTimeMetric(profileName, activeProcessName string) {
+	opts := p.PtpConfigMapUpdates.LookupPtpProcessOpts(profileName)
+	if opts == nil || !opts.Phc2SysEnabled() || !opts.ChronydEnabled() {
+		return
+	}
+	counterpart := chronydProcessName
+	if activeProcessName == chronydProcessName {
+		counterpart = phc2sysProcessName
+	}
+	DeleteSyncStateMetrics(counterpart, ClockRealTime)
 }
 
 func (p *PTPEventManager) processDownEvent(profileName, processName string, ptpStats stats.PTPStats, profileType ptp4lconf.PtpProfileType) {

--- a/plugins/ptp_operator/metrics/ntp_test.go
+++ b/plugins/ptp_operator/metrics/ntp_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/redhat-cne/cloud-event-proxy/pkg/common"
 	ptpConfig "github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/config"
 	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/metrics"
@@ -22,14 +24,48 @@ const (
 	ntpChronydCfgName  = "chronyd.0.config"
 	ntpPhc2sysOpts     = "-a -r -r -n 24"
 	ntpChronydOpts     = "-f /etc/chrony.conf"
+	ntpStorePath       = "/tmp/store"
+	ntpSlaveIface      = "ens3f0"
+	labelProcess       = "process"
+	labelIface         = "iface"
 )
+
+// syncStateSeriesExists reports whether the openshift_ptp_clock_state gauge
+// currently has a CLOCK_REALTIME series for the given process, WITHOUT
+// creating one as a side effect (unlike SyncState.With(...)).
+func syncStateSeriesExists(process string) bool {
+	ch := make(chan prometheus.Metric, 64)
+	go func() {
+		metrics.SyncState.Collect(ch)
+		close(ch)
+	}()
+	for m := range ch {
+		var d dto.Metric
+		if err := m.Write(&d); err != nil {
+			continue
+		}
+		var p, i string
+		for _, lp := range d.Label {
+			switch lp.GetName() {
+			case labelProcess:
+				p = lp.GetValue()
+			case labelIface:
+				i = lp.GetValue()
+			}
+		}
+		if p == process && i == metrics.ClockRealTime {
+			return true
+		}
+	}
+	return false
+}
 
 // TestNTPProcessDownDoesNotEmitOsClockSyncStateChange verifies that when
 // phc2sys reports process_status 0 in an NTP-failover configuration (chronyd
 // enabled), no OsClockSyncStateChange event is emitted for CLOCK_REALTIME.
 // Chronyd is the sole E3 publisher in NTP mode.
 func TestNTPProcessDownDoesNotEmitOsClockSyncStateChange(t *testing.T) {
-	eventManager := metrics.NewPTPEventManager("", initPubSubTypes(), "testnode", &common.SCConfiguration{StorePath: "/tmp/store"})
+	eventManager := metrics.NewPTPEventManager("", initPubSubTypes(), "testnode", &common.SCConfiguration{StorePath: ntpStorePath})
 	eventManager.MockTest(true)
 
 	ptp4lCfg := &ptp4lconf.PTP4lConfig{
@@ -37,7 +73,7 @@ func TestNTPProcessDownDoesNotEmitOsClockSyncStateChange(t *testing.T) {
 		Profile: ntpFailoverProfile,
 		Interfaces: []*ptp4lconf.PTPInterface{
 			{
-				Name:     "ens3f0",
+				Name:     ntpSlaveIface,
 				PortID:   1,
 				PortName: "port 1",
 				Role:     types.SLAVE,
@@ -80,7 +116,7 @@ func TestNTPProcessDownDoesNotEmitOsClockSyncStateChange(t *testing.T) {
 func TestNTPProcessDownEmitsOsClockWhenNoChronyd(t *testing.T) {
 	profileName := "ptp-oc"
 
-	eventManager := metrics.NewPTPEventManager("", initPubSubTypes(), "testnode", &common.SCConfiguration{StorePath: "/tmp/store"})
+	eventManager := metrics.NewPTPEventManager("", initPubSubTypes(), "testnode", &common.SCConfiguration{StorePath: ntpStorePath})
 	eventManager.MockTest(true)
 
 	ptp4lCfg := &ptp4lconf.PTP4lConfig{
@@ -88,7 +124,7 @@ func TestNTPProcessDownEmitsOsClockWhenNoChronyd(t *testing.T) {
 		Profile: profileName,
 		Interfaces: []*ptp4lconf.PTPInterface{
 			{
-				Name:     "ens3f0",
+				Name:     ntpSlaveIface,
 				PortID:   1,
 				PortName: "port 1",
 				Role:     types.SLAVE,
@@ -130,7 +166,7 @@ func TestNTPProcessDownEmitsOsClockWhenNoChronyd(t *testing.T) {
 // TestNTPChronydSelectedSourceSetsLocked verifies that chronyd "Selected source"
 // correctly sets CLOCK_REALTIME to LOCKED and is the sole E3 publisher.
 func TestNTPChronydSelectedSourceSetsLocked(t *testing.T) {
-	eventManager := metrics.NewPTPEventManager("", initPubSubTypes(), "testnode", &common.SCConfiguration{StorePath: "/tmp/store"})
+	eventManager := metrics.NewPTPEventManager("", initPubSubTypes(), "testnode", &common.SCConfiguration{StorePath: ntpStorePath})
 	eventManager.MockTest(true)
 
 	ptp4lCfg := &ptp4lconf.PTP4lConfig{
@@ -173,7 +209,7 @@ func TestNTPChronydSelectedSourceSetsLocked(t *testing.T) {
 // absent) is in FREERUN. Per the state chart, sync-state = worst(os-clock=LOCKED,
 // ptp-lock=FREERUN) = FREERUN.
 func TestNTPNodeSyncStateIncludesMasterFreerun(t *testing.T) {
-	eventManager := metrics.NewPTPEventManager("", initPubSubTypes(), "testnode", &common.SCConfiguration{StorePath: "/tmp/store"})
+	eventManager := metrics.NewPTPEventManager("", initPubSubTypes(), "testnode", &common.SCConfiguration{StorePath: ntpStorePath})
 	eventManager.MockTest(true)
 
 	ptp4lCfg := &ptp4lconf.PTP4lConfig{
@@ -181,7 +217,7 @@ func TestNTPNodeSyncStateIncludesMasterFreerun(t *testing.T) {
 		Profile: ntpFailoverProfile,
 		Interfaces: []*ptp4lconf.PTPInterface{
 			{
-				Name:     "ens3f0",
+				Name:     ntpSlaveIface,
 				PortID:   1,
 				PortName: "port 1",
 				Role:     types.SLAVE,
@@ -208,7 +244,7 @@ func TestNTPNodeSyncStateIncludesMasterFreerun(t *testing.T) {
 	ptp4lStats := eventManager.GetStats(types.ConfigName(ntpPtp4lCfgName))
 	ptp4lStats.CheckSource(metrics.MasterClockType, ntpPtp4lCfgName, "ptp4l")
 	ptp4lStats[metrics.MasterClockType].SetLastSyncState(ptp.FREERUN)
-	ptp4lStats[metrics.MasterClockType].SetAlias("ens3f0")
+	ptp4lStats[metrics.MasterClockType].SetAlias(ntpSlaveIface)
 
 	chronydStats := eventManager.GetStats(types.ConfigName(ntpChronydCfgName))
 	chronydStats.CheckSource(metrics.ClockRealTime, ntpChronydCfgName, "chronyd")
@@ -223,7 +259,7 @@ func TestNTPNodeSyncStateIncludesMasterFreerun(t *testing.T) {
 // phc2sys goes down but chronyd maintains CLOCK_REALTIME, resulting in a
 // single consistent CLOCK_REALTIME state (LOCKED) without conflicting events.
 func TestNTPNoDoubleClockRealtime(t *testing.T) {
-	eventManager := metrics.NewPTPEventManager("", initPubSubTypes(), "testnode", &common.SCConfiguration{StorePath: "/tmp/store"})
+	eventManager := metrics.NewPTPEventManager("", initPubSubTypes(), "testnode", &common.SCConfiguration{StorePath: ntpStorePath})
 	eventManager.MockTest(true)
 
 	ptp4lCfg := &ptp4lconf.PTP4lConfig{
@@ -231,7 +267,7 @@ func TestNTPNoDoubleClockRealtime(t *testing.T) {
 		Profile: ntpFailoverProfile,
 		Interfaces: []*ptp4lconf.PTPInterface{
 			{
-				Name:     "ens3f0",
+				Name:     ntpSlaveIface,
 				PortID:   1,
 				PortName: "port 1",
 				Role:     types.SLAVE,
@@ -261,7 +297,7 @@ func TestNTPNoDoubleClockRealtime(t *testing.T) {
 	replacer := strings.NewReplacer("[", " ", "]", " ", ":", " ")
 	_ = replacer
 
-	ptp4lSlave := fmt.Sprintf("ptp4l[1000.000]: [%s] port 1 (ens3f0): LISTENING to SLAVE on RS_SLAVE", ntpPtp4lCfgName)
+	ptp4lSlave := fmt.Sprintf("ptp4l[1000.000]: [%s] port 1 (%s): LISTENING to SLAVE on RS_SLAVE", ntpPtp4lCfgName, ntpSlaveIface)
 	eventManager.ExtractMetrics(ptp4lSlave)
 	t.Log("Step 1: ptp4l port goes SLAVE")
 
@@ -302,7 +338,7 @@ func TestNTPNoDoubleClockRealtime(t *testing.T) {
 func TestNTPNodeSyncStateDuringHoldover(t *testing.T) {
 	profileName := "gnss-failover"
 
-	eventManager := metrics.NewPTPEventManager("", initPubSubTypes(), "testnode", &common.SCConfiguration{StorePath: "/tmp/store"})
+	eventManager := metrics.NewPTPEventManager("", initPubSubTypes(), "testnode", &common.SCConfiguration{StorePath: ntpStorePath})
 	eventManager.MockTest(true)
 
 	ptp4lCfg := &ptp4lconf.PTP4lConfig{
@@ -310,7 +346,7 @@ func TestNTPNodeSyncStateDuringHoldover(t *testing.T) {
 		Profile: profileName,
 		Interfaces: []*ptp4lconf.PTPInterface{
 			{
-				Name:     "ens3f0",
+				Name:     ntpSlaveIface,
 				PortID:   1,
 				PortName: "port 1",
 				Role:     types.SLAVE,
@@ -329,7 +365,7 @@ func TestNTPNodeSyncStateDuringHoldover(t *testing.T) {
 	ptpStats := eventManager.GetStats(types.ConfigName(ntpPtp4lCfgName))
 	ptpStats.CheckSource(metrics.MasterClockType, ntpPtp4lCfgName, "ptp4l")
 	ptpStats[metrics.MasterClockType].SetLastSyncState(ptp.HOLDOVER)
-	ptpStats[metrics.MasterClockType].SetAlias("ens3f0")
+	ptpStats[metrics.MasterClockType].SetAlias(ntpSlaveIface)
 
 	ptpStats.CheckSource(metrics.ClockRealTime, ntpPtp4lCfgName, "phc2sys")
 	ptpStats[metrics.ClockRealTime].SetLastSyncState(ptp.LOCKED)
@@ -337,6 +373,75 @@ func TestNTPNodeSyncStateDuringHoldover(t *testing.T) {
 	nodeState := eventManager.GetNodeSyncState(ptp.LOCKED)
 	assert.Equal(t, ptp.HOLDOVER, nodeState,
 		"LOST GNSS (HOLDOVER): sync-state must be HOLDOVER even though os-clock is LOCKED")
+}
+
+// TestNTPFailoverClockRealTimeMetricSwapsOwner reproduces the reported bug:
+// after ntpfailover switches CLOCK_REALTIME ownership between phc2sys and
+// chronyd, exactly one openshift_ptp_clock_state{iface="CLOCK_REALTIME"}
+// series must be exposed at a time — the previous owner's stale series must
+// be removed rather than lingering forever.
+func TestNTPFailoverClockRealTimeMetricSwapsOwner(t *testing.T) {
+	eventManager := metrics.NewPTPEventManager("", initPubSubTypes(), "testnode", &common.SCConfiguration{StorePath: ntpStorePath})
+	eventManager.MockTest(true)
+
+	ptp4lCfg := &ptp4lconf.PTP4lConfig{
+		Name:    ntpPtp4lCfgName,
+		Profile: ntpFailoverProfile,
+		Interfaces: []*ptp4lconf.PTPInterface{
+			{
+				Name:     ntpSlaveIface,
+				PortID:   1,
+				PortName: "port 1",
+				Role:     types.SLAVE,
+			},
+		},
+	}
+	eventManager.AddPTPConfig(types.ConfigName(ntpPtp4lCfgName), ptp4lCfg)
+
+	chronydCfg := &ptp4lconf.PTP4lConfig{
+		Name:    ntpChronydCfgName,
+		Profile: ntpFailoverProfile,
+	}
+	eventManager.AddPTPConfig(types.ConfigName(ntpChronydCfgName), chronydCfg)
+
+	phc2sysOpts := ntpPhc2sysOpts
+	chronydOpts := ntpChronydOpts
+	eventManager.PtpConfigMapUpdates.PtpProcessOpts = map[string]*ptpConfig.PtpProcessOpts{
+		ntpFailoverProfile: {
+			Phc2Opts:    &phc2sysOpts,
+			ChronydOpts: &chronydOpts,
+		},
+	}
+
+	// SyncState is a package-level singleton shared across tests in this
+	// binary; reset both series to establish a clean baseline for this test.
+	metrics.DeleteSyncStateMetrics("phc2sys", metrics.ClockRealTime)
+	metrics.DeleteSyncStateMetrics("chronyd", metrics.ClockRealTime)
+
+	// Initial stable GNSS: phc2sys owns CLOCK_REALTIME.
+	metrics.UpdateSyncStateMetrics("phc2sys", metrics.ClockRealTime, ptp.LOCKED)
+	assert.True(t, syncStateSeriesExists("phc2sys"),
+		"phc2sys CLOCK_REALTIME series must exist during stable GNSS")
+	assert.False(t, syncStateSeriesExists("chronyd"),
+		"chronyd CLOCK_REALTIME series must not exist yet during stable GNSS")
+
+	// GNSS loss -> NTP failover: chronyd takes over CLOCK_REALTIME.
+	chronydSelected := fmt.Sprintf("chronyd[1000.000]: [%s] Selected source 192.168.1.1 (ntp.example.com)", ntpChronydCfgName)
+	eventManager.ExtractMetrics(chronydSelected)
+
+	assert.True(t, syncStateSeriesExists("chronyd"),
+		"chronyd CLOCK_REALTIME series must exist during stable NTP")
+	assert.False(t, syncStateSeriesExists("phc2sys"),
+		"phc2sys stale CLOCK_REALTIME series must be removed once chronyd takes over")
+
+	// GNSS recovery: phc2sys reports CLOCK_REALTIME offset again and reclaims ownership.
+	phc2sysOffset := fmt.Sprintf("phc2sys[1001.000]: [%s] CLOCK_REALTIME phc offset       -10 s2 freq  -100 delay   100", ntpPtp4lCfgName)
+	eventManager.ExtractMetrics(phc2sysOffset)
+
+	assert.True(t, syncStateSeriesExists("phc2sys"),
+		"phc2sys CLOCK_REALTIME series must exist again after GNSS recovery")
+	assert.False(t, syncStateSeriesExists("chronyd"),
+		"chronyd stale CLOCK_REALTIME series must be removed once phc2sys reclaims ownership")
 }
 
 // Silence unused-import warnings for packages referenced indirectly.

--- a/plugins/ptp_operator/metrics/registry.go
+++ b/plugins/ptp_operator/metrics/registry.go
@@ -230,11 +230,12 @@ func UpdateSyncStateMetrics(process, iface string, state ptp.SyncState) {
 		return
 	}
 	var clockState float64
-	if state == ptp.LOCKED {
+	switch state {
+	case ptp.LOCKED:
 		clockState = float64(types.LOCKED)
-	} else if state == ptp.FREERUN {
+	case ptp.FREERUN:
 		clockState = float64(types.FREERUN)
-	} else if state == ptp.HOLDOVER {
+	case ptp.HOLDOVER:
 		clockState = float64(types.HOLDOVER)
 	}
 	// prevent reporting wrong metrics
@@ -245,6 +246,12 @@ func UpdateSyncStateMetrics(process, iface string, state ptp.SyncState) {
 	log.Debugf("UpdateSyncStateMetrics: process=%s iface=%s state=%s value=%.0f", process, iface, state, clockState)
 	SyncState.With(prometheus.Labels{
 		"process": process, "node": ptpNodeName, "iface": iface}).Set(clockState)
+}
+
+// DeleteSyncStateMetrics ... delete a single sync state series for a process/iface pair
+func DeleteSyncStateMetrics(process, iface string) {
+	SyncState.Delete(prometheus.Labels{
+		"process": process, "node": ptpNodeName, "iface": iface})
 }
 
 // UpdateNmeaStatusMetrics ... update nmea status metrics


### PR DESCRIPTION
Fix phc2sys / chrony stale metric by cleaning up the old metric, so there is only exactly one CLOCK_REALTIME metric on the system at all times

Assisted by Cursor