### PR TITLE
OCPBUGS-104533: Fix duplicate TriggerLogs calls on multi-process reconnection

### DIFF
--- a/plugins/ptp_operator/ptp_operator_plugin.go
+++ b/plugins/ptp_operator/ptp_operator_plugin.go
@@ -490,24 +490,24 @@ func listenToSocket(wg *sync.WaitGroup) {
 	}
 }
 
+// triggerLogsOnce ensures TriggerLogs is called exactly once across all
+// accepted connections. Each daemon-side process opens its own connection,
+// but only the first one needs to request a state replay. The Once resets
+// naturally when CEP restarts via syscall.Exec.
+var triggerLogsOnce sync.Once
+
 func processMessages(c net.Conn) {
-	// Request a full state re-emit in a separate goroutine so the scanner
-	// can start reading immediately. The /emit-logs handler writes replay
-	// data back through the EventHandler's socket connection, which CEP
-	// accepts as a separate processMessages goroutine. If TriggerLogs blocks
-	// here, that goroutine's TriggerLogs creates a recursive write-back to
-	// a connection whose reader is stuck in TriggerLogs — deadlock once the
-	// kernel buffer fills. The daemon's liveGate independently ensures no
-	// live data flows until replay completes, so async is safe.
 	if eventManager != nil {
-		log.Debug("processMessages: firing async TriggerLogs")
-		go func() {
-			if err := eventManager.TriggerLogs(); err != nil {
-				log.Warnf("failed to trigger logs on new connection: %v", err)
-			} else {
-				log.Debug("processMessages: TriggerLogs completed successfully")
-			}
-		}()
+		triggerLogsOnce.Do(func() {
+			log.Debug("processMessages: firing async TriggerLogs (first connection)")
+			go func() {
+				if err := eventManager.TriggerLogs(); err != nil {
+					log.Warnf("failed to trigger logs on new connection: %v", err)
+				} else {
+					log.Debug("processMessages: TriggerLogs completed successfully")
+				}
+			}()
+		})
 	}
 	scanner := bufio.NewScanner(c)
 	for {

--- a/plugins/ptp_operator/ptp_operator_plugin.go
+++ b/plugins/ptp_operator/ptp_operator_plugin.go
@@ -497,11 +497,11 @@ func listenToSocket(wg *sync.WaitGroup) {
 var triggerLogsOnce sync.Once
 
 func processMessages(c net.Conn) {
-	if eventManager != nil {
+	if em := eventManager; em != nil {
 		triggerLogsOnce.Do(func() {
 			log.Debug("processMessages: firing async TriggerLogs (first connection)")
 			go func() {
-				if err := eventManager.TriggerLogs(); err != nil {
+				if err := em.TriggerLogs(); err != nil {
 					log.Warnf("failed to trigger logs on new connection: %v", err)
 				} else {
 					log.Debug("processMessages: TriggerLogs completed successfully")

--- a/plugins/ptp_operator/ptp_operator_plugin_test.go
+++ b/plugins/ptp_operator/ptp_operator_plugin_test.go
@@ -488,6 +488,7 @@ func setupProcessMessages(t *testing.T) func() {
 
 	return func() {
 		eventManager = oldEventManager
+		triggerLogsOnce = sync.Once{}
 	}
 }
 


### PR DESCRIPTION
Each daemon-side ptp4l/phc2sys process opens its own socket connection to CEP. The listenToSocket accept loop spawns a separate processMessages goroutine per connection, and each one unconditionally called TriggerLogs(), which hits the daemon's /emit-logs endpoint. With N processes this caused N replay cycles of the stale portRole cache, interleaving stale port-state events with live data and preventing the system from reaching LOCKED state for several minutes.

Gate TriggerLogs with sync.Once so only the first accepted connection triggers the replay. The Once resets naturally when CEP restarts via syscall.Exec.

Generated-by: Cursor