### PR TITLE
ci: drop openSUSE unstable repo for podman, use runner-provided package

### DIFF
--- a/.github/workflows/netdevsim-ci.yml
+++ b/.github/workflows/netdevsim-ci.yml
@@ -16,8 +16,10 @@ env:
   DKMS_VER: "6.9.5"
   DKMS_REPO: https://github.com/redhat-cne/netdevsim-dkms.git
   DKMS_BRANCH: main
-  PTP_REPO: https://github.com/k8snetworkplumbingwg/ptp-operator.git
-  PTP_BRANCH: main
+  # Temporary: exercise k8snetworkplumbingwg/ptp-operator#285 (.dockerignore).
+  # Revert to k8snetworkplumbingwg/ptp-operator@main after that PR merges.
+  PTP_REPO: https://github.com/edcdavid/ptp-operator-upstream.git
+  PTP_BRANCH: ci-exclude-local-runs-from-build-context
 
 jobs:
   # ------------------------------------------------------------------

--- a/.github/workflows/netdevsim-ci.yml
+++ b/.github/workflows/netdevsim-ci.yml
@@ -187,7 +187,7 @@ jobs:
 
           VM_IP=$(hostname -I | awk '{print $1}')
           cd /root/ptp-operator/scripts
-          ./run-on-vm.sh --dkms --images "${VM_IP}"
+          ./run-on-vm.sh --verbose --dkms --images "${VM_IP}"
 
           rm -rf /tmp/go-build* /root/.cache/go-build
           BUILD
@@ -279,7 +279,7 @@ jobs:
 
           VM_IP=$(hostname -I | awk '{print $1}')
           cd /root/ptp-operator/scripts
-          ./run-on-vm.sh --dkms --load /tmp/ptp-images.tar "${VM_IP}"
+          ./run-on-vm.sh --verbose --dkms --load /tmp/ptp-images.tar "${VM_IP}"
           LOAD
 
       - name: "Free disk space before tests"
@@ -301,7 +301,7 @@ jobs:
 
           VM_IP=$(hostname -I | awk '{print $1}')
           cd /root/ptp-operator/scripts
-          ./run-on-vm.sh --dkms --deploy "${VM_IP}" --mode "${{ matrix.mode }}" "${VM_IP}"
+          ./run-on-vm.sh --verbose --dkms --deploy "${VM_IP}" --mode "${{ matrix.mode }}" "${VM_IP}"
           DEPLOY
 
       - name: Upload test artifacts

--- a/.github/workflows/netdevsim-ci.yml
+++ b/.github/workflows/netdevsim-ci.yml
@@ -150,21 +150,12 @@ jobs:
           echo "RAM: $(free -h | awk '/Mem:/{print $2}')"
           echo "Kernel: $(uname -r)"
 
-      - name: Install latest podman
+      - name: Verify podman and upgrade crun
         run: |
-          . /etc/os-release
-          sudo mkdir -p /etc/apt/keyrings
-          curl -fsSL "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${VERSION_ID}/Release.key" \
-            | sudo gpg --dearmor --yes -o /etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg] \
-            https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${VERSION_ID}/ /" \
-            | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list >/dev/null
-          sudo apt-get update
-          sudo apt-get install -y podman
           podman --version
           CRUN_VER=1.19.1
           CRUN_PATH="$(which crun 2>/dev/null || echo /usr/bin/crun)"
-          sudo curl -fsSL -o "${CRUN_PATH}" \
+          sudo curl -fsSL --retry 7 --retry-all-errors -o "${CRUN_PATH}" \
             "https://github.com/containers/crun/releases/download/${CRUN_VER}/crun-${CRUN_VER}-linux-amd64"
           sudo chmod +x "${CRUN_PATH}"
           crun --version | head -1
@@ -222,21 +213,12 @@ jobs:
           echo "RAM: $(free -h | awk '/Mem:/{print $2}')"
           echo "Kernel: $(uname -r)"
 
-      - name: Install latest podman
+      - name: Verify podman and upgrade crun
         run: |
-          . /etc/os-release
-          sudo mkdir -p /etc/apt/keyrings
-          curl -fsSL "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${VERSION_ID}/Release.key" \
-            | sudo gpg --dearmor --yes -o /etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg] \
-            https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${VERSION_ID}/ /" \
-            | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list >/dev/null
-          sudo apt-get update
-          sudo apt-get install -y podman
           podman --version
           CRUN_VER=1.19.1
           CRUN_PATH="$(which crun 2>/dev/null || echo /usr/bin/crun)"
-          sudo curl -fsSL -o "${CRUN_PATH}" \
+          sudo curl -fsSL --retry 7 --retry-all-errors -o "${CRUN_PATH}" \
             "https://github.com/containers/crun/releases/download/${CRUN_VER}/crun-${CRUN_VER}-linux-amd64"
           sudo chmod +x "${CRUN_PATH}"
           crun --version | head -1
@@ -244,7 +226,7 @@ jobs:
       - name: Install OpenShift CLI (oc)
         run: |
           if ! command -v oc &>/dev/null; then
-            curl -sLO https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz
+            curl -sLO --retry 7 --retry-all-errors https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz
             sudo tar xzf openshift-client-linux.tar.gz -C /usr/local/bin oc kubectl
             rm -f openshift-client-linux.tar.gz
           fi
@@ -252,6 +234,7 @@ jobs:
 
       - name: Install DKMS dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -y dkms gcc make ethtool linuxptp \
             linux-headers-$(uname -r) \
             linux-modules-extra-$(uname -r)

--- a/.github/workflows/netdevsim-ci.yml
+++ b/.github/workflows/netdevsim-ci.yml
@@ -186,6 +186,8 @@ jobs:
           VM_IP=$(hostname -I | awk '{print $1}')
           cd /root/ptp-operator/scripts
           ./run-on-vm.sh --dkms --images "${VM_IP}"
+
+          rm -rf /tmp/go-build* /root/.cache/go-build
           BUILD
 
       - name: Upload image tarball
@@ -277,6 +279,15 @@ jobs:
           cd /root/ptp-operator/scripts
           ./run-on-vm.sh --dkms --load /tmp/ptp-images.tar "${VM_IP}"
           LOAD
+
+      - name: "Free disk space before tests"
+        run: |
+          sudo bash -l <<'CLEANUP'
+          set -euo pipefail
+          rm -rf /tmp/ptp-images.tar /tmp/ptp-images-load
+          rm -rf /tmp/go-build* /var/cache/apt /root/.cache
+          df -h
+          CLEANUP
 
       - name: "Run scenario: ${{ matrix.mode }}"
         run: |


### PR DESCRIPTION
## Summary
- Stop installing podman from the openSUSE Kubic unstable apt repo in netdevsim CI; `ubuntu-24.04` runners already provide podman 4.9.3.
- Avoid intermittent CI failures when `download.opensuse.org` returns 503 / drops connections.
- Add `--retry` to the `oc` CLI download.
- Free disk space after loading the image tarball (and clear go-build cache after image build), matching ptp-operator, so Kind bring-up does not hang on low-disk runners.
- **Temporary:** clone ptp-operator from [PR #285](https://github.com/k8snetworkplumbingwg/ptp-operator/pull/285) (`ci-exclude-local-runs-from-build-context`) to verify the `.dockerignore` fix for `archive/tar: write too long`. Revert to `k8snetworkplumbingwg/ptp-operator@main` after that merges.

## Test plan
- [ ] Confirm `netdevsim-ci` workflow installs/uses runner podman without openSUSE repo steps
- [ ] Confirm `oc` download succeeds with retries on transient network errors
- [ ] Confirm `ptp-images` succeeds (no `write too long` on `COPY`)
- [ ] Confirm `ptp-test` jobs show a `Free disk space before tests` step and Kind cluster create completes (especially `oc`)

Assisted-By: Cursor