### PR TITLE
OCPBUGS-111881: Fix T-BC dual-upstream port role metrics

### DIFF
--- a/plugins/ptp_operator/metrics/logparser.go
+++ b/plugins/ptp_operator/metrics/logparser.go
@@ -298,14 +298,23 @@ func extractPTP4lEventState(output string) (portID int, role types.PtpPortRole, 
 		strings.Contains(output, "LISTENING to PASSIVE") {
 		role = types.PASSIVE
 	} else if strings.Contains(output, "UNCALIBRATED to MASTER") ||
-		strings.Contains(output, "LISTENING to MASTER") {
+		strings.Contains(output, "LISTENING to MASTER") ||
+		strings.Contains(output, "to PRE_MASTER") ||
+		strings.Contains(output, "PRE_MASTER to MASTER") {
+		// PRE_MASTER is a transient state before full MASTER (IEEE 1588-2019 §9.2.5):
+		// the port behaves as MASTER but suppresses PTP message transmission until
+		// qualification timeout expires. Report as MASTER for metric purposes.
 		role = types.MASTER
 	} else if strings.Contains(output, "FAULT_DETECTED") ||
 		strings.Contains(output, "SYNCHRONIZATION_FAULT") ||
-		strings.Contains(output, "SLAVE to UNCALIBRATED") ||
-		strings.Contains(output, "MASTER to UNCALIBRATED on RS_SLAVE") ||
-		strings.Contains(output, "LISTENING to UNCALIBRATED on RS_SLAVE") {
+		strings.Contains(output, "SLAVE to UNCALIBRATED") {
 		role = types.FAULTY
+		clockState = ptp.HOLDOVER
+	} else if strings.Contains(output, "MASTER to UNCALIBRATED") ||
+		strings.Contains(output, "LISTENING to UNCALIBRATED") {
+		// BMCA re-evaluation on backup port — standard IEEE 1588 UNCALIBRATED phase,
+		// not a fault. Report LISTENING while the port evaluates offset before locking.
+		role = types.LISTENING
 		clockState = ptp.HOLDOVER
 	} else if strings.Contains(output, "SLAVE to MASTER") ||
 		strings.Contains(output, "SLAVE to GRAND_MASTER") {

--- a/plugins/ptp_operator/metrics/logparser_test.go
+++ b/plugins/ptp_operator/metrics/logparser_test.go
@@ -423,7 +423,7 @@ func TestExtractPTP4lEventState(t *testing.T) {
 			name:          "LISTENING to UNCALIBRATED ",
 			logLine:       "ptp4l.1.config  port 1 (ens2f0)  LISTENING to UNCALIBRATED on RS_SLAVE",
 			expectedPort:  1,
-			expectedRole:  types.FAULTY,
+			expectedRole:  types.LISTENING,
 			expectedState: ptp.HOLDOVER,
 		},
 		{
@@ -437,7 +437,14 @@ func TestExtractPTP4lEventState(t *testing.T) {
 			name:          "LISTENING to UNCALIBRATED",
 			logLine:       "ptp4l[72530.751]: [ptp4l.0.config:5] port 1 (ens1f0): LISTENING to UNCALIBRATED on RS_SLAVE",
 			expectedPort:  1,
-			expectedRole:  types.FAULTY,
+			expectedRole:  types.LISTENING,
+			expectedState: ptp.HOLDOVER,
+		},
+		{
+			name:          "MASTER to UNCALIBRATED RS_SLAVE",
+			logLine:       "ptp4l[72531.000]: [ptp4l.0.config:5] port 2 (ens1f1): MASTER to UNCALIBRATED on RS_SLAVE",
+			expectedPort:  2,
+			expectedRole:  types.LISTENING,
 			expectedState: ptp.HOLDOVER,
 		},
 		{
@@ -474,6 +481,27 @@ func TestExtractPTP4lEventState(t *testing.T) {
 			expectedPort:  1,
 			expectedRole:  types.MASTER,
 			expectedState: ptp.HOLDOVER,
+		},
+		{
+			name:          "UNCALIBRATED to PRE_MASTER RS_MASTER",
+			logLine:       "ptp4l[17192.487]: [ptp4l.1.config] port 2 (eno8403): UNCALIBRATED to PRE_MASTER on RS_MASTER",
+			expectedPort:  2,
+			expectedRole:  types.MASTER,
+			expectedState: ptp.FREERUN,
+		},
+		{
+			name:          "LISTENING to PRE_MASTER RS_MASTER",
+			logLine:       "ptp4l[17020.571]: [ptp4l.1.config] port 2 (eno8403): LISTENING to PRE_MASTER on RS_MASTER",
+			expectedPort:  2,
+			expectedRole:  types.MASTER,
+			expectedState: ptp.FREERUN,
+		},
+		{
+			name:          "PRE_MASTER to MASTER QUALIFICATION_TIMEOUT_EXPIRES",
+			logLine:       "ptp4l[17192.737]: [ptp4l.1.config] port 2 (eno8403): PRE_MASTER to MASTER on QUALIFICATION_TIMEOUT_EXPIRES",
+			expectedPort:  2,
+			expectedRole:  types.MASTER,
+			expectedState: ptp.FREERUN,
 		},
 		{
 			name:          "INITIALIZING to LISTENING (follower only)",

--- a/plugins/ptp_operator/metrics/ptp4lParse_test.go
+++ b/plugins/ptp_operator/metrics/ptp4lParse_test.go
@@ -252,3 +252,97 @@ func TestStartHoldoverTimerWithNilPtpOptsStillRecovers(t *testing.T) {
 
 	assert.Equal(t, ptp.FREERUN, ptpStats[master].LastSyncState())
 }
+
+// TestParsePTP4l_DualUpstreamPreMasterRecovery reproduces the actual switchover/recovery
+// sequence observed in OCPBUGS-111881 log-dual-upstream.txt, where the backup port (eno8403)
+// transitions through MASTER to UNCALIBRATED → UNCALIBRATED to PRE_MASTER → PRE_MASTER to MASTER
+// during and after the switchover, and must report MASTER (2) — not FAULTY (3) — in the metric.
+//
+// Sequence from ptp4l log:
+//
+//	ptp4l[17186.990] port 1 (eno8303): SLAVE to FAULTY           → eno8303=FAULTY
+//	ptp4l[17187.015] port 2 (eno8403): MASTER to UNCALIBRATED    → eno8403=LISTENING (fixed, was FAULTY)
+//	ptp4l[17192.156] port 1 (eno8303): FAULTY to LISTENING       → eno8303=LISTENING
+//	ptp4l[17192.487] port 1 (eno8303): LISTENING to UNCALIBRATED → eno8303=LISTENING (fixed, was FAULTY)
+//	ptp4l[17192.487] port 2 (eno8403): UNCALIBRATED to PRE_MASTER → eno8403=MASTER (was UNKNOWN/dropped)
+//	ptp4l[17192.737] port 2 (eno8403): PRE_MASTER to MASTER      → eno8403=MASTER (was UNKNOWN/dropped)
+//	ptp4l[17208.615] port 1 (eno8303): UNCALIBRATED to SLAVE     → eno8303=SLAVE
+func TestParsePTP4l_DualUpstreamPreMasterRecovery(t *testing.T) {
+	ensureTestNode(t)
+	SetMasterOffsetSource(ptp4lProcessName)
+
+	mgr := NewPTPEventManager("", nil, testNode, nil)
+	mgr.MockTest(true)
+	mockFS := &MockFileSystem{}
+	Filesystem = mockFS
+
+	cfgName := "ptp4l.1.config"
+	profileName := testProfileName
+
+	ptp4lCfg := &ptp4lconf.PTP4lConfig{
+		Name:        cfgName,
+		Profile:     profileName,
+		ProfileType: ptp4lconf.TBC,
+		Interfaces: []*ptp4lconf.PTPInterface{
+			{Name: "eno8303", PortID: 1, PortName: "port 1", Role: types.SLAVE},
+			{Name: "eno8403", PortID: 2, PortName: "port 2", Role: types.MASTER},
+		},
+	}
+	mgr.AddPTPConfig(types.ConfigName(cfgName), ptp4lCfg)
+	mgr.Stats[types.ConfigName(cfgName)] = make(stats.PTPStats)
+	ptpStats := mgr.GetStats(types.ConfigName(cfgName))
+	ptpStats.CheckSource(master, cfgName, ptp4lProcessName)
+	ptpStats[master].SetAlias("eno8303x")
+	ptpStats[master].SetLastSyncState(ptp.LOCKED)
+
+	roleLabel := func(iface string) map[string]string {
+		return map[string]string{"process": ptp4lProcessName, "node": testNode, "iface": iface}
+	}
+
+	// Pre-initialize metrics to match starting state (eno8303=SLAVE, eno8403=MASTER)
+	UpdateInterfaceRoleMetrics(ptp4lProcessName, "eno8303", types.SLAVE)
+	UpdateInterfaceRoleMetrics(ptp4lProcessName, "eno8403", types.MASTER)
+
+	parse := func(output string) {
+		fields := []string{"ptp4l", "0", cfgName}
+		mgr.ParsePTP4l(ptp4lProcessName, cfgName, profileName, output, fields,
+			ptp4lconf.PTPInterface{}, ptp4lCfg, ptpStats)
+	}
+
+	// Step 1: eno8303 link goes down → SLAVE to FAULTY
+	parse("ptp4l[17186.990]: [ptp4l.1.config] port 1 (eno8303): SLAVE to FAULTY on FAULT_DETECTED (FT_UNSPECIFIED)")
+	assert.Equal(t, types.FAULTY, ptp4lCfg.Interfaces[0].Role, "step1: eno8303 should be FAULTY")
+	assert.Equal(t, float64(types.FAULTY), testutil.ToFloat64(InterfaceRole.With(roleLabel("eno8303"))), "step1: eno8303 metric=FAULTY")
+
+	// Step 2: eno8403 backup starts evaluating upstream (MASTER to UNCALIBRATED → LISTENING, not FAULTY)
+	parse("ptp4l[17187.015]: [ptp4l.1.config] port 2 (eno8403): MASTER to UNCALIBRATED on RS_SLAVE")
+	assert.Equal(t, types.LISTENING, ptp4lCfg.Interfaces[1].Role, "step2: eno8403 should be LISTENING (BMCA eval, not FAULTY)")
+	assert.Equal(t, float64(types.LISTENING), testutil.ToFloat64(InterfaceRole.With(roleLabel("eno8403"))), "step2: eno8403 metric=LISTENING")
+
+	// Step 3: eno8303 link recovers → FAULTY to LISTENING
+	parse("ptp4l[17192.156]: [ptp4l.1.config] port 1 (eno8303): FAULTY to LISTENING on INIT_COMPLETE")
+	assert.Equal(t, types.LISTENING, ptp4lCfg.Interfaces[0].Role, "step3: eno8303 should be LISTENING")
+	assert.Equal(t, float64(types.LISTENING), testutil.ToFloat64(InterfaceRole.With(roleLabel("eno8303"))), "step3: eno8303 metric=LISTENING")
+
+	// Step 4: eno8303 selected as upstream (LISTENING to UNCALIBRATED → LISTENING, not FAULTY)
+	parse("ptp4l[17192.487]: [ptp4l.1.config] port 1 (eno8303): LISTENING to UNCALIBRATED on RS_SLAVE")
+	assert.Equal(t, types.LISTENING, ptp4lCfg.Interfaces[0].Role, "step4: eno8303 should remain LISTENING during BMCA eval")
+	assert.Equal(t, float64(types.LISTENING), testutil.ToFloat64(InterfaceRole.With(roleLabel("eno8303"))), "step4: eno8303 metric=LISTENING")
+
+	// Step 5: eno8403 transitions to PRE_MASTER (reported as MASTER)
+	parse("ptp4l[17192.487]: [ptp4l.1.config] port 2 (eno8403): UNCALIBRATED to PRE_MASTER on RS_MASTER")
+	assert.Equal(t, types.MASTER, ptp4lCfg.Interfaces[1].Role, "step5: eno8403 should be MASTER (PRE_MASTER→MASTER)")
+	assert.Equal(t, float64(types.MASTER), testutil.ToFloat64(InterfaceRole.With(roleLabel("eno8403"))), "step5: eno8403 metric=MASTER")
+
+	// Step 6: eno8403 fully becomes MASTER
+	parse("ptp4l[17192.737]: [ptp4l.1.config] port 2 (eno8403): PRE_MASTER to MASTER on QUALIFICATION_TIMEOUT_EXPIRES")
+	assert.Equal(t, types.MASTER, ptp4lCfg.Interfaces[1].Role, "step6: eno8403 should remain MASTER")
+	assert.Equal(t, float64(types.MASTER), testutil.ToFloat64(InterfaceRole.With(roleLabel("eno8403"))), "step6: eno8403 metric=MASTER")
+
+	// Step 7: eno8303 locks as SLAVE — final recovered state
+	parse("ptp4l[17208.615]: [ptp4l.1.config] port 1 (eno8303): UNCALIBRATED to SLAVE on MASTER_CLOCK_SELECTED")
+	assert.Equal(t, types.SLAVE, ptp4lCfg.Interfaces[0].Role, "step7: eno8303 should be SLAVE")
+	assert.Equal(t, types.MASTER, ptp4lCfg.Interfaces[1].Role, "step7: eno8403 stays MASTER (serving downstream)")
+	assert.Equal(t, float64(types.SLAVE), testutil.ToFloat64(InterfaceRole.With(roleLabel("eno8303"))), "step7: eno8303 metric=SLAVE")
+	assert.Equal(t, float64(types.MASTER), testutil.ToFloat64(InterfaceRole.With(roleLabel("eno8403"))), "step7: eno8403 metric=MASTER")
+}


### PR DESCRIPTION
## Fix T-BC dual-upstream port role metrics

**Please note - this PR is fixing a part of the problem. To fully fix the problem, a companion [PR](https://github.com/k8snetworkplumbingwg/linuxptp-daemon/pull/268) in the `linuxptp-daemon` is required**
    
### Problem description: Dual-upstream T-BC port metrics are stale after switchover.
    
1. First lock - backup port is "Listening", but in reality it is "Master"
```
ptp4l[85220.383]: [ptp4l.1.config:5] port 1 (eno8303): INITIALIZING to LISTENING on INIT_COMPLETE
ptp4l[85220.403]: [ptp4l.1.config:5] port 2 (eno8403): INITIALIZING to LISTENING on INIT_COMPLETE
ptp4l[85220.739]: [ptp4l.1.config:5] port 1 (eno8303): LISTENING to UNCALIBRATED on RS_SLAVE
ptp4l[85220.739]: [ptp4l.1.config:5] port 2 (eno8403): LISTENING to PRE_MASTER on RS_MASTER
ptp4l[85220.989]: [ptp4l.1.config:5] port 2 (eno8403): PRE_MASTER to MASTER on QUALIFICATION_TIMEOUT_EXPIRES
I0819 08:33:19.525130 1896198 event.go:1445] Port Event ptp4l[85220.739]: [ptp4l.1.config:5] port 1 (eno8303): LISTENING to UNCALIBRATED on RS_SLAVE
I0819 08:33:19.525145 1896198 event.go:1445] Port Event ptp4l[85220.989]: [ptp4l.1.config:5] port 2 (eno8403): PRE_MASTER to MASTER on QUALIFICATION_TIMEOUT_EXPIRES
ptp4l[85236.930]: [ptp4l.1.config:5] port 1 (eno8303): UNCALIBRATED to SLAVE on MASTER_CLOCK_SELECTED

___
# HELP openshift_ptp_interface_role 0 = PASSIVE, 1 = SLAVE, 2 = MASTER, 3 = FAULTY, 4 = UNKNOWN, 5 = LISTENING
openshift_ptp_interface_role{iface="eno8303",node="master-p4.perla4.lab.eng.cert.redhat.com",process="ptp4l"} 1
openshift_ptp_interface_role{iface="eno8403",node="master-p4.perla4.lab.eng.cert.redhat.com",process="ptp4l"} 5
```
 2. Into switchover transition - both faulty (wrong):

```
openshift_ptp_interface_role{iface="eno8303",node="master-p4.perla4.lab.eng.cert.redhat.com",process="ptp4l"} 3
openshift_ptp_interface_role{iface="eno8403",node="master-p4.perla4.lab.eng.cert.redhat.com",process="ptp4l"} 3
```
3. Backup - OK
 ```
 openshift_ptp_interface_role{iface="eno8303",node="master-p4.perla4.lab.eng.cert.redhat.com",process="ptp4l"} 3
 openshift_ptp_interface_role{iface="eno8403",node="master-p4.perla4.lab.eng.cert.redhat.com",process="ptp4l"} 1
 ```
    
4. Back to normal - both SLAVE (not ok, eno8403 should be listening or master, depending on the real port state)
```
openshift_ptp_interface_role{iface="eno8303",node="master-p4.perla4.lab.eng.cert.redhat.com",process="ptp4l"} 1
openshift_ptp_interface_role{iface="eno8403",node="master-p4.perla4.lab.eng.cert.redhat.com",process="ptp4l"} 1
```
### Solution: 
    - Re-classify MASTER/LISTENING to UNCALIBRATED transition result as LISTENING (not FAULTY)
    - Add PRE_MASTER transition handling, mapped to MASTER
    - Enforce single-SLAVE invariant per config for TBC profiles

### Test
1. Initial state
```
$ oc -c linuxptp-daemon-container rsh ds/linuxptp-daemon curl -s localhost:9091/metrics |grep -E "eno8303|eno8403|HELP openshift_ptp_interface_role"
# HELP openshift_ptp_interface_role 0 = PASSIVE, 1 = SLAVE, 2 = MASTER, 3 = FAULTY, 4 = UNKNOWN, 5 = LISTENING
openshift_ptp_interface_role{iface="eno8303",node="master-p4.perla4.lab.eng.cert.redhat.com",process="ptp4l"} 1
openshift_ptp_interface_role{iface="eno8403",node="master-p4.perla4.lab.eng.cert.redhat.com",process="ptp4l"} 2
```
3. Backup state
```
ptp4l[82636.725]: [ptp4l.1.config:5] port 1 (eno8303): SLAVE to FAULTY on FAULT_DETECTED (FT_UNSPECIFIED)
ptp4l[82636.756]: [ptp4l.1.config:5] port 2 (eno8403): MASTER to UNCALIBRATED on RS_SLAVE
ptp4l[82652.942]: [ptp4l.1.config:5] port 2 (eno8403): UNCALIBRATED to SLAVE on MASTER_CLOCK_SELECTED

$ oc -c linuxptp-daemon-container rsh ds/linuxptp-daemon curl -s localhost:9091/metrics |grep -E "eno8303|eno8403|HELP openshift_ptp_interface_role"
# HELP openshift_ptp_interface_role 0 = PASSIVE, 1 = SLAVE, 2 = MASTER, 3 = FAULTY, 4 = UNKNOWN, 5 = LISTENING
openshift_ptp_interface_role{iface="eno8303",node="master-p4.perla4.lab.eng.cert.redhat.com",process="ptp4l"} 3
openshift_ptp_interface_role{iface="eno8403",node="master-p4.perla4.lab.eng.cert.redhat.com",process="ptp4l"} 1
```
5. Back to normal
```
ptp4l[82736.439]: [ptp4l.1.config:5] port 1 (eno8303): FAULTY to LISTENING on INIT_COMPLETE
ptp4l[82736.774]: [ptp4l.1.config:5] port 1 (eno8303): LISTENING to UNCALIBRATED on RS_SLAVE
ptp4l[82736.774]: [ptp4l.1.config:5] port 2 (eno8403): SLAVE to PRE_MASTER on RS_MASTER
ptp4l[82737.024]: [ptp4l.1.config:5] port 2 (eno8403): PRE_MASTER to MASTER on QUALIFICATION_TIMEOUT_EXPIRES
ptp4l[82752.903]: [ptp4l.1.config:5] port 1 (eno8303): UNCALIBRATED to SLAVE on MASTER_CLOCK_SELECTED
$ oc -c linuxptp-daemon-container rsh ds/linuxptp-daemon curl -s localhost:9091/metrics |grep -E "eno8303|eno8403|HELP openshift_ptp_interface_role"
# HELP openshift_ptp_interface_role 0 = PASSIVE, 1 = SLAVE, 2 = MASTER, 3 = FAULTY, 4 = UNKNOWN, 5 = LISTENING
openshift_ptp_interface_role{iface="eno8303",node="master-p4.perla4.lab.eng.cert.redhat.com",process="ptp4l"} 1
openshift_ptp_interface_role{iface="eno8403",node="master-p4.perla4.lab.eng.cert.redhat.com",process="ptp4l"} 2
```
/cc @nocturnalastro @jzding @sebsoto @lack @edcdavid