### PR TITLE
CNF-26637: Deprecate minOffsetThreshold and use absolute offset comparison

### DIFF
--- a/plugins/ptp_operator/config/config.go
+++ b/plugins/ptp_operator/config/config.go
@@ -45,9 +45,10 @@ const (
 	// DefaultUpdateInterval for watching ptpconfigmap update
 	DefaultUpdateInterval = 60
 	// DefaultProfilePath  default ptp profile path
-	DefaultProfilePath         = "/etc/linuxptp"
-	maxOffsetThreshold   int64 = 100 // in nano secs
-	minOffsetThreshold   int64 = -100
+	DefaultProfilePath       = "/etc/linuxptp"
+	maxOffsetThreshold int64 = 100 // in nano secs
+	// minOffsetThreshold is deprecated; no synthetic default is used
+	// anymore, so this constant was removed.
 	holdoverTimeout      int64 = 5
 	ignorePtp4lSection         = "global"
 	HaProfileIdentifier        = "haProfiles"
@@ -317,11 +318,13 @@ func (l *LinuxPTPConfigMapUpdate) UpdatePTPThreshold() {
 		} else if isNtpFailoverEnabled(&profile) {
 			holdOverTh = holdoverTimeout
 			maxOffsetTh = 1000
-			minOffsetTh = -1000
+			// minOffsetTh is deprecated and left at its zero value rather
+			// than a synthetic -1000.
 		} else {
 			holdOverTh = holdoverTimeout
 			maxOffsetTh = maxOffsetThreshold
-			minOffsetTh = minOffsetThreshold
+			// minOffsetTh is deprecated and left at its zero value rather
+			// than a synthetic default.
 		}
 
 		l.EventThreshold[*profile.Name] = &PtpClockThreshold{
@@ -580,7 +583,8 @@ func GetDefaultThreshold() PtpClockThreshold {
 	return PtpClockThreshold{
 		HoldOverTimeout:    holdoverTimeout,
 		MaxOffsetThreshold: maxOffsetThreshold,
-		MinOffsetThreshold: minOffsetThreshold,
-		Close:              make(chan struct{}),
+		// MinOffsetThreshold is deprecated and left at its zero value rather
+		// than a synthetic default.
+		Close: make(chan struct{}),
 	}
 }

--- a/plugins/ptp_operator/config/config_test.go
+++ b/plugins/ptp_operator/config/config_test.go
@@ -132,8 +132,9 @@ func Test_Config(t *testing.T) {
 				PtpClockThreshold: &ptpConfig.PtpClockThreshold{
 					HoldOverTimeout:    5,
 					MaxOffsetThreshold: 1000,
-					MinOffsetThreshold: -1000,
-					Close:              make(chan struct{}),
+					// MinOffsetThreshold is deprecated: the NTP-failover
+					// default now resolves to 0, not a synthetic -1000.
+					Close: make(chan struct{}),
 				},
 			}},
 			profilePath: "../_testprofile",
@@ -257,12 +258,15 @@ func TestUpdatePTPThreshold_NtpFailover(t *testing.T) {
 		expectedMin int64
 	}{
 		{
+			// MinOffsetThreshold is deprecated: the default (no explicit
+			// PtpClockThreshold on the profile) now resolves to 0, not a
+			// synthetic -100.
 			name: "default threshold without ntpfailover",
 			profile: ptpConfig.PtpProfile{
 				Name: &profileName,
 			},
 			expectedMax: 100,
-			expectedMin: -100,
+			expectedMin: 0,
 		},
 		{
 			name: "ntpfailover with gnssFailover enabled uses looser threshold",
@@ -273,7 +277,7 @@ func TestUpdatePTPThreshold_NtpFailover(t *testing.T) {
 				},
 			},
 			expectedMax: 1000,
-			expectedMin: -1000,
+			expectedMin: 0,
 		},
 		{
 			name: "ntpfailover with gnssFailover disabled uses standard threshold",
@@ -284,7 +288,7 @@ func TestUpdatePTPThreshold_NtpFailover(t *testing.T) {
 				},
 			},
 			expectedMax: 100,
-			expectedMin: -100,
+			expectedMin: 0,
 		},
 		{
 			name: "explicit PtpClockThreshold takes precedence over ntpfailover",
@@ -359,6 +363,53 @@ func TestUpdatePTPThreshold_NilCallbackDoesNotPanic(t *testing.T) {
 		EventThreshold: make(map[string]*ptpConfig.PtpClockThreshold),
 	}
 	assert.NotPanics(t, func() { l.UpdatePTPThreshold() })
+}
+
+func TestUpdatePTPThreshold_MinOffsetThresholdIgnored(t *testing.T) {
+	profileName := "test-profile"
+
+	tests := []struct {
+		name        string
+		profile     ptpConfig.PtpProfile
+		expectedMax int64
+	}{
+		{
+			name: "omitted MinOffsetThreshold",
+			profile: ptpConfig.PtpProfile{
+				Name: &profileName,
+				PtpClockThreshold: &ptpConfig.PtpClockThreshold{
+					HoldOverTimeout:    5,
+					MaxOffsetThreshold: 200,
+				},
+			},
+			expectedMax: 200,
+		},
+		{
+			name: "asymmetric MinOffsetThreshold",
+			profile: ptpConfig.PtpProfile{
+				Name: &profileName,
+				PtpClockThreshold: &ptpConfig.PtpClockThreshold{
+					HoldOverTimeout:    5,
+					MaxOffsetThreshold: 200,
+					MinOffsetThreshold: -50,
+				},
+			},
+			expectedMax: 200,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := &ptpConfig.LinuxPTPConfigMapUpdate{
+				NodeProfiles:   []ptpConfig.PtpProfile{tt.profile},
+				EventThreshold: make(map[string]*ptpConfig.PtpClockThreshold),
+			}
+			l.UpdatePTPThreshold()
+			th := l.EventThreshold[profileName]
+			assert.NotNil(t, th)
+			assert.Equal(t, tt.expectedMax, th.MaxOffsetThreshold)
+		})
+	}
 }
 
 func TestUpdatePTPProcessOptions_TS2PhcConfSetsDefaultOpts(t *testing.T) {

--- a/plugins/ptp_operator/metrics/logparser.go
+++ b/plugins/ptp_operator/metrics/logparser.go
@@ -330,11 +330,15 @@ func FindInLogForCfgFileIndex(out string) int {
 	return -1
 }
 
-func isOffsetInRange(ptpOffset, maxOffsetThreshold, minOffsetThreshold int64) bool {
-	if ptpOffset < maxOffsetThreshold && ptpOffset > minOffsetThreshold {
-		return true
+func absInt64(n int64) int64 {
+	if n < 0 {
+		return -n
 	}
-	return false
+	return n
+}
+
+func isOffsetInRange(ptpOffset, maxOffsetThreshold int64) bool {
+	return absInt64(ptpOffset) < maxOffsetThreshold
 }
 
 func (p *PTPEventManager) parsePTPStatus(output string, fields []string) (int64, error) {

--- a/plugins/ptp_operator/metrics/logparser_internal_test.go
+++ b/plugins/ptp_operator/metrics/logparser_internal_test.go
@@ -1,0 +1,66 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_isOffsetInRange(t *testing.T) {
+	tests := []struct {
+		name               string
+		ptpOffset          int64
+		maxOffsetThreshold int64
+		expected           bool
+	}{
+		{
+			name:               "in-range positive offset",
+			ptpOffset:          50,
+			maxOffsetThreshold: 100,
+			expected:           true,
+		},
+		{
+			name:               "in-range negative offset",
+			ptpOffset:          -50,
+			maxOffsetThreshold: 100,
+			expected:           true,
+		},
+		{
+			name:               "out-of-range positive offset",
+			ptpOffset:          150,
+			maxOffsetThreshold: 100,
+			expected:           false,
+		},
+		{
+			name:               "out-of-range negative offset",
+			ptpOffset:          -150,
+			maxOffsetThreshold: 100,
+			expected:           false,
+		},
+		{
+			name:               "exact positive boundary (non-inclusive)",
+			ptpOffset:          100,
+			maxOffsetThreshold: 100,
+			expected:           false,
+		},
+		{
+			name:               "exact negative boundary (non-inclusive)",
+			ptpOffset:          -100,
+			maxOffsetThreshold: 100,
+			expected:           false,
+		},
+		{
+			name:               "zero offset",
+			ptpOffset:          0,
+			maxOffsetThreshold: 100,
+			expected:           true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := isOffsetInRange(tt.ptpOffset, tt.maxOffsetThreshold)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/plugins/ptp_operator/metrics/manager.go
+++ b/plugins/ptp_operator/metrics/manager.go
@@ -443,22 +443,22 @@ func (p *PTPEventManager) GenPTPEvent(ptpProfileName string, oStats *stats.Stats
 	case ptp.LOCKED:
 		switch lastClockState {
 		case ptp.FREERUN: // last state was already sent for FreeRUN , but if its within then send again with new state
-			if isOffsetInRange(ptpOffset, threshold.MaxOffsetThreshold, threshold.MinOffsetThreshold) { // within range
-				log.Infof(" publishing event for ( profile %s) %s with last state %s and current clock state %s and offset %d for ( Max/Min Threshold %d/%d )",
-					ptpProfileName, eventResourceName, lastClockState, clockState, ptpOffset, threshold.MaxOffsetThreshold, threshold.MinOffsetThreshold)
+			if isOffsetInRange(ptpOffset, threshold.MaxOffsetThreshold) { // within range
+				log.Infof("publishing event for (profile %s) %s with last state %s and current clock state %s and offset %d for (Max Threshold %d)",
+					ptpProfileName, eventResourceName, lastClockState, clockState, ptpOffset, threshold.MaxOffsetThreshold)
 				oStats.SetLastSyncState(clockState)
 				p.PublishEvent(clockState, ptpOffset, eventResourceName, eventType) // change to locked
 				oStats.SetLastOffset(ptpOffset)
 				oStats.AddValue(ptpOffset) // update off set when its in locked state and hold over only
 			}
 		case ptp.LOCKED: // last state was in sync , check if it is out of sync now
-			if isOffsetInRange(ptpOffset, threshold.MaxOffsetThreshold, threshold.MinOffsetThreshold) {
+			if isOffsetInRange(ptpOffset, threshold.MaxOffsetThreshold) {
 				oStats.SetLastOffset(ptpOffset)
 				oStats.AddValue(ptpOffset) // update off set when its in locked state and hold over only
 			} else {
 				clockState = ptp.FREERUN
-				log.Infof(" publishing event for ( profile %s) %s with last state %s and current clock state %s and offset %d for ( Max/Min Threshold %d/%d )",
-					ptpProfileName, eventResourceName, lastClockState, clockState, ptpOffset, threshold.MaxOffsetThreshold, threshold.MinOffsetThreshold)
+				log.Infof("publishing event for (profile %s) %s with last state %s and current clock state %s and offset %d for (Max Threshold %d)",
+					ptpProfileName, eventResourceName, lastClockState, clockState, ptpOffset, threshold.MaxOffsetThreshold)
 				oStats.SetLastSyncState(clockState)
 				p.PublishEvent(clockState, ptpOffset, eventResourceName, eventType)
 				oStats.SetLastOffset(ptpOffset)
@@ -467,12 +467,12 @@ func (p *PTPEventManager) GenPTPEvent(ptpProfileName string, oStats *stats.Stats
 			//FOR OC/BC  do nothing, the timeout will switch holdover to FREE-RUN OR LOCKED  if it is not within the holdover timeout
 			// FOR T-GM its handled differently
 			// previous state was HOLDOVER, now it is in LOCKED state, cancel any HOLDOVER
-			if isOffsetInRange(ptpOffset, threshold.MaxOffsetThreshold, threshold.MinOffsetThreshold) {
+			if isOffsetInRange(ptpOffset, threshold.MaxOffsetThreshold) {
 				log.Infof("interface %s is in LOCKED state, cancel any holdover states", eventResourceName)
 				log.Debugf("cancelling holdover timer: profile=%s resource=%s", ptpProfileName, eventResourceName)
 				threshold.SafeClose()
-				log.Infof(" publishing event for ( profile %s) %s with last state %s and current clock state %s and offset %d for ( Max/Min Threshold %d/%d )",
-					ptpProfileName, eventResourceName, lastClockState, clockState, ptpOffset, threshold.MaxOffsetThreshold, threshold.MinOffsetThreshold)
+				log.Infof("publishing event for (profile %s) %s with last state %s and current clock state %s and offset %d for (Max Threshold %d)",
+					ptpProfileName, eventResourceName, lastClockState, clockState, ptpOffset, threshold.MaxOffsetThreshold)
 				oStats.SetLastSyncState(clockState)
 				p.PublishEvent(clockState, ptpOffset, eventResourceName, eventType) // change to locked
 				oStats.SetLastOffset(ptpOffset)
@@ -481,13 +481,13 @@ func (p *PTPEventManager) GenPTPEvent(ptpProfileName string, oStats *stats.Stats
 
 		default: // not yet used states
 			clockState = ptp.FREERUN
-			if isOffsetInRange(ptpOffset, threshold.MaxOffsetThreshold, threshold.MinOffsetThreshold) {
+			if isOffsetInRange(ptpOffset, threshold.MaxOffsetThreshold) {
 				clockState = ptp.LOCKED
 			}
 			log.Warnf("%s sync state %s, last ptp state is unknown, setting to  %s", eventResourceName, lastClockState, clockState)
 
-			log.Infof(" publishing event for (profile %s) %s with last state %s and current clock state %s and offset %d for ( Max/Min Threshold %d/%d )",
-				ptpProfileName, eventResourceName, lastClockState, clockState, ptpOffset, threshold.MaxOffsetThreshold, threshold.MinOffsetThreshold)
+			log.Infof("publishing event for (profile %s) %s with last state %s and current clock state %s and offset %d for (Max Threshold %d)",
+				ptpProfileName, eventResourceName, lastClockState, clockState, ptpOffset, threshold.MaxOffsetThreshold)
 			oStats.SetLastSyncState(clockState)
 			p.PublishEvent(clockState, ptpOffset, eventResourceName, eventType) // change to unknown
 			oStats.SetLastOffset(ptpOffset)
@@ -511,8 +511,8 @@ func (p *PTPEventManager) GenPTPEvent(ptpProfileName string, oStats *stats.Stats
 		// the HOLDOVER→FREERUN transition through.
 		if lastClockState != ptp.HOLDOVER || eventType == ptp.OsClockSyncStateChange {
 			if lastClockState != ptp.FREERUN { // don't send event if last event was freerun
-				log.Infof("publishing event for (profile %s) %s with last state %s and current clock state %s and offset %d for ( Max/Min Threshold %d/%d )",
-					ptpProfileName, eventResourceName, lastClockState, clockState, ptpOffset, threshold.MaxOffsetThreshold, threshold.MinOffsetThreshold)
+				log.Infof("publishing event for (profile %s) %s with last state %s and current clock state %s and offset %d for (Max Threshold %d)",
+					ptpProfileName, eventResourceName, lastClockState, clockState, ptpOffset, threshold.MaxOffsetThreshold)
 				p.PublishEvent(clockState, ptpOffset, eventResourceName, eventType)
 			}
 			oStats.SetLastOffset(ptpOffset)
@@ -520,12 +520,12 @@ func (p *PTPEventManager) GenPTPEvent(ptpProfileName string, oStats *stats.Stats
 		}
 	default:
 		clockState = ptp.FREERUN
-		if isOffsetInRange(ptpOffset, threshold.MaxOffsetThreshold, threshold.MinOffsetThreshold) {
+		if isOffsetInRange(ptpOffset, threshold.MaxOffsetThreshold) {
 			clockState = ptp.LOCKED
 		}
 		log.Warnf("%s unknown current ptp state, setting to  %s", eventResourceName, clockState)
-		log.Infof(" publishing event for (profile %s) %s with last state %s and current clock state %s and offset %d for ( Max/Min Threshold %d/%d )",
-			ptpProfileName, eventResourceName, lastClockState, clockState, ptpOffset, threshold.MaxOffsetThreshold, threshold.MinOffsetThreshold)
+		log.Infof("publishing event for (profile %s) %s with last state %s and current clock state %s and offset %d for (Max Threshold %d)",
+			ptpProfileName, eventResourceName, lastClockState, clockState, ptpOffset, threshold.MaxOffsetThreshold)
 		oStats.SetLastSyncState(clockState)
 		p.PublishEvent(clockState, ptpOffset, eventResourceName, ptp.PtpStateChange) // change to unknown state
 		oStats.SetLastOffset(ptpOffset)

--- a/plugins/ptp_operator/metrics/metrics.go
+++ b/plugins/ptp_operator/metrics/metrics.go
@@ -373,7 +373,7 @@ func (p *PTPEventManager) ExtractMetrics(msg string) {
 						p.GenPTPEvent(profileName, ptpStats[types.IFace(interfaceName)], masterResource, int64(ptpOffset), syncState, ptp.PtpStateChange)
 					} else {
 						threshold := p.PtpThreshold(profileName, false)
-						if syncState != ptp.HOLDOVER && !isOffsetInRange(int64(ptpOffset), threshold.MaxOffsetThreshold, threshold.MinOffsetThreshold) {
+						if syncState != ptp.HOLDOVER && !isOffsetInRange(int64(ptpOffset), threshold.MaxOffsetThreshold) {
 							syncState = ptp.FREERUN
 						}
 						ptpStats[types.IFace(interfaceName)].SetLastSyncState(syncState)


### PR DESCRIPTION
## Summary

In `ptpClockThreshold`, threshold configuration currently specifies both `maxOffsetThreshold` and `minOffsetThreshold`. Because timing offsets are symmetric, defining separate upper and lower offset boundaries is redundant.

`minOffsetThreshold` is deprecated in favor of a single absolute-value comparison against `maxOffsetThreshold`:

`abs(offset) < maxOffsetThreshold`

This PR updates `isOffsetInRange()` and its call sites in `cloud-event-proxy` to evaluate whether `abs(offset) < maxOffsetThreshold` (non-inclusive boundary, preserving existing comparison semantics).

## Jira

* https://redhat.atlassian.net/browse/CNF-26630
* Parent: [CNF-25637](https://redhat.atlassian.net/browse/CNF-25637)

## Testing

* Unit tests added in `logparser_internal_test.go` and `config_test.go` covering in-range, out-of-range positive/negative, exact non-inclusive boundary, and backward compatibility when `minOffsetThreshold` is omitted/zero/asymmetric.