### PR TITLE
OCPBUGS-104524: Fix openshift_ptp_threshold metric not refreshed after PtpConfig change

### DIFF
--- a/plugins/ptp_operator/config/config.go
+++ b/plugins/ptp_operator/config/config.go
@@ -166,6 +166,7 @@ type LinuxPTPConfigMapUpdate struct {
 	PtpSettings            map[string]map[string]string
 	HAProfile              string
 	TBCProfiles            []string // list of TBC profiles
+	OnThresholdUpdate      func(thresholds map[string]*PtpClockThreshold)
 }
 
 // AppliedNodeProfileJSON ....
@@ -332,6 +333,9 @@ func (l *LinuxPTPConfigMapUpdate) UpdatePTPThreshold() {
 
 		log.Infof("update ptp threshold values for %s\n holdoverTimeout: %d\n maxThreshold: %d\n minThreshold: %d\n",
 			*profile.Name, holdOverTh, maxOffsetTh, minOffsetTh)
+	}
+	if l.OnThresholdUpdate != nil {
+		l.OnThresholdUpdate(l.EventThreshold)
 	}
 }
 

--- a/plugins/ptp_operator/config/config_test.go
+++ b/plugins/ptp_operator/config/config_test.go
@@ -319,6 +319,48 @@ func TestUpdatePTPThreshold_NtpFailover(t *testing.T) {
 	}
 }
 
+func TestUpdatePTPThreshold_OnThresholdUpdateCallback(t *testing.T) {
+	profileName := "callback-profile"
+	l := &ptpConfig.LinuxPTPConfigMapUpdate{
+		NodeProfiles: []ptpConfig.PtpProfile{
+			{
+				Name: &profileName,
+				PtpClockThreshold: &ptpConfig.PtpClockThreshold{
+					HoldOverTimeout:    30,
+					MaxOffsetThreshold: 200,
+					MinOffsetThreshold: -200,
+				},
+			},
+		},
+		EventThreshold: make(map[string]*ptpConfig.PtpClockThreshold),
+	}
+
+	callbackCount := 0
+	l.OnThresholdUpdate = func(thresholds map[string]*ptpConfig.PtpClockThreshold) {
+		callbackCount++
+		th := thresholds[profileName]
+		assert.NotNil(t, th, "threshold for profile must exist in callback")
+		assert.Equal(t, int64(200), th.MaxOffsetThreshold)
+		assert.Equal(t, int64(-200), th.MinOffsetThreshold)
+		assert.Equal(t, int64(30), th.HoldOverTimeout)
+	}
+
+	l.UpdatePTPThreshold()
+
+	assert.Equal(t, 1, callbackCount, "OnThresholdUpdate callback must be invoked exactly once")
+}
+
+func TestUpdatePTPThreshold_NilCallbackDoesNotPanic(t *testing.T) {
+	profileName := "nil-callback"
+	l := &ptpConfig.LinuxPTPConfigMapUpdate{
+		NodeProfiles: []ptpConfig.PtpProfile{
+			{Name: &profileName},
+		},
+		EventThreshold: make(map[string]*ptpConfig.PtpClockThreshold),
+	}
+	assert.NotPanics(t, func() { l.UpdatePTPThreshold() })
+}
+
 func TestUpdatePTPProcessOptions_TS2PhcConfSetsDefaultOpts(t *testing.T) {
 	ptp4lOpts := "-2 -s"
 	profileName := "ts2phc-profile"

--- a/plugins/ptp_operator/ptp_operator_plugin.go
+++ b/plugins/ptp_operator/ptp_operator_plugin.go
@@ -31,6 +31,7 @@ import (
 	"github.com/redhat-cne/sdk-go/pkg/event"
 
 	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/alias"
+	ptpConfig "github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/config"
 	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/ptp4lconf"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -200,14 +201,6 @@ func startPtpConfigSync(timeout time.Duration, nodeName string, configuration *c
 			eventManager.PtpConfigMapUpdates.UpdatePTPThreshold()
 			eventManager.PtpConfigMapUpdates.UpdatePTPSetting()
 			eventManager.RefreshProfileTypes()
-			for key, np := range eventManager.PtpConfigMapUpdates.EventThreshold {
-				ptpMetrics.Threshold.With(prometheus.Labels{
-					"threshold": "MinOffsetThreshold", "node": nodeName, "profile": key}).Set(float64(np.MinOffsetThreshold))
-				ptpMetrics.Threshold.With(prometheus.Labels{
-					"threshold": "MaxOffsetThreshold", "node": nodeName, "profile": key}).Set(float64(np.MaxOffsetThreshold))
-				ptpMetrics.Threshold.With(prometheus.Labels{
-					"threshold": "HoldOverTimeout", "node": nodeName, "profile": key}).Set(float64(np.HoldOverTimeout))
-			}
 		}
 	case <-time.After(timeout):
 		log.Warnf("configmap not available after %s, proceeding without profile settings", timeout)
@@ -251,6 +244,16 @@ func Start(wg *sync.WaitGroup, configuration *common.SCConfiguration, _ func(e i
 		log.Warn(err)
 	}
 	eventManager.SetInitalMetrics()
+	eventManager.PtpConfigMapUpdates.OnThresholdUpdate = func(thresholds map[string]*ptpConfig.PtpClockThreshold) {
+		for key, np := range thresholds {
+			ptpMetrics.Threshold.With(prometheus.Labels{
+				"threshold": "MinOffsetThreshold", "node": nodeName, "profile": key}).Set(float64(np.MinOffsetThreshold))
+			ptpMetrics.Threshold.With(prometheus.Labels{
+				"threshold": "MaxOffsetThreshold", "node": nodeName, "profile": key}).Set(float64(np.MaxOffsetThreshold))
+			ptpMetrics.Threshold.With(prometheus.Labels{
+				"threshold": "HoldOverTimeout", "node": nodeName, "profile": key}).Set(float64(np.HoldOverTimeout))
+		}
+	}
 	startPtpConfigSync(ptpConfigSyncInitialTimeout, nodeName, configuration)
 	loadInitialPtp4lConfigs()
 

--- a/plugins/ptp_operator/ptp_operator_plugin.go
+++ b/plugins/ptp_operator/ptp_operator_plugin.go
@@ -245,14 +245,7 @@ func Start(wg *sync.WaitGroup, configuration *common.SCConfiguration, _ func(e i
 	}
 	eventManager.SetInitalMetrics()
 	eventManager.PtpConfigMapUpdates.OnThresholdUpdate = func(thresholds map[string]*ptpConfig.PtpClockThreshold) {
-		for key, np := range thresholds {
-			ptpMetrics.Threshold.With(prometheus.Labels{
-				"threshold": "MinOffsetThreshold", "node": nodeName, "profile": key}).Set(float64(np.MinOffsetThreshold))
-			ptpMetrics.Threshold.With(prometheus.Labels{
-				"threshold": "MaxOffsetThreshold", "node": nodeName, "profile": key}).Set(float64(np.MaxOffsetThreshold))
-			ptpMetrics.Threshold.With(prometheus.Labels{
-				"threshold": "HoldOverTimeout", "node": nodeName, "profile": key}).Set(float64(np.HoldOverTimeout))
-		}
+		setThresholdMetrics(nodeName, thresholds)
 	}
 	startPtpConfigSync(ptpConfigSyncInitialTimeout, nodeName, configuration)
 	loadInitialPtp4lConfigs()
@@ -566,4 +559,15 @@ func InitPubSubTypes() map[ptp.EventType]*ptpTypes.EventPublisherType {
 		Resource:  ptp.SynceClockQuality,
 	}
 	return InitPubs
+}
+
+func setThresholdMetrics(nodeName string, thresholds map[string]*ptpConfig.PtpClockThreshold) {
+	for key, np := range thresholds {
+		ptpMetrics.Threshold.With(prometheus.Labels{
+			"threshold": "MinOffsetThreshold", "node": nodeName, "profile": key}).Set(float64(np.MinOffsetThreshold))
+		ptpMetrics.Threshold.With(prometheus.Labels{
+			"threshold": "MaxOffsetThreshold", "node": nodeName, "profile": key}).Set(float64(np.MaxOffsetThreshold))
+		ptpMetrics.Threshold.With(prometheus.Labels{
+			"threshold": "HoldOverTimeout", "node": nodeName, "profile": key}).Set(float64(np.HoldOverTimeout))
+	}
 }

--- a/plugins/ptp_operator/ptp_operator_plugin_test.go
+++ b/plugins/ptp_operator/ptp_operator_plugin_test.go
@@ -32,6 +32,7 @@ import (
 
 	v2 "github.com/cloudevents/sdk-go/v2"
 	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	ptpConfig "github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/config"
 	event2 "github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/event"
 	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/metrics"
@@ -815,6 +816,6 @@ func TestSetThresholdMetrics(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		assert.NotNil(t, g)
+		assert.Equal(t, tc.expected, testutil.ToFloat64(g), "metric value for %s", tc.threshold)
 	}
-	_ = testCases
 }

--- a/plugins/ptp_operator/ptp_operator_plugin_test.go
+++ b/plugins/ptp_operator/ptp_operator_plugin_test.go
@@ -789,3 +789,32 @@ func getMockOverrideFn() func(e v2.Event, d *channel.DataChan) error {
 		return nil
 	}
 }
+
+func TestSetThresholdMetrics(t *testing.T) {
+	metrics.Threshold.Reset()
+	thresholds := map[string]*ptpConfig.PtpClockThreshold{
+		"test-profile": {
+			MaxOffsetThreshold: 100,
+			MinOffsetThreshold: -100,
+			HoldOverTimeout:    5,
+		},
+	}
+	setThresholdMetrics("test-node", thresholds)
+
+	testCases := []struct {
+		threshold string
+		expected  float64
+	}{
+		{"MinOffsetThreshold", -100},
+		{"MaxOffsetThreshold", 100},
+		{"HoldOverTimeout", 5},
+	}
+	for _, tc := range testCases {
+		g, err := metrics.Threshold.GetMetricWith(map[string]string{
+			"threshold": tc.threshold, "node": "test-node", "profile": "test-profile",
+		})
+		assert.NoError(t, err)
+		assert.NotNil(t, g)
+	}
+	_ = testCases
+}


### PR DESCRIPTION
## Summary
- `openshift_ptp_threshold` Prometheus metric stays at defaults after a runtime PtpConfig `ptpClockThreshold` update when CEP is enabled
- The metric was only `.Set()` in `startPtpConfigSync()` (1s timeout window at startup). The lazy-reload path in `EnsureProcessOptions()` updated the internal `EventThreshold` map but never refreshed the gauge.
- Add an `OnThresholdUpdate` callback to `LinuxPTPConfigMapUpdate`, invoked at the end of `UpdatePTPThreshold()`. The plugin registers this callback to set the Prometheus metric, so both the initial sync and lazy-reload paths update the gauge.

Fixes: OCPBUGS-104524

## Test plan
- [ ] All existing unit tests pass (`go test ./plugins/ptp_operator/...`)
- [ ] Deploy on a cluster with CEP enabled, modify `ptpClockThreshold` in PtpConfig, verify `openshift_ptp_threshold` metric reflects new values within 30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)