### PR TITLE
OCPBUGS-106193: [4.22] Fix openshift_ptp_threshold metric not refreshed after PtpConfig change

### DIFF
--- a/plugins/ptp_operator/config/config.go
+++ b/plugins/ptp_operator/config/config.go
@@ -163,6 +163,7 @@ type LinuxPTPConfigMapUpdate struct {
 	PtpSettings            map[string]map[string]string
 	HAProfile              string
 	TBCProfiles            []string // list of TBC profiles
+	OnThresholdUpdate      func(thresholds map[string]*PtpClockThreshold)
 }
 
 // AppliedNodeProfileJSON ....
@@ -322,6 +323,9 @@ func (l *LinuxPTPConfigMapUpdate) UpdatePTPThreshold() {
 
 		log.Infof("update ptp threshold values for %s\n holdoverTimeout: %d\n maxThreshold: %d\n minThreshold: %d\n",
 			*profile.Name, holdOverTh, maxOffsetTh, minOffsetTh)
+	}
+	if l.OnThresholdUpdate != nil {
+		l.OnThresholdUpdate(l.EventThreshold)
 	}
 }
 

--- a/plugins/ptp_operator/config/config_test.go
+++ b/plugins/ptp_operator/config/config_test.go
@@ -227,6 +227,48 @@ func TestUpdatePTPProcessOptions_NilChronydOpts(t *testing.T) {
 	assert.True(t, opts.Phc2SysEnabled())
 }
 
+func TestUpdatePTPThreshold_OnThresholdUpdateCallback(t *testing.T) {
+	profileName := "callback-profile"
+	l := &ptpConfig.LinuxPTPConfigMapUpdate{
+		NodeProfiles: []ptpConfig.PtpProfile{
+			{
+				Name: &profileName,
+				PtpClockThreshold: &ptpConfig.PtpClockThreshold{
+					HoldOverTimeout:    30,
+					MaxOffsetThreshold: 200,
+					MinOffsetThreshold: -200,
+				},
+			},
+		},
+		EventThreshold: make(map[string]*ptpConfig.PtpClockThreshold),
+	}
+
+	callbackCount := 0
+	l.OnThresholdUpdate = func(thresholds map[string]*ptpConfig.PtpClockThreshold) {
+		callbackCount++
+		th := thresholds[profileName]
+		assert.NotNil(t, th, "threshold for profile must exist in callback")
+		assert.Equal(t, int64(200), th.MaxOffsetThreshold)
+		assert.Equal(t, int64(-200), th.MinOffsetThreshold)
+		assert.Equal(t, int64(30), th.HoldOverTimeout)
+	}
+
+	l.UpdatePTPThreshold()
+
+	assert.Equal(t, 1, callbackCount, "OnThresholdUpdate callback must be invoked exactly once")
+}
+
+func TestUpdatePTPThreshold_NilCallbackDoesNotPanic(t *testing.T) {
+	profileName := "nil-callback"
+	l := &ptpConfig.LinuxPTPConfigMapUpdate{
+		NodeProfiles: []ptpConfig.PtpProfile{
+			{Name: &profileName},
+		},
+		EventThreshold: make(map[string]*ptpConfig.PtpClockThreshold),
+	}
+	assert.NotPanics(t, func() { l.UpdatePTPThreshold() })
+}
+
 func TestUpdatePTPProcessOptions_TS2PhcConfSetsDefaultOpts(t *testing.T) {
 	ptp4lOpts := "-2 -s"
 	profileName := "ts2phc-profile"

--- a/plugins/ptp_operator/ptp_operator_plugin.go
+++ b/plugins/ptp_operator/ptp_operator_plugin.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/redhat-cne/sdk-go/pkg/event"
 
+	ptpConfig "github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/config"
 	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/ptp4lconf"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -225,14 +226,6 @@ func startPtpConfigSync(timeout time.Duration, nodeName string, configuration *c
 			eventManager.PtpConfigMapUpdates.UpdatePTPThreshold()
 			eventManager.PtpConfigMapUpdates.UpdatePTPSetting()
 			eventManager.RefreshProfileTypes()
-			for key, np := range eventManager.PtpConfigMapUpdates.EventThreshold {
-				ptpMetrics.Threshold.With(prometheus.Labels{
-					"threshold": "MinOffsetThreshold", "node": nodeName, "profile": key}).Set(float64(np.MinOffsetThreshold))
-				ptpMetrics.Threshold.With(prometheus.Labels{
-					"threshold": "MaxOffsetThreshold", "node": nodeName, "profile": key}).Set(float64(np.MaxOffsetThreshold))
-				ptpMetrics.Threshold.With(prometheus.Labels{
-					"threshold": "HoldOverTimeout", "node": nodeName, "profile": key}).Set(float64(np.HoldOverTimeout))
-			}
 		}
 	case <-time.After(timeout):
 		log.Warnf("configmap not available after %s, proceeding without profile settings", timeout)
@@ -276,6 +269,16 @@ func Start(wg *sync.WaitGroup, configuration *common.SCConfiguration, _ func(e i
 		log.Warn(err)
 	}
 	eventManager.SetInitalMetrics()
+	eventManager.PtpConfigMapUpdates.OnThresholdUpdate = func(thresholds map[string]*ptpConfig.PtpClockThreshold) {
+		for key, np := range thresholds {
+			ptpMetrics.Threshold.With(prometheus.Labels{
+				"threshold": "MinOffsetThreshold", "node": nodeName, "profile": key}).Set(float64(np.MinOffsetThreshold))
+			ptpMetrics.Threshold.With(prometheus.Labels{
+				"threshold": "MaxOffsetThreshold", "node": nodeName, "profile": key}).Set(float64(np.MaxOffsetThreshold))
+			ptpMetrics.Threshold.With(prometheus.Labels{
+				"threshold": "HoldOverTimeout", "node": nodeName, "profile": key}).Set(float64(np.HoldOverTimeout))
+		}
+	}
 	startPtpConfigSync(ptpConfigSyncInitialTimeout, nodeName, configuration)
 	nConfigs := loadInitialPtp4lConfigs()
 

--- a/plugins/ptp_operator/ptp_operator_plugin.go
+++ b/plugins/ptp_operator/ptp_operator_plugin.go
@@ -270,14 +270,7 @@ func Start(wg *sync.WaitGroup, configuration *common.SCConfiguration, _ func(e i
 	}
 	eventManager.SetInitalMetrics()
 	eventManager.PtpConfigMapUpdates.OnThresholdUpdate = func(thresholds map[string]*ptpConfig.PtpClockThreshold) {
-		for key, np := range thresholds {
-			ptpMetrics.Threshold.With(prometheus.Labels{
-				"threshold": "MinOffsetThreshold", "node": nodeName, "profile": key}).Set(float64(np.MinOffsetThreshold))
-			ptpMetrics.Threshold.With(prometheus.Labels{
-				"threshold": "MaxOffsetThreshold", "node": nodeName, "profile": key}).Set(float64(np.MaxOffsetThreshold))
-			ptpMetrics.Threshold.With(prometheus.Labels{
-				"threshold": "HoldOverTimeout", "node": nodeName, "profile": key}).Set(float64(np.HoldOverTimeout))
-		}
+		setThresholdMetrics(nodeName, thresholds)
 	}
 	startPtpConfigSync(ptpConfigSyncInitialTimeout, nodeName, configuration)
 	nConfigs := loadInitialPtp4lConfigs()
@@ -608,4 +601,15 @@ func InitPubSubTypes() map[ptp.EventType]*ptpTypes.EventPublisherType {
 		Resource:  ptp.SynceClockQuality,
 	}
 	return InitPubs
+}
+
+func setThresholdMetrics(nodeName string, thresholds map[string]*ptpConfig.PtpClockThreshold) {
+	for key, np := range thresholds {
+		ptpMetrics.Threshold.With(prometheus.Labels{
+			"threshold": "MinOffsetThreshold", "node": nodeName, "profile": key}).Set(float64(np.MinOffsetThreshold))
+		ptpMetrics.Threshold.With(prometheus.Labels{
+			"threshold": "MaxOffsetThreshold", "node": nodeName, "profile": key}).Set(float64(np.MaxOffsetThreshold))
+		ptpMetrics.Threshold.With(prometheus.Labels{
+			"threshold": "HoldOverTimeout", "node": nodeName, "profile": key}).Set(float64(np.HoldOverTimeout))
+	}
 }

--- a/plugins/ptp_operator/ptp_operator_plugin_test.go
+++ b/plugins/ptp_operator/ptp_operator_plugin_test.go
@@ -801,3 +801,32 @@ func getMockOverrideFn() func(e v2.Event, d *channel.DataChan) error {
 		return nil
 	}
 }
+
+func TestSetThresholdMetrics(t *testing.T) {
+	metrics.Threshold.Reset()
+	thresholds := map[string]*ptpConfig.PtpClockThreshold{
+		"test-profile": {
+			MaxOffsetThreshold: 100,
+			MinOffsetThreshold: -100,
+			HoldOverTimeout:    5,
+		},
+	}
+	setThresholdMetrics("test-node", thresholds)
+
+	testCases := []struct {
+		threshold string
+		expected  float64
+	}{
+		{"MinOffsetThreshold", -100},
+		{"MaxOffsetThreshold", 100},
+		{"HoldOverTimeout", 5},
+	}
+	for _, tc := range testCases {
+		g, err := metrics.Threshold.GetMetricWith(map[string]string{
+			"threshold": tc.threshold, "node": "test-node", "profile": "test-profile",
+		})
+		assert.NoError(t, err)
+		assert.NotNil(t, g)
+	}
+	_ = testCases
+}

--- a/plugins/ptp_operator/ptp_operator_plugin_test.go
+++ b/plugins/ptp_operator/ptp_operator_plugin_test.go
@@ -32,6 +32,7 @@ import (
 
 	v2 "github.com/cloudevents/sdk-go/v2"
 	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	ptpConfig "github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/config"
 	event2 "github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/event"
 	"github.com/redhat-cne/cloud-event-proxy/plugins/ptp_operator/metrics"
@@ -827,6 +828,6 @@ func TestSetThresholdMetrics(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		assert.NotNil(t, g)
+		assert.Equal(t, tc.expected, testutil.ToFloat64(g), "metric value for %s", tc.threshold)
 	}
-	_ = testCases
 }


### PR DESCRIPTION
## Summary

Cherry-pick of PR #726 to release-4.22.

`openshift_ptp_threshold` Prometheus metric stays at defaults after a runtime PtpConfig `ptpClockThreshold` update when cloud-event-proxy is enabled. The metric was only set during the 1-second startup sync window; subsequent threshold changes via `EnsureProcessOptions()` updated in-memory values but never refreshed the metric.

Fix: add an `OnThresholdUpdate` callback to `LinuxPTPConfigMapUpdate` that fires on every `UpdatePTPThreshold()` call, ensuring the Prometheus metric is always in sync.

## Changes

- Add `OnThresholdUpdate` callback field to `LinuxPTPConfigMapUpdate`
- Fire callback at end of `UpdatePTPThreshold()`
- Register callback in `Start()` to set threshold metrics
- Extract `setThresholdMetrics()` for testability
- Unit tests for callback invocation, nil safety, and metric value assertions

## Test plan

- [x] `TestUpdatePTPThreshold_OnThresholdUpdateCallback` — callback fires with correct values
- [x] `TestUpdatePTPThreshold_NilCallbackDoesNotPanic` — nil callback safe
- [x] `TestSetThresholdMetrics` — metric values asserted via `testutil.ToFloat64`
- [x] Full test suite passes on release-4.22

[OCPBUGS-104524](https://redhat.atlassian.net/browse/OCPBUGS-104524), cherry-pick of [PR #726](https://github.com/redhat-cne/cloud-event-proxy/pull/726)