### PR TITLE
[release-4.20] OCPBUGS-104529: Fix T-BC ptp-state-change event not firing after ptp4l kill

### DIFF
--- a/plugins/ptp_operator/metrics/metrics.go
+++ b/plugins/ptp_operator/metrics/metrics.go
@@ -122,7 +122,7 @@ func (p *PTPEventManager) ExtractMetrics(msg string) {
 	if strings.Contains(output, ptpProcessStatusIdentifier) {
 		if status, err := parsePTPStatus(output, fields); err == nil {
 			if status == PtpProcessDown {
-				p.processDownEvent(profileName, processName, ptpStats)
+				p.processDownEvent(profileName, processName, ptpStats, ptp4lCfg.ProfileType)
 			}
 		} else {
 			log.Errorf("error in process status %s: %v", output, err)
@@ -368,7 +368,7 @@ func (p *PTPEventManager) ExtractMetrics(msg string) {
 		ptpInterface, ptp4lCfg, ptpStats)
 }
 
-func (p *PTPEventManager) processDownEvent(profileName, processName string, ptpStats stats.PTPStats) {
+func (p *PTPEventManager) processDownEvent(profileName, processName string, ptpStats stats.PTPStats, profileType ptp4lconf.PtpProfileType) {
 	// if the process is responsible to set master offset
 	if processName == ts2phcProcessName {
 		//  update metrics for all interface defined by ts2phc
@@ -389,6 +389,17 @@ func (p *PTPEventManager) processDownEvent(profileName, processName string, ptpS
 			}
 		}
 	} else { // other profiles
+		// T-BC: when ptp4l dies, fire FREERUN for the T-BC aggregate resource.
+		// Without this, the T-BC stats key is never set to FREERUN (DPLL/ts2phc
+		// keep T-BC-STATUS at s2), so ParseTBCLogs never detects a state
+		// transition and the recovery LOCKED event is never published.
+		if profileType == ptp4lconf.TBC && processName == ptp4lProcessName {
+			tbcKey := types.IFace(stats.TBCMainClockName)
+			if tbcStat, ok := ptpStats[tbcKey]; ok && tbcStat.Alias() != "" {
+				masterResource := fmt.Sprintf("%s/%s", tbcStat.Alias(), MasterClockType)
+				p.GenPTPEvent(profileName, tbcStat, masterResource, FreeRunOffsetValue, ptp.FREERUN, ptp.PtpStateChange)
+			}
+		}
 		if masterOffsetSource == processName {
 			if ptpStats[master].Alias() != "" {
 				masterResource := fmt.Sprintf("%s/%s", ptpStats[master].Alias(), MasterClockType)

--- a/plugins/ptp_operator/metrics/tbc_test.go
+++ b/plugins/ptp_operator/metrics/tbc_test.go
@@ -643,3 +643,68 @@ func TestTBCOffsetMetricUpdatedEveryLog(t *testing.T) {
 		})
 	}
 }
+
+// TestTBCProcessDownEventFiresFreerun verifies that killing ptp4l on a T-BC
+// profile sets the T-BC stats key to FREERUN and publishes a ptp-state-change
+// event, and that subsequent T-BC-STATUS s2 publishes a LOCKED event.
+// Regression test for OCPBUGS-85330.
+func TestTBCProcessDownEventFiresFreerun(t *testing.T) {
+	eventManager := metrics.NewPTPEventManager("", initPubSubTypes(), "testnode", &common.SCConfiguration{StorePath: "/tmp/store"})
+	eventManager.MockTest(true)
+
+	configName = "ptp4l.1.config"
+	tbcProfile := "tbc-tr"
+
+	eventManager.PtpConfigMapUpdates.TBCProfiles = []string{tbcProfile}
+	eventManager.PtpConfigMapUpdates.PtpProcessOpts = make(map[string]*ptpConfig.PtpProcessOpts)
+
+	ptp4lCfg := &ptp4lconf.PTP4lConfig{
+		Name:        configName,
+		Profile:     tbcProfile,
+		ProfileType: ptp4lconf.TBC,
+		Interfaces: []*ptp4lconf.PTPInterface{
+			{
+				Name:     "ens2f0",
+				PortID:   1,
+				PortName: "port 1",
+				Role:     types.SLAVE,
+			},
+		},
+	}
+	eventManager.AddPTPConfig(types.ConfigName(configName), ptp4lCfg)
+
+	ptpStats := eventManager.GetStats(types.ConfigName(configName))
+	ptpStats[metrics.MasterClockType] = &stats.Stats{}
+	ptpStats[metrics.MasterClockType].SetAlias("enox")
+	tbcKey := types.IFace(stats.TBCMainClockName)
+	ptpStats[tbcKey] = &stats.Stats{}
+	ptpStats[tbcKey].SetAlias("enox")
+	ptpStats[tbcKey].SetLastSyncState(ptp.LOCKED)
+
+	// Step 1: Simulate ptp4l process down (PTP_PROCESS_STATUS:0)
+	downLog := "ptp4l[1780430740]:[ptp4l.1.config] PTP_PROCESS_STATUS:0"
+	eventManager.ResetMockEvent()
+	eventManager.ExtractMetrics(downLog)
+
+	// Verify T-BC stats key is now FREERUN
+	assert.Equal(t, ptp.FREERUN, ptpStats[tbcKey].LastSyncState(),
+		"T-BC stats should be FREERUN after ptp4l down")
+
+	// Verify a PtpStateChange event was published
+	mockEvents := eventManager.GetMockEvent()
+	assert.Contains(t, mockEvents, ptp.PtpStateChange,
+		"PtpStateChange event should fire on ptp4l down for T-BC")
+
+	// Step 2: Simulate T-BC-STATUS s2 arriving (DPLL still locked)
+	replacer := strings.NewReplacer("[", " ", "]", " ", ":", " ")
+	tbcLog := "T-BC[1780430800]:[ts2phc.1.config] ens2f0 offset 0 T-BC-STATUS s2"
+	output := replacer.Replace(tbcLog)
+	fields := strings.Fields(output)
+
+	eventManager.ResetMockEvent()
+	eventManager.ParseTBCLogs("T-BC", configName, output, fields, ptpStats)
+
+	// Verify T-BC stats key transitions back to LOCKED
+	assert.Equal(t, ptp.LOCKED, ptpStats[tbcKey].LastSyncState(),
+		"T-BC stats should be LOCKED after T-BC-STATUS s2")
+}


### PR DESCRIPTION
## Summary
- Cherry-pick of PR #691 (OCPBUGS-85330) to `release-4.20`
- `processDownEvent()` did not handle T-BC profiles: when ptp4l died, the masterOffsetSource check (`ts2phc != ptp4l`) silently skipped event generation
- The T-BC stats key was never set to FREERUN, so `ParseTBCLogs` never detected a state transition and neither FREERUN nor LOCKED events were published
- Adds T-BC-specific handling: when ptp4l dies on a T-BC profile, fire FREERUN on the T-BC stats key via `GenPTPEvent`

Fixes: https://issues.redhat.com/browse/OCPBUGS-104529

Cherry-pick of: #691 (main), #692 (release-4.22)

## Test plan
- [x] `go test ./plugins/ptp_operator/metrics/...` passes on release-4.20
- [ ] Deploy on 4.20 T-BC cluster, kill ptp4l related to phc2sys, verify FREERUN→LOCKED events are published

🤖 Generated with [Claude Code](https://claude.com/claude-code)