### PR TITLE
OCPBUGS-105425: Publish os-clock FREERUN when phc2sys stops selecting CLOCK_REALTIME

### DIFF
--- a/plugins/ptp_operator/metrics/OS_CLOCK_DISCIPLINE.md
+++ b/plugins/ptp_operator/metrics/OS_CLOCK_DISCIPLINE.md
@@ -1,0 +1,71 @@
+# OS Clock Discipline State Machine
+
+When phc2sys runs with `-a -r`, it automatically selects clock sinks after
+upstream topology changes.  If it stops selecting CLOCK_REALTIME as a sink,
+the system clock is no longer network-disciplined but the synchronisation
+state can remain reported as LOCKED.  This state machine detects that
+condition and publishes a FREERUN event.
+
+## Phases
+
+| Phase | Description |
+|---|---|
+| **Idle** | No selection window is open. This phase does not imply the clock is disciplined — it only means the state machine is not actively tracking a selection burst. Actual discipline is determined by the normal offset processing path. |
+| **Selecting** | A window opened after phc2sys logged "reconfiguring after port state change". Waiting for selection lines. |
+| **SourceSelected** | A source clock (network interface) was selected, but CLOCK_REALTIME has not been selected as a sink. A settle timer is running. |
+| **Undisciplined** | CLOCK_REALTIME is confirmed not network-disciplined. A FREERUN event has been published. |
+
+## Transitions
+
+```mermaid
+flowchart TD
+    A([Idle]) -- reconfiguring after port state change --> B([Selecting])
+    B -- selecting NIC for synchronization --> C([SourceSelected])
+    B -- selecting CLOCK_REALTIME --> A
+    B -- waiting or postponing --> A
+    C -- selecting CLOCK_REALTIME --> A
+    C -- waiting or postponing --> A
+    C -- already selected --> F{chronyd enabled?}
+    C -- settle timer expires --> F
+    F -- no --> D([Undisciplined])
+    F -- yes, skip --> A
+    D -- publish FREERUN --> E[/OsClockSyncStateChange FREERUN/]
+    D -- CLOCK_REALTIME phc offset received --> A
+    D -- reconfiguring after port state change --> B
+```
+
+## Triggers
+
+Each transition is triggered by a specific phc2sys log line:
+
+| Log line | From | To | Action |
+|---|---|---|---|
+| `reconfiguring after port state change` | Any | Selecting | Opens a new selection window. Increments the generation counter. |
+| `selecting <NIC> for synchronization` | Selecting, SourceSelected | SourceSelected | Records that a source clock was selected. Arms (or re-arms) the settle timer. |
+| `selecting CLOCK_REALTIME for synchronization` | Any | Idle | CLOCK_REALTIME is being disciplined. Cancels the settle timer. |
+| `<NIC> as domain source clock` | SourceSelected | SourceSelected | Mid-burst marker. Re-arms the settle timer. |
+| `<NIC> as out-of-domain source clock` | SourceSelected | SourceSelected | Mid-burst marker. Re-arms the settle timer. |
+| `source clock not ready, waiting` | Selecting, SourceSelected | Idle | Selection is incomplete. Aborts the window. |
+| `multiple source clocks available, postponing sync` | Selecting, SourceSelected | Idle | Selection is incomplete. Aborts the window. |
+| `no PHC ready, waiting` | Selecting, SourceSelected | Idle | Selection is incomplete. Aborts the window. |
+| `already selected` (without CLOCK_REALTIME offset) | Selecting, SourceSelected | Undisciplined (if SourceSelected) or Idle | Selection burst ended. Publishes FREERUN if a source clock was seen without CLOCK_REALTIME. |
+| *(settle timer expires)* | SourceSelected | Undisciplined | No further selection lines arrived. Publishes FREERUN. |
+| `CLOCK_REALTIME phc offset ...` | Any | Idle | A system clock offset sample proves discipline. Clears any open window or undisciplined state. |
+
+## Settle Timer
+
+After a network interface is selected, a 200 millisecond settle timer starts.
+If CLOCK_REALTIME is selected or an "already selected" line arrives before the
+timer fires, the timer is cancelled.  If the timer fires without interruption,
+the window finalises and a FREERUN event is published.
+
+The timer carries a generation counter.  If a new "reconfiguring" line opens a
+fresh window before the old timer fires, the generation will not match and the
+stale callback is discarded.
+
+## Concurrency
+
+All phase transitions are serialised by a mutex internal to the state machine.
+The settle timer callback runs on a separate goroutine and acquires the
+extract-metrics mutex before finalising, preventing races with the main log
+processing path.

--- a/plugins/ptp_operator/metrics/manager.go
+++ b/plugins/ptp_operator/metrics/manager.go
@@ -32,9 +32,12 @@ type PTPEventManager struct {
 	nodeName       string
 	scConfig       *common.SCConfiguration
 	lock           sync.RWMutex
-	Stats          map[types.ConfigName]stats.PTPStats
-	mock           bool
-	mockEvent      []ptp.EventType
+	// extractMu serializes ExtractMetrics with settle-timer callbacks that
+	// publish OS-clock FREERUN (time.AfterFunc runs on another goroutine).
+	extractMu sync.Mutex
+	Stats     map[types.ConfigName]stats.PTPStats
+	mock      bool
+	mockEvent []ptp.EventType
 	// PtpConfigMapUpdates holds ptp-configmap updated details
 	PtpConfigMapUpdates *ptpConfig.LinuxPTPConfigMapUpdate
 	// Ptp4lConfigInterfaces holds interfaces and its roles, after reading from ptp4l config files
@@ -371,10 +374,12 @@ func (p *PTPEventManager) PublishEvent(state ptp.SyncState, ptpOffset int64, sou
 	}
 	// Handle mock mode
 	if p.mock {
+		p.lock.Lock()
 		p.mockEvent = []ptp.EventType{eventType}
 		if eventType == ptp.PtpStateChange || eventType == ptp.OsClockSyncStateChange {
 			p.mockEvent = append(p.mockEvent, ptp.SyncStateChange)
 		}
+		p.lock.Unlock()
 		log.Infof("PublishEvent state=%s, ptpOffset=%d, source=%s, eventType=%s", state, ptpOffset, source, eventType)
 	} else {
 		// /cluster/xyz/ptp/CLOCK_REALTIME this is not address the event is published to
@@ -578,11 +583,17 @@ func (p *PTPEventManager) resolveProfileName(profileName, configName string) str
 
 // GetMockEvent ...
 func (p *PTPEventManager) GetMockEvent() []ptp.EventType {
-	return p.mockEvent
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	out := make([]ptp.EventType, len(p.mockEvent))
+	copy(out, p.mockEvent)
+	return out
 }
 
 // ResetMockEvent ...
 func (p *PTPEventManager) ResetMockEvent() {
+	p.lock.Lock()
+	defer p.lock.Unlock()
 	p.mockEvent = []ptp.EventType{}
 }
 

--- a/plugins/ptp_operator/metrics/metrics.go
+++ b/plugins/ptp_operator/metrics/metrics.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/alias"
 	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/ptp4lconf"
@@ -84,8 +85,15 @@ const (
 	ppsStatus       = "pps_status"
 )
 
+// phc2sysSelectionSettleDelay waits for the rest of a reconfigure burst
+// (e.g. "selecting CLOCK_REALTIME for synchronization") before treating a
+// NIC-only sink selection as OS-clock undisciplined (finalised by silence).
+var phc2sysSelectionSettleDelay = 200 * time.Millisecond
+
 // ExtractMetrics ... extract metrics from ptp logs.
 func (p *PTPEventManager) ExtractMetrics(msg string) {
+	p.extractMu.Lock()
+	defer p.extractMu.Unlock()
 	defer func() {
 		if err := recover(); err != nil {
 			log.Errorf("restored from extract metrics and events: %s", err)
@@ -207,6 +215,9 @@ func (p *PTPEventManager) ExtractMetrics(msg string) {
 			// do nothing processDown identifier will update  metrics and stats
 			// but prevent further from reading offsets
 			return
+		} else if processName == phc2sysProcessName &&
+			p.handlePhc2sysSyncDirection(profileName, configName, output, fields, ptpStats) {
+			return
 		} else if strings.Contains(output, " offset ") { //  DPLL has Offset too
 			// ptp4l[5196819.100]: [ptp4l.0.config] master offset   -2162130 s2 freq +22451884 path delay    374976
 			// phc2sys[4268818.286]: [ptp4l.0.config] CLOCK_REALTIME phc offset       -62 s0 freq  -78368 delay   1100
@@ -228,6 +239,9 @@ func (p *PTPEventManager) ExtractMetrics(msg string) {
 				return // don't do if iface not known
 			}
 			log.Debugf("ExtractMetrics: offset parsed: process=%s iface=%s offset=%.0f syncState=%s", processName, interfaceName, ptpOffset, syncState)
+			if processName == phc2sysProcessName {
+				handlePhc2sysOffsetSyncDirection(profileName, configName, interfaceName, ptpStats)
+			}
 			//  only ts2phc process will return actual interface name- allow all ts2phcprocess or iface in (master or  clock realtime)
 			if processName != ts2phcProcessName && interfaceName != master && interfaceName != ClockRealTime {
 				return // only master and clock_realtime are supported

--- a/plugins/ptp_operator/metrics/os_clock_discipline.go
+++ b/plugins/ptp_operator/metrics/os_clock_discipline.go
@@ -1,0 +1,171 @@
+package metrics
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/stats"
+	"github.com/redhat-cne/sdk-go/pkg/event/ptp"
+	log "github.com/sirupsen/logrus"
+)
+
+// OS-clock discipline (phc2sysOpts: -a -r)
+//
+// After upstream loss, phc2sys may stop selecting CLOCK_REALTIME as a sink, so
+// "CLOCK_REALTIME phc offset" samples stop and E3 can stay LOCKED. Watch the
+// selection burst after "reconfiguring after port state change":
+//   - NIC selected, CLOCK_REALTIME not (already selected / settle silence) → E3 FREERUN
+//   - selecting CLOCK_REALTIME or CLOCK_REALTIME phc offset → clear sticky, normal path
+//
+// Not reverse sync (-r -r). Do not force E3 from T-BC alone (OCPBUGS-88369).
+
+// osClockLineClass classifies a phc2sys log line for the selection-window
+// state machine.  Merging the per-line checks into one classifier keeps the
+// handler a clean switch.
+type osClockLineClass int
+
+const (
+	osClockLineOther       osClockLineClass = iota // no match — continue to normal processing
+	osClockLineReconfigure                         // "reconfiguring after port state change"
+	osClockLineWaiting                             // "source clock not ready" / "postponing" / "no PHC ready"
+	osClockLineSourceClock                         // "as domain source clock" / "as out-of-domain source clock"
+	osClockLineFinalised                           // "already selected" or " offset "
+)
+
+func classifyOsClockLine(output string) osClockLineClass {
+	if strings.Contains(output, "reconfiguring after port state change") {
+		return osClockLineReconfigure
+	}
+	if strings.Contains(output, "source clock not ready, waiting") ||
+		strings.Contains(output, "multiple source clocks available, postponing sync") ||
+		strings.Contains(output, "no PHC ready, waiting") {
+		return osClockLineWaiting
+	}
+	if strings.Contains(output, "as domain source clock") ||
+		strings.Contains(output, "as out-of-domain source clock") {
+		return osClockLineSourceClock
+	}
+	if strings.Contains(output, "already selected") ||
+		strings.Contains(output, " offset ") {
+		return osClockLineFinalised
+	}
+	return osClockLineOther
+}
+
+func (p *PTPEventManager) handlePhc2sysSyncDirection(profileName, configName, output string,
+	fields []string, ptpStats stats.PTPStats) bool {
+	ptpStats.CheckSource(ClockRealTime, configName, phc2sysProcessName)
+	cr := ptpStats[ClockRealTime]
+
+	onSettle := func(generation uint64) {
+		p.extractMu.Lock()
+		defer p.extractMu.Unlock()
+		if cr.OsClock.FinaliseIfGeneration(generation) {
+			log.Infof("os-clock: profile=%s reason=selection-settle → E3 FREERUN", profileName)
+			p.publishOsClockFreerunUndisciplined(profileName, ptpStats)
+		}
+	}
+
+	switch classifyOsClockLine(output) {
+	case osClockLineReconfigure:
+		cr.OsClock.Begin()
+		log.Debugf("os-clock: profile=%s selection-window=begin", profileName)
+		return true
+
+	case osClockLineWaiting:
+		if cr.OsClock.IsWindowOpen() {
+			cr.OsClock.Abort()
+			log.Debugf("os-clock: profile=%s selection-window=abort reason=waiting", profileName)
+		}
+		return true
+
+	case osClockLineSourceClock:
+		cr.OsClock.ReArmSettle(phc2sysSelectionSettleDelay, onSettle)
+		return true
+
+	case osClockLineFinalised:
+		if !cr.OsClock.IsWindowOpen() {
+			return false
+		}
+		if strings.Contains(output, ClockRealTime) && strings.Contains(output, " offset ") {
+			cr.OsClock.Abort()
+			return false
+		}
+		if cr.OsClock.Finalise() {
+			log.Infof("os-clock: profile=%s reason=selection-finalised → E3 FREERUN", profileName)
+			p.publishOsClockFreerunUndisciplined(profileName, ptpStats)
+		}
+		if strings.Contains(output, " offset ") {
+			return false
+		}
+		return true
+	}
+
+	if clockName, ok := parseSelectingForSynchronization(fields); ok {
+		if !cr.OsClock.IsWindowOpen() {
+			if clockName == ClockRealTime {
+				cr.OsClock.SinkClockSelected()
+			}
+			return true
+		}
+		if clockName == ClockRealTime {
+			cr.OsClock.SinkClockSelected()
+			log.Debugf("os-clock: profile=%s selecting=CLOCK_REALTIME → disciplined", profileName)
+			return true
+		}
+		cr.OsClock.SourceClockSelected(phc2sysSelectionSettleDelay, onSettle)
+		log.Debugf("os-clock: profile=%s selecting=%s → arm settle", profileName, clockName)
+		return true
+	}
+
+	return false
+}
+
+// handlePhc2sysOffsetSyncDirection clears undisciplined state when a forward
+// CLOCK_REALTIME phc-offset sample arrives, proving discipline.
+func handlePhc2sysOffsetSyncDirection(profileName, configName,
+	interfaceName string, ptpStats stats.PTPStats) {
+	if interfaceName != ClockRealTime {
+		return
+	}
+	ptpStats.CheckSource(ClockRealTime, configName, phc2sysProcessName)
+	cr := ptpStats[ClockRealTime]
+	was := cr.OsClock.IsUndisciplined()
+	cr.OsClock.ClearOnRealtimeOffset()
+	if was {
+		log.Infof("os-clock: profile=%s reason=clock-realtime-phc-offset → clear undisciplined",
+			profileName)
+	}
+}
+
+func (p *PTPEventManager) publishOsClockFreerunUndisciplined(profileName string, ptpStats stats.PTPStats) {
+	s, ok := ptpStats[ClockRealTime]
+	if !ok {
+		return
+	}
+	opts := p.PtpConfigMapUpdates.LookupPtpProcessOpts(profileName)
+	if opts != nil && opts.ChronydEnabled() {
+		log.Debugf("os-clock: profile=%s skip E3 FREERUN (chronyd owns OS clock)", profileName)
+		return
+	}
+	p.GenPTPEvent(profileName, s, ClockRealTime, FreeRunOffsetValue, ptp.FREERUN, ptp.OsClockSyncStateChange)
+	UpdateSyncStateMetrics(phc2sysProcessName, ClockRealTime, ptp.FREERUN)
+}
+
+func parseSelectingForSynchronization(fields []string) (string, bool) {
+	idx := slices.Index(fields, "selecting")
+	if idx < 0 {
+		return "", false
+	}
+	// "selecting <clock> for synchronization"
+	if idx+3 < len(fields) && fields[idx+2] == "for" && fields[idx+3] == "synchronization" {
+		return fields[idx+1], true
+	}
+	// "selecting system clock for synchronization"
+	if idx+4 < len(fields) &&
+		fields[idx+1] == "system" && fields[idx+2] == "clock" &&
+		fields[idx+3] == "for" && fields[idx+4] == "synchronization" {
+		return ClockRealTime, true
+	}
+	return "", false
+}

--- a/plugins/ptp_operator/metrics/os_clock_discipline_test.go
+++ b/plugins/ptp_operator/metrics/os_clock_discipline_test.go
@@ -1,0 +1,284 @@
+package metrics
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/redhat-cne/cloud-event-proxy/pkg/common"
+	ptpConfig "github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/config"
+	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/ptp4lconf"
+	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/stats"
+	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/types"
+	"github.com/redhat-cne/sdk-go/pkg/event/ptp"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	osClockProfile  = "bc-os-clock"
+	osClockCfgName  = "ptp4l.0.config"
+	osClockIface    = "ens5f0"
+	osClockIface2   = "ens5f1"
+	osClockPhc2Opts = "-a -r"
+	osClockPortName = "port 1"
+)
+
+// setPhc2sysSelectionSettleDelayForTest overrides the settle delay for tests.
+func setPhc2sysSelectionSettleDelayForTest(d time.Duration) (restore func()) {
+	prev := phc2sysSelectionSettleDelay
+	phc2sysSelectionSettleDelay = d
+	return func() { phc2sysSelectionSettleDelay = prev }
+}
+
+func osClockInitPubSubTypes() map[ptp.EventType]*types.EventPublisherType {
+	initPubs := make(map[ptp.EventType]*types.EventPublisherType)
+	initPubs[ptp.OsClockSyncStateChange] = &types.EventPublisherType{
+		EventType: ptp.OsClockSyncStateChange,
+		Resource:  ptp.OsClockSyncState,
+	}
+	initPubs[ptp.PtpClockClassChange] = &types.EventPublisherType{
+		EventType: ptp.PtpClockClassChange,
+		Resource:  ptp.PtpClockClass,
+	}
+	initPubs[ptp.PtpStateChange] = &types.EventPublisherType{
+		EventType: ptp.PtpStateChange,
+		Resource:  ptp.PtpLockState,
+	}
+	initPubs[ptp.GnssStateChange] = &types.EventPublisherType{
+		EventType: ptp.GnssStateChange,
+		Resource:  ptp.GnssSyncStatus,
+	}
+	return initPubs
+}
+
+func setupOsClockDisciplineManager(t *testing.T, withChronyd bool) *PTPEventManager {
+	t.Helper()
+	eventManager := NewPTPEventManager("", osClockInitPubSubTypes(), "testnode", &common.SCConfiguration{StorePath: t.TempDir()})
+	eventManager.MockTest(true)
+
+	ptp4lCfg := &ptp4lconf.PTP4lConfig{
+		Name:    osClockCfgName,
+		Profile: osClockProfile,
+		Interfaces: []*ptp4lconf.PTPInterface{
+			{
+				Name:     osClockIface,
+				PortID:   1,
+				PortName: osClockPortName,
+				Role:     types.SLAVE,
+			},
+		},
+	}
+	eventManager.AddPTPConfig(types.ConfigName(osClockCfgName), ptp4lCfg)
+
+	phc2Opts := osClockPhc2Opts
+	opts := &ptpConfig.PtpProcessOpts{Phc2Opts: &phc2Opts}
+	if withChronyd {
+		chronydOpts := "-f /etc/chrony.conf"
+		opts.ChronydOpts = &chronydOpts
+	}
+	eventManager.PtpConfigMapUpdates.PtpProcessOpts = map[string]*ptpConfig.PtpProcessOpts{
+		osClockProfile: opts,
+	}
+	return eventManager
+}
+
+func lockClockRealtime(t *testing.T, eventManager *PTPEventManager) {
+	t.Helper()
+	line := fmt.Sprintf("phc2sys[3263.065]: [%s] CLOCK_REALTIME phc offset 3 s2 freq -20217 delay 536", osClockCfgName)
+	eventManager.ExtractMetrics(line)
+	ptpStats := eventManager.GetStats(types.ConfigName(osClockCfgName))
+	cStat, ok := ptpStats[ClockRealTime]
+	assert.True(t, ok)
+	assert.Equal(t, ptp.LOCKED, cStat.LastSyncState())
+}
+
+func waitOsClockFreerun(t *testing.T, eventManager *PTPEventManager) {
+	t.Helper()
+	assert.Eventually(t, func() bool {
+		return containsEvent(eventManager.GetMockEvent(), ptp.OsClockSyncStateChange)
+	}, time.Second, 10*time.Millisecond)
+	ptpStats := eventManager.GetStats(types.ConfigName(osClockCfgName))
+	cStat := ptpStats[ClockRealTime]
+	assert.Equal(t, ptp.FREERUN, cStat.LastSyncState())
+	assert.True(t, cStat.OsClock.IsUndisciplined())
+}
+
+func containsEvent(events []ptp.EventType, target ptp.EventType) bool {
+	for _, e := range events {
+		if e == target {
+			return true
+		}
+	}
+	return false
+}
+
+// TestOsClockSilenceSettlePublishesFreerun: reconfigure + selecting NIC, then
+// silence → settle timeout publishes E3 FREERUN.
+func TestOsClockSilenceSettlePublishesFreerun(t *testing.T) {
+	restore := setPhc2sysSelectionSettleDelayForTest(30 * time.Millisecond)
+	t.Cleanup(restore)
+
+	eventManager := setupOsClockDisciplineManager(t, false)
+	lockClockRealtime(t, eventManager)
+	eventManager.ResetMockEvent()
+
+	eventManager.ExtractMetrics(fmt.Sprintf(
+		"phc2sys[3264.000]: [%s] reconfiguring after port state change", osClockCfgName))
+	eventManager.ExtractMetrics(fmt.Sprintf(
+		"phc2sys[3264.000]: [%s] selecting %s for synchronization", osClockCfgName, osClockIface))
+
+	waitOsClockFreerun(t, eventManager)
+}
+
+// TestOsClockAlreadySelectedPublishesFreerun: selection ends with
+// "already selected" and no CLOCK_REALTIME sample → E3 FREERUN.
+func TestOsClockAlreadySelectedPublishesFreerun(t *testing.T) {
+	eventManager := setupOsClockDisciplineManager(t, false)
+	lockClockRealtime(t, eventManager)
+	eventManager.ResetMockEvent()
+
+	eventManager.ExtractMetrics(fmt.Sprintf(
+		"phc2sys[3264.000]: [%s] reconfiguring after port state change", osClockCfgName))
+	eventManager.ExtractMetrics(fmt.Sprintf(
+		"phc2sys[3264.000]: [%s] selecting %s for synchronization", osClockCfgName, osClockIface))
+	eventManager.ExtractMetrics(fmt.Sprintf(
+		"phc2sys[3264.000]: [%s] skipping %s: %s has the same clock and is already selected",
+		osClockCfgName, osClockIface2, osClockIface))
+
+	ptpStats := eventManager.GetStats(types.ConfigName(osClockCfgName))
+	cStat := ptpStats[ClockRealTime]
+	assert.Equal(t, ptp.FREERUN, cStat.LastSyncState())
+	assert.True(t, cStat.OsClock.IsUndisciplined())
+	assert.Contains(t, eventManager.GetMockEvent(), ptp.OsClockSyncStateChange)
+}
+
+// TestForwardSelectRealtimeCancelsSettle: selecting CLOCK_REALTIME cancels
+// settle so a healthy reconfig does not spuriously FREERUN.
+func TestForwardSelectRealtimeCancelsSettle(t *testing.T) {
+	restore := setPhc2sysSelectionSettleDelayForTest(40 * time.Millisecond)
+	t.Cleanup(restore)
+
+	eventManager := setupOsClockDisciplineManager(t, false)
+	lockClockRealtime(t, eventManager)
+	eventManager.ResetMockEvent()
+
+	eventManager.ExtractMetrics(fmt.Sprintf(
+		"phc2sys[3264.000]: [%s] reconfiguring after port state change", osClockCfgName))
+	eventManager.ExtractMetrics(fmt.Sprintf(
+		"phc2sys[3264.000]: [%s] selecting %s for synchronization", osClockCfgName, osClockIface))
+	eventManager.ExtractMetrics(fmt.Sprintf(
+		"phc2sys[3264.000]: [%s] selecting %s as domain source clock", osClockCfgName, osClockIface))
+	eventManager.ExtractMetrics(fmt.Sprintf(
+		"phc2sys[3264.000]: [%s] selecting CLOCK_REALTIME for synchronization", osClockCfgName))
+
+	time.Sleep(80 * time.Millisecond)
+
+	ptpStats := eventManager.GetStats(types.ConfigName(osClockCfgName))
+	cStat := ptpStats[ClockRealTime]
+	assert.Equal(t, ptp.LOCKED, cStat.LastSyncState())
+	assert.False(t, cStat.OsClock.IsUndisciplined())
+	for _, evt := range eventManager.GetMockEvent() {
+		assert.NotEqual(t, ptp.OsClockSyncStateChange, evt)
+	}
+}
+
+// TestOsClockFreerunSkippedWhenChronydEnabled: chronyd owns E3 — no FREERUN.
+func TestOsClockFreerunSkippedWhenChronydEnabled(t *testing.T) {
+	restore := setPhc2sysSelectionSettleDelayForTest(30 * time.Millisecond)
+	t.Cleanup(restore)
+
+	eventManager := setupOsClockDisciplineManager(t, true)
+	lockClockRealtime(t, eventManager)
+	eventManager.ResetMockEvent()
+
+	eventManager.ExtractMetrics(fmt.Sprintf(
+		"phc2sys[3264.000]: [%s] reconfiguring after port state change", osClockCfgName))
+	eventManager.ExtractMetrics(fmt.Sprintf(
+		"phc2sys[3264.000]: [%s] selecting %s for synchronization", osClockCfgName, osClockIface))
+	eventManager.ExtractMetrics(fmt.Sprintf(
+		"phc2sys[3264.000]: [%s] skipping %s: %s has the same clock and is already selected",
+		osClockCfgName, osClockIface2, osClockIface))
+
+	time.Sleep(80 * time.Millisecond)
+
+	ptpStats := eventManager.GetStats(types.ConfigName(osClockCfgName))
+	assert.Equal(t, ptp.LOCKED, ptpStats[ClockRealTime].LastSyncState())
+	for _, evt := range eventManager.GetMockEvent() {
+		assert.NotEqual(t, ptp.OsClockSyncStateChange, evt)
+	}
+}
+
+// TestTBCFreerunPlusOsClockSilencePublishesE3: T-BC FREERUN alone must not
+// force E3 (OCPBUGS-88369); silence after NIC-only selection still does
+// (OCPBUGS-105425).
+func TestTBCFreerunPlusOsClockSilencePublishesE3(t *testing.T) {
+	restore := setPhc2sysSelectionSettleDelayForTest(30 * time.Millisecond)
+	t.Cleanup(restore)
+
+	tbcProfile := "tbc-os-clock"
+	cfgName := osClockCfgName
+	iface := osClockIface
+
+	eventManager := NewPTPEventManager("", osClockInitPubSubTypes(), "testnode",
+		&common.SCConfiguration{StorePath: t.TempDir()})
+	eventManager.MockTest(true)
+	eventManager.PtpConfigMapUpdates.TBCProfiles = []string{tbcProfile}
+
+	ptp4lCfg := &ptp4lconf.PTP4lConfig{
+		Name:        cfgName,
+		Profile:     tbcProfile,
+		ProfileType: ptp4lconf.TBC,
+		Interfaces: []*ptp4lconf.PTPInterface{
+			{
+				Name:     iface,
+				PortID:   1,
+				PortName: osClockPortName,
+				Role:     types.SLAVE,
+			},
+		},
+	}
+	eventManager.AddPTPConfig(types.ConfigName(cfgName), ptp4lCfg)
+
+	phc2Opts := osClockPhc2Opts
+	eventManager.PtpConfigMapUpdates.PtpProcessOpts = map[string]*ptpConfig.PtpProcessOpts{
+		tbcProfile: {Phc2Opts: &phc2Opts},
+	}
+
+	ptpStats := eventManager.GetStats(types.ConfigName(cfgName))
+	ptpStats[MasterClockType] = stats.NewStats(cfgName)
+	ptpStats[MasterClockType].SetAlias(iface)
+
+	replacer := strings.NewReplacer("[", " ", "]", " ", ":", " ")
+	tbcLockedLog := fmt.Sprintf("T-BC[1743005894]:[%s] %s offset 5 T-BC-STATUS s2", cfgName, iface)
+	output := replacer.Replace(tbcLockedLog)
+	eventManager.ParseTBCLogs("T-BC", cfgName, output, strings.Fields(output), ptpStats)
+
+	eventManager.ExtractMetrics(fmt.Sprintf(
+		"phc2sys[3263.065]: [%s] CLOCK_REALTIME phc offset 3 s2 freq -20217 delay 536", cfgName))
+	cStat := ptpStats[ClockRealTime]
+	assert.Equal(t, ptp.LOCKED, cStat.LastSyncState())
+
+	eventManager.ResetMockEvent()
+	tbcFreerunLog := fmt.Sprintf("T-BC[1743005900]:[%s] %s offset 123 T-BC-STATUS s0", cfgName, iface)
+	output = replacer.Replace(tbcFreerunLog)
+	eventManager.ParseTBCLogs("T-BC", cfgName, output, strings.Fields(output), ptpStats)
+
+	tbcKey := types.IFace(stats.TBCMainClockName)
+	assert.Equal(t, ptp.FREERUN, ptpStats[tbcKey].LastSyncState())
+	assert.Equal(t, ptp.LOCKED, cStat.LastSyncState(),
+		"CLOCK_REALTIME must stay LOCKED when only T-BC goes FREERUN")
+	assert.NotContains(t, eventManager.GetMockEvent(), ptp.OsClockSyncStateChange)
+
+	eventManager.ResetMockEvent()
+	eventManager.ExtractMetrics(fmt.Sprintf(
+		"phc2sys[3264.000]: [%s] reconfiguring after port state change", cfgName))
+	eventManager.ExtractMetrics(fmt.Sprintf(
+		"phc2sys[3264.000]: [%s] selecting %s for synchronization", cfgName, iface))
+
+	assert.Eventually(t, func() bool {
+		return containsEvent(eventManager.GetMockEvent(), ptp.OsClockSyncStateChange)
+	}, time.Second, 10*time.Millisecond)
+	assert.Equal(t, ptp.FREERUN, cStat.LastSyncState())
+	assert.True(t, cStat.OsClock.IsUndisciplined())
+}

--- a/plugins/ptp_operator/stats/os_clock_discipline.go
+++ b/plugins/ptp_operator/stats/os_clock_discipline.go
@@ -1,0 +1,166 @@
+package stats
+
+import (
+	"sync"
+	"time"
+)
+
+// OsClockPhase tracks where the OS-clock discipline detection state machine
+// is within a phc2sys selection burst after upstream loss under -a -r.
+//
+// Transitions:
+//
+//	Idle ──Begin()──→ Selecting ──SourceClockSelected()──→ SourceSelected ──Finalise()──→ Undisciplined
+//	                  │                        │                          │
+//	                  └──SinkClockSelected()──→ Idle                        └──ClearOnRealtimeOffset()──→ Idle
+//	                  └──Abort()───────────→ Idle └──SinkClockSelected()──→ Idle
+//	                                            └──Abort()─────────→ Idle
+type OsClockPhase int
+
+const (
+	OsClockIdle           OsClockPhase = iota // No selection window open
+	OsClockSelecting                          // Window opened by "reconfiguring after port state change"
+	OsClockSourceSelected                     // Source clock selected, waiting for CLOCK_REALTIME or settle timeout
+	OsClockUndisciplined                      // CLOCK_REALTIME not being network-disciplined
+)
+
+// OsClockDiscipline is a self-contained state machine tracking whether
+// phc2sys is disciplining CLOCK_REALTIME.  Embed it in Stats.
+type OsClockDiscipline struct {
+	mu        sync.Mutex
+	phase     OsClockPhase
+	settle    *time.Timer
+	selectGen uint64
+}
+
+// Phase returns the current phase.
+func (d *OsClockDiscipline) Phase() OsClockPhase {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.phase
+}
+
+// IsUndisciplined reports whether CLOCK_REALTIME is not network-disciplined.
+func (d *OsClockDiscipline) IsUndisciplined() bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.phase == OsClockUndisciplined
+}
+
+// IsWindowOpen reports whether a selection window is currently open.
+func (d *OsClockDiscipline) IsWindowOpen() bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.phase == OsClockSelecting || d.phase == OsClockSourceSelected
+}
+
+// Begin opens (or resets) a selection window after
+// "reconfiguring after port state change".
+func (d *OsClockDiscipline) Begin() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.stopSettleLocked()
+	d.selectGen++
+	d.phase = OsClockSelecting
+}
+
+// Abort closes an open window without transitioning to Undisciplined.
+func (d *OsClockDiscipline) Abort() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.stopSettleLocked()
+	if d.phase == OsClockSelecting || d.phase == OsClockSourceSelected {
+		d.phase = OsClockIdle
+	}
+}
+
+// SourceClockSelected records a non-CLOCK_REALTIME sink and arms the settle timer.
+func (d *OsClockDiscipline) SourceClockSelected(delay time.Duration, onSettle func(uint64)) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.phase != OsClockSelecting && d.phase != OsClockSourceSelected {
+		return
+	}
+	d.phase = OsClockSourceSelected
+	d.stopSettleLocked()
+	gen := d.selectGen
+	d.settle = time.AfterFunc(delay, func() { onSettle(gen) })
+}
+
+// SinkClockSelected records that CLOCK_REALTIME was selected; clears the
+// window and any undisciplined state.
+func (d *OsClockDiscipline) SinkClockSelected() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.stopSettleLocked()
+	d.phase = OsClockIdle
+}
+
+// ReArmSettle resets the settle timer while in SourceSelected phase.
+func (d *OsClockDiscipline) ReArmSettle(delay time.Duration, onSettle func(uint64)) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.phase != OsClockSourceSelected {
+		return
+	}
+	d.stopSettleLocked()
+	gen := d.selectGen
+	d.settle = time.AfterFunc(delay, func() { onSettle(gen) })
+}
+
+// Finalise closes the window.  Returns true if a NIC was seen without
+// CLOCK_REALTIME, meaning FREERUN should be published.
+func (d *OsClockDiscipline) Finalise() bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.finaliseLocked()
+}
+
+// FinaliseIfGeneration is for settle-timer callbacks; only finalises if the
+// generation matches (i.e. the window has not been superseded).
+func (d *OsClockDiscipline) FinaliseIfGeneration(generation uint64) bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.selectGen != generation {
+		return false
+	}
+	return d.finaliseLocked()
+}
+
+// ClearOnRealtimeOffset closes any open window when a forward CLOCK_REALTIME
+// phc-offset sample proves discipline, and resets the undisciplined flag.
+func (d *OsClockDiscipline) ClearOnRealtimeOffset() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.stopSettleLocked()
+	d.phase = OsClockIdle
+}
+
+// Reset clears all state.
+func (d *OsClockDiscipline) Reset() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.stopSettleLocked()
+	d.phase = OsClockIdle
+}
+
+func (d *OsClockDiscipline) stopSettleLocked() {
+	if d.settle != nil {
+		d.settle.Stop()
+		d.settle = nil
+	}
+}
+
+func (d *OsClockDiscipline) finaliseLocked() bool {
+	d.stopSettleLocked()
+	if d.phase != OsClockSelecting && d.phase != OsClockSourceSelected {
+		return false
+	}
+	activate := d.phase == OsClockSourceSelected
+	if activate {
+		d.phase = OsClockUndisciplined
+	} else {
+		d.phase = OsClockIdle
+	}
+	return activate
+}

--- a/plugins/ptp_operator/stats/stats.go
+++ b/plugins/ptp_operator/stats/stats.go
@@ -45,6 +45,7 @@ type Stats struct {
 	ptpDependentEventState *event.PTPEventState
 	configDeleted          bool
 	syncE                  *SyncEStats // device name is the key
+	OsClock                OsClockDiscipline
 }
 
 // SyncEStats collects stats for synceE
@@ -165,6 +166,7 @@ func (s *Stats) reset() { //nolint:unused
 	s.processName = ""
 	s.lastOffset = 0
 	s.offsetSource = ""
+	s.OsClock.Reset()
 }
 
 // NewStats ... create new stats


### PR DESCRIPTION
## Summary
- Detect when phc2sys (`phc2sysOpts: -a -r`) stops selecting `CLOCK_REALTIME` as a sink after upstream loss (selection window: `already selected` / settle silence)
- Publish `OsClockSyncState` FREERUN so E3 does not stay stuck LOCKED after `CLOCK_REALTIME phc offset` samples stop
- Does **not** implement reverse sync (`-r -r` / `sys offset` / as-source); that mode is out of scope
- Does not bring back T-BC forcing E3 (removed in OCPBUGS-88369)

Fixes: OCPBUGS-105425

## Why OCPBUGS-88369 missed this
88369 stopped T-BC from forcing the OS clock FREERUN. After that, E3 only updated when phc2sys still printed `CLOCK_REALTIME phc offset` lines. With `-a -r`, after upstream loss those lines often stop (CLOCK_REALTIME is no longer selected as sink — not reverse sync, which needs `-r -r`), so E3 could stay LOCKED. Test T-BC often uses `-s <iface>` (samples keep coming), and the 88369 tests always fed another CLOCK_REALTIME sample — so this case was never hit.

Two rules that both must stay true:
1. T-BC FREERUN alone must not force E3 FREERUN.
2. When phc2sys stops disciplining CLOCK_REALTIME and samples stop, E3 must still go FREERUN.

Do not bring back “T-BC forces E3” to fix (2) — that breaks (1) again.
Covered together by the combined T-BC FREERUN + selection-silence unit test.

## Test plan
- [x] Unit tests for selection-window FREERUN / recovery / chronyd skip / T-BC+silence
- [ ] E2E BC upstream-loss: OsClockSyncState FREERUN then LOCKED on recovery (ptp-operator serial)

Assisted-By: Cursor